### PR TITLE
prov/efa: Make peer->next_msg_id atomic

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -152,8 +152,7 @@ ssize_t efa_rdm_atomic_generic_efa(struct efa_rdm_ep *efa_rdm_ep,
 		goto out;
 	}
 
-	txe->msg_id = (peer->next_msg_id != ~0) ?
-			    peer->next_msg_id++ : ++peer->next_msg_id;
+	txe->msg_id = peer->next_msg_id++;
 
 	err = efa_rdm_atomic_post_atomic(efa_rdm_ep, txe);
 

--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -152,13 +152,13 @@ ssize_t efa_rdm_atomic_generic_efa(struct efa_rdm_ep *efa_rdm_ep,
 		goto out;
 	}
 
-	txe->msg_id = peer->next_msg_id++;
+	txe->msg_id = ofi_atomic_inc32(&peer->next_msg_id) - 1;
 
 	err = efa_rdm_atomic_post_atomic(efa_rdm_ep, txe);
 
 	if (OFI_UNLIKELY(err)) {
 		efa_rdm_txe_release(txe);
-		peer->next_msg_id--;
+		ofi_atomic_dec32(&peer->next_msg_id);
 	}
 
 out:

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -206,7 +206,7 @@ ssize_t efa_rdm_msg_generic_send(struct efa_rdm_ep *ep, const struct fi_msg *msg
 
 	assert(txe->op == ofi_op_msg || txe->op == ofi_op_tagged);
 
-	txe->msg_id = peer->next_msg_id++;
+	txe->msg_id = ofi_atomic_inc32(&peer->next_msg_id) - 1;
 
 	EFA_DBG(FI_LOG_EP_DATA,
 		"peer: %" PRIu64
@@ -219,7 +219,7 @@ ssize_t efa_rdm_msg_generic_send(struct efa_rdm_ep *ep, const struct fi_msg *msg
 	err = efa_rdm_msg_post_rtm(ep, txe);
 	if (OFI_UNLIKELY(err)) {
 		efa_rdm_txe_release(txe);
-		peer->next_msg_id--;
+		ofi_atomic_dec32(&peer->next_msg_id);
 	}
 
 out:

--- a/prov/efa/src/rdm/efa_rdm_peer.c
+++ b/prov/efa/src/rdm/efa_rdm_peer.c
@@ -22,6 +22,8 @@ int efa_rdm_peer_construct(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep, str
 	int ret;
 	memset(peer, 0, sizeof(struct efa_rdm_peer));
 
+	ofi_atomic_initialize32(&peer->next_msg_id, 0);
+
 	peer->ep = ep;
 	peer->conn = conn;
 	peer->is_self = efa_is_same_addr(&ep->base_ep.src_addr, conn->ep_addr);

--- a/prov/efa/src/rdm/efa_rdm_peer.h
+++ b/prov/efa/src/rdm/efa_rdm_peer.h
@@ -5,6 +5,7 @@
 #define EFA_RDM_PEER_H
 
 #include "ofi_recvwin.h"
+#include "ofi_atom.h"
 #include "efa_rdm_ope.h"
 #include "efa_rdm_protocol.h"
 #include "efa_rdm_rxe_map.h"
@@ -98,7 +99,7 @@ struct efa_rdm_peer {
 	 * @details temporarily hold packets that are out-of-order, whose msg_id is larger that the one EP is expecting from the peer
 	 */
 	struct efa_rdm_robuf robuf;
-	uint32_t next_msg_id;		/**< msg_id to be assigned to the next packet sent to the peer. */
+	ofi_atomic32_t next_msg_id;	/**< msg_id to be assigned to the next packet sent to the peer. */
 	uint32_t flags;			/**< flags such as #EFA_RDM_PEER_REQ_SENT #EFA_RDM_PEER_HANDSHAKE_SENT #EFA_RDM_PEER_HANDSHAKE_RECEIVED and #EFA_RDM_PEER_IN_BACKOFF */
 	uint32_t nextra_p3;		/**< number of members in extra_info plus 3 (See protocol v4 document section 2.1) */
 	uint64_t extra_info[EFA_RDM_MAX_NUM_EXINFO]; /**< the feature/request flag for each version (See protocol v4 document section 2.1)*/

--- a/prov/efa/test/efa_unit_test_av.c
+++ b/prov/efa/test/efa_unit_test_av.c
@@ -495,7 +495,7 @@ void test_av_implicit_to_explicit(void **state)
 	assert_int_equal(err, 0);
 
 	/* Modify the peer and verify that the peer is moved as-is */
-	peer->next_msg_id = 355;
+	ofi_atomic_set32(&peer->next_msg_id, 355);
 	peer->flags |= EFA_RDM_PEER_IN_BACKOFF;
 
 	/* Insert explicitly */
@@ -518,7 +518,7 @@ void test_av_implicit_to_explicit(void **state)
 	assert_int_equal(test_addr, explicit_fi_addr);
 
 	/* Verify the manually set peer properties above */
-	assert_int_equal(peer->next_msg_id, 355);
+	assert_int_equal(ofi_atomic_get32(&peer->next_msg_id), 355);
 	assert_true(peer->flags & EFA_RDM_PEER_IN_BACKOFF);
 
 	/* Unset the flag to make fi_av_remove easier */


### PR DESCRIPTION
Convert next_msg_id from uint32_t to ofi_atomic32_t so it can be safely incremented without srx_lock in a future lock-free send path.
