### PR TITLE
[v2.6.x] prov/efa: Add device refcount to prevent use-after-free during fi_fini

### DIFF
--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -167,6 +167,8 @@ int efa_device_construct_data(struct efa_device *efa_device,
 
 	assert(efa_device->ibv_ctx);
 
+	ofi_atomic_initialize32(&efa_device->ref_cnt, 0);
+
 	/* Initialize QP table */
 	efa_device->qp_table = NULL;
 	qp_table_size = roundup_power_of_two(efa_device->ibv_attr.max_qp);
@@ -420,9 +422,19 @@ err_free:
 void efa_device_list_finalize(void)
 {
 	int i;
+	bool any_active = false;
 
 	if (g_efa_selected_device_list) {
 		for (i = 0; i < g_efa_selected_device_cnt; i++) {
+			if (ofi_atomic_get32(&g_efa_selected_device_list[i].ref_cnt) > 0) {
+				EFA_WARN(FI_LOG_DOMAIN,
+					 "Device %d still has active references (ref_cnt=%d), "
+					 "skipping teardown for this device.\n",
+					 i, ofi_atomic_get32(&g_efa_selected_device_list[i].ref_cnt));
+				any_active = true;
+				continue;
+			}
+
 			ofi_genlock_destroy(&g_efa_selected_device_list[i].qp_table_lock);
 
 #ifndef _WIN32
@@ -433,17 +445,20 @@ void efa_device_list_finalize(void)
 			efa_device_destruct(&g_efa_selected_device_list[i]);
 		}
 
-		free(g_efa_selected_device_list);
-		g_efa_selected_device_list = NULL;
+		if (!any_active) {
+			free(g_efa_selected_device_list);
+			g_efa_selected_device_list = NULL;
+			g_efa_selected_device_cnt = 0;
+		}
 	}
 
-	g_efa_selected_device_cnt = 0;
-
-	if (g_efa_ibv_gid_list) {
-		free(g_efa_ibv_gid_list);
-		g_efa_ibv_gid_list = NULL;
+	if (!any_active) {
+		if (g_efa_ibv_gid_list) {
+			free(g_efa_ibv_gid_list);
+			g_efa_ibv_gid_list = NULL;
+		}
+		g_efa_ibv_gid_cnt = 0;
 	}
-	g_efa_ibv_gid_cnt = 0;
 }
 
 /**

--- a/prov/efa/src/efa_device.h
+++ b/prov/efa/src/efa_device.h
@@ -9,6 +9,7 @@
 #include <infiniband/efadv.h>
 #include <stdbool.h>
 #include "ofi_lock.h"
+#include "ofi_atom.h"
 
 struct efa_qp;
 
@@ -33,6 +34,11 @@ struct efa_device {
 	uint32_t		max_comp_cntr;
 	uint64_t		comp_count_max_value;
 	uint64_t		err_count_max_value;
+	/* Refcount of open domains using this device. efa_device_list_finalize
+	 * skips destruction when ref_cnt > 0, preventing use-after-free when
+	 * fi_fini races with threads still inside the provider.
+	 */
+	ofi_atomic32_t		ref_cnt;
 };
 
 int efa_device_list_initialize(void);

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -87,6 +87,7 @@ static int efa_domain_init_device_and_pd(struct efa_domain *efa_domain,
 		    strcmp((const char *) (domain_name + strlen(device_name)),
 		           domain_name_suffix) == 0) {
 			efa_domain->device = &g_efa_selected_device_list[i];
+			ofi_atomic_inc32(&efa_domain->device->ref_cnt);
 			break;
 		}
 	}
@@ -424,6 +425,9 @@ static int efa_domain_close(fid_t fid)
 
 	if (efa_domain->info)
 		fi_freeinfo(efa_domain->info);
+
+	if (efa_domain->device)
+		ofi_atomic_dec32(&efa_domain->device->ref_cnt);
 
 	ofi_genlock_destroy(&efa_domain->srx_lock);
 	free(efa_domain);

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -705,11 +705,14 @@ void test_rdm_cq_create_error_handling(void **state)
 	expect_function_call(efa_mock_create_cq_ex_return_null);
 
 	efa_domain = container_of(resource->domain, struct efa_domain, util_domain.domain_fid);
+	ofi_atomic_initialize32(&efa_device.ref_cnt, 0);
+	ofi_atomic_inc32(&efa_device.ref_cnt);
 	efa_domain->device = &efa_device;
 
 	assert_int_not_equal(fi_cq_open(resource->domain, &cq_attr, &resource->cq, NULL), 0);
 	/* set cq as NULL to avoid double free by fi_close in cleanup stage */
 	resource->cq = NULL;
+	efa_domain->device = &g_efa_selected_device_list[0];
 	efa_device_destruct(&efa_device);
 	ibv_free_device_list(ibv_device_list);
 }

--- a/prov/efa/test/efa_unit_test_device.c
+++ b/prov/efa/test/efa_unit_test_device.c
@@ -31,3 +31,45 @@ void test_efa_device_construct_error_handling(void **state)
 	ibv_free_device_list(ibv_device_list);
 }
 
+/**
+ * @brief Verify that efa_device_list_finalize skips device destruction
+ * when ref_cnt > 0
+ */
+void test_efa_device_finalize_skips_active_device(void **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_domain *efa_domain;
+	struct efa_device *device;
+	int i;
+
+	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+
+	efa_domain = container_of(resource->domain, struct efa_domain,
+				  util_domain.domain_fid);
+	device = efa_domain->device;
+
+	assert_true(ofi_atomic_get32(&device->ref_cnt) > 0);
+
+	/*
+	 * Bump ref_cnt on all other devices so that efa_device_list_finalize
+	 * skips them too. Without this, the finalize call destroys other
+	 * devices, and the fi_fini() call at process exit will attempt to
+	 * double-destroy them.
+	 */
+	for (i = 0; i < g_efa_selected_device_cnt; i++) {
+		if (&g_efa_selected_device_list[i] != device)
+			ofi_atomic_inc32(&g_efa_selected_device_list[i].ref_cnt);
+	}
+
+	efa_device_list_finalize();
+
+	assert_non_null(device->qp_table);
+	assert_non_null(g_efa_selected_device_list);
+
+	/* Restore ref_cnt so normal cleanup at process exit can proceed */
+	for (i = 0; i < g_efa_selected_device_cnt; i++) {
+		if (&g_efa_selected_device_list[i] != device)
+			ofi_atomic_dec32(&g_efa_selected_device_list[i].ref_cnt);
+	}
+}
+

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -175,8 +175,12 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_ah_lru_eviction_implicit_av_insert, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end efa_unit_test_av.c */
 
-		/* begin efa_unit_test_ep.c */
+		/* begin efa_unit_test_device.c */
 		cmocka_unit_test_setup_teardown(test_efa_device_construct_error_handling, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_device_finalize_skips_active_device, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		/* end efa_unit_test_device.c */
+
+		/* begin efa_unit_test_ep.c */
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ep_ignore_missing_host_id_file, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ep_has_valid_host_id, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_rdm_ep_ignore_short_host_id, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -129,6 +129,7 @@ void test_ah_lru_eviction_implicit_av_insert(void **state);
 /* end efa_unit_test_av.c */
 
 void test_efa_device_construct_error_handling(void **state);
+void test_efa_device_finalize_skips_active_device(void **state);
 void test_efa_rdm_ep_ignore_missing_host_id_file(void **state);
 void test_efa_rdm_ep_has_valid_host_id(void **state);
 void test_efa_rdm_ep_ignore_short_host_id(void **state);


### PR DESCRIPTION
When exit() is called with threads still inside the EFA provider (e.g. CQ polling or EP close), the fi_fini library destructor calls efa_device_list_finalize() which frees the per-device qp_table. Threads that are concurrently dereferencing qp_table segfault.

Add an atomic ref_cnt to struct efa_device. Each fi_domain open increments the refcount of its associated device, and each domain close decrements it. efa_device_list_finalize skips destruction of any device whose ref_cnt is still positive, keeping qp_table and the device list intact for threads that are still executing inside the provider.

This is safe because efa_device_list_finalize is only called from fi_fini (process exit or dlclose). On process exit, the OS reclaims all memory after _exit(). On clean dlclose, all domains must already be closed, so full teardown proceeds normally.


(cherry picked from commit 8533e213b74e72a7ae14d83462019744261da1e8)