### PR TITLE
prov/efa: fix null dereference bugs in rdm_pke_rtm

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -307,8 +307,10 @@ nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
 	prov/efa/test/gtest/efa_gtest_common_mocks.cc \
 	prov/efa/test/gtest/efa_gtest_common_resource.cc \
 	prov/efa/test/gtest/efa_gtest_common_helpers.c \
+	prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c \
 	prov/efa/test/gtest/efa_gtest_conn.cc \
-	prov/efa/test/gtest/efa_gtest_ah.cc
+	prov/efa/test/gtest/efa_gtest_ah.cc \
+	prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc
 
 prov_efa_test_gtest_efa_gtest_CPPFLAGS = \
 	$(AM_CPPFLAGS) \

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -174,7 +174,6 @@ void efa_rdm_pke_rtm_update_rxe(struct efa_rdm_pke *pkt_entry,
  * @brief process a RTM that has been matched to a RX entry
  *
  * @param[in,out]	pkt_entry	RTM packet entry
- * @param[in,out]	rxe			RX entry that matches the RTM
  *
  * @returns
  * 0 on success
@@ -283,6 +282,13 @@ ssize_t efa_rdm_pke_proc_msgrtm(struct efa_rdm_pke *pkt_entry)
 	rtm_hdr = (struct efa_rdm_rtm_base_hdr *)pkt_entry->wiredata;
 	if (rtm_hdr->flags & EFA_RDM_REQ_READ_NACK) {
 		rxe = efa_rdm_rxe_map_lookup(&pkt_entry->peer->rxe_map, efa_rdm_pke_get_rtm_msg_id(pkt_entry));
+		if (OFI_UNLIKELY(!rxe)) {
+			efa_base_ep_write_eq_error(
+				&ep->base_ep, FI_EINVAL,
+				FI_EFA_ERR_PKT_PROC_MSGRTM);
+			efa_rdm_pke_release_rx(pkt_entry);
+			return -FI_EINVAL;
+		}
 		rxe->internal_flags |= EFA_RDM_OPE_READ_NACK;
 	} else {
 		rxe = efa_rdm_msg_alloc_rxe_for_msgrtm(ep, &pkt_entry);
@@ -331,6 +337,13 @@ static ssize_t efa_rdm_pke_proc_tagrtm(struct efa_rdm_pke *pkt_entry)
 	rtm_hdr = (struct efa_rdm_rtm_base_hdr *) pkt_entry->wiredata;
 	if (rtm_hdr->flags & EFA_RDM_REQ_READ_NACK) {
 		rxe = efa_rdm_rxe_map_lookup(&pkt_entry->peer->rxe_map, efa_rdm_pke_get_rtm_msg_id(pkt_entry));
+		if (OFI_UNLIKELY(!rxe)) {
+			efa_base_ep_write_eq_error(
+				&ep->base_ep, FI_EINVAL,
+				FI_EFA_ERR_PKT_PROC_TAGRTM);
+			efa_rdm_pke_release_rx(pkt_entry);
+			return -FI_EINVAL;
+		}
 		rxe->internal_flags |= EFA_RDM_OPE_READ_NACK;
 	} else {
 		rxe = efa_rdm_msg_alloc_rxe_for_tagrtm(ep, &pkt_entry);
@@ -864,7 +877,6 @@ void efa_rdm_pke_handle_medium_rtm_send_completion(struct efa_rdm_pke *pkt_entry
  * RTM and 2 types of RUNTREAD RTM.
  *
  * @param[in,out]	pkt_entry	packet entry
- * @param[in]	peer	efa_rdm_peer struct of the sender
  */
 ssize_t efa_rdm_pke_proc_matched_mulreq_rtm(struct efa_rdm_pke *pkt_entry)
 {
@@ -1332,6 +1344,7 @@ ssize_t efa_rdm_pke_init_runtread_tagrtm(struct efa_rdm_pke *pkt_entry,
  * This function applies to both RUNTREAD_MSGRTM and RUNTREAD_TAGRTM.
  *
  * @param[in,out]	pkt_entry	packet entry
+ * @param[in,out]	peer	efa_rdm_peer struct of the sender
  */
 void efa_rdm_pke_handle_runtread_rtm_sent(struct efa_rdm_pke *pkt_entry, struct efa_rdm_peer *peer)
 {

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.c
@@ -55,6 +55,21 @@ fi_addr_t efa_test_insert_peer_new_gid(struct fid_ep *ep, struct fid_av *av)
 	return fi_addr;
 }
 
+fi_addr_t efa_test_insert_self_gid_peer(struct fid_ep *ep, struct fid_av *av)
+{
+	struct efa_ep_addr raw_addr = {0};
+	size_t raw_addr_len = sizeof(raw_addr);
+	fi_addr_t peer_addr = FI_ADDR_NOTAVAIL;
+
+	if (fi_getname(&ep->fid, &raw_addr, &raw_addr_len))
+		return FI_ADDR_NOTAVAIL;
+	raw_addr.qpn = 0;
+	raw_addr.qkey = 0x1234;
+	if (fi_av_insert(av, &raw_addr, 1, &peer_addr, 0, NULL) != 1)
+		return FI_ADDR_NOTAVAIL;
+	return peer_addr;
+}
+
 struct ibv_ah *efa_test_implicit_addr_to_ibv_ah(struct fid_av *av,
 						fi_addr_t fi_addr)
 {

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.h
@@ -37,6 +37,12 @@ int efa_test_explicit_av_insert(struct fid_ep *ep, struct fid_av *av,
  */
 fi_addr_t efa_test_insert_peer_new_gid(struct fid_ep *ep, struct fid_av *av);
 
+/**
+ * @brief Insert a peer using the EP's own GID.
+ * @return the fi_addr, or FI_ADDR_NOTAVAIL on failure
+ */
+fi_addr_t efa_test_insert_self_gid_peer(struct fid_ep *ep, struct fid_av *av);
+
 struct ibv_ah;
 
 /**

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc
@@ -1,0 +1,62 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_common_helpers.h"
+#include "efa_gtest_common_mocks.h"
+#include "efa_gtest_common_resource.h"
+#include "efa_gtest_rdm_pke_utils.h"
+#include <gtest/gtest.h>
+
+using testing::Bool;
+using testing::StrictMock;
+using testing::TestWithParam;
+
+class EfaRtmTest : public TestWithParam<bool>
+{
+	protected:
+	struct efa_resource resource = {};
+	StrictMock<MockEfa> mock_efa;
+	fi_addr_t peer_addr = FI_ADDR_UNSPEC;
+
+	void SetUp() override
+	{
+		memset(&resource, 0, sizeof(resource));
+		efa_test_resource_construct(
+			&resource, efa_test_alloc_default_hints(
+					   FI_EP_RDM, EFA_FABRIC_NAME));
+		ASSERT_NE(resource.ep, nullptr);
+
+		peer_addr =
+			efa_test_insert_self_gid_peer(resource.ep, resource.av);
+		ASSERT_NE(peer_addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
+
+		MockEfa::set(&mock_efa);
+	}
+
+	void TearDown() override
+	{
+		MockEfa::set(nullptr);
+		efa_test_resource_destruct(&resource);
+	}
+};
+
+/**
+ * @brief Asserts that a READ_NACK RTM whose msg_id misses the peer's rxe_map is
+ * handled (not a NULL deref) in both efa_rdm_pke_proc_{msg/tag}rtm
+ */
+TEST_P(EfaRtmTest, read_nack_missing_rxe_no_null_deref)
+{
+	ssize_t ret = 0;
+
+	ASSERT_EQ(efa_test_rtm_read_nack_missing_rxe(resource.ep, peer_addr,
+						     GetParam(), &ret),
+		  1);
+	/* Reached only if the handler did not crash; the missing entry is an
+	 * error, not silent success. */
+	EXPECT_NE(ret, 0);
+}
+
+INSTANTIATE_TEST_SUITE_P(, EfaRtmTest, Bool(),
+			 [](const testing::TestParamInfo<bool> &info) {
+				 return info.param ? "tagrtm" : "msgrtm";
+			 });

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_rdm_pke_utils.h"
+#include "efa.h"
+#include "rdm/efa_rdm_ep.h"
+#include "rdm/efa_rdm_pke_rtm.h"
+
+int efa_test_rtm_read_nack_missing_rxe(struct fid_ep *ep, fi_addr_t peer_addr,
+				       int tagged, ssize_t *ret)
+{
+	struct efa_rdm_ep *efa_rdm_ep =
+		container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	struct efa_rdm_pke *pke;
+	struct efa_rdm_rtm_base_hdr *rtm_hdr;
+
+	if (!peer)
+		return 0;
+
+	pke = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool,
+				EFA_RDM_PKE_FROM_EFA_RX_POOL);
+	if (!pke)
+		return 0;
+	pke->peer = peer;
+	pke->ep = efa_rdm_ep;
+
+	rtm_hdr = (struct efa_rdm_rtm_base_hdr *) pke->wiredata;
+	memset(rtm_hdr, 0, sizeof(*rtm_hdr));
+	rtm_hdr->type = tagged ? EFA_RDM_LONGCTS_TAGRTM_PKT
+			       : EFA_RDM_LONGCTS_MSGRTM_PKT;
+	rtm_hdr->version = EFA_RDM_PROTOCOL_VERSION;
+	rtm_hdr->flags = EFA_RDM_REQ_MSG | EFA_RDM_REQ_READ_NACK;
+	if (tagged)
+		rtm_hdr->flags |= EFA_RDM_REQ_TAGGED;
+	/* since peer has empty rxe_map, any msg_id can trigger lookup error */
+	rtm_hdr->msg_id = 0x77u;
+
+	*ret = efa_rdm_pke_proc_rtm_rta(pke, peer);
+	return 1;
+}

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.h
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All
+ * rights reserved. */
+
+/* C-linkage bridge for rdm pke tests. 
+ * See efa_gtest_common_helpers.h for why this exists. */
+
+#ifndef EFA_GTEST_RDM_PKE_UTILS_H
+#define EFA_GTEST_RDM_PKE_UTILS_H
+
+#include <rdma/fabric.h>
+#include <rdma/fi_endpoint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Calls the RTM RX handler with a LONGCTS READ_NACK packet whose msg_id
+ * is missing from the peer's rxe_map.
+ *
+ * @param[in]	ep		RDM efa endpoint
+ * @param[in]	peer_addr	pre-inserted fi_addr of the peer
+ * @param[in]	tagged		non-zero drives the tagged path (proc_tagrtm)
+ * @param[out]	ret		return code of the handler
+ * @return	1 if the handler returned without crashing, 0 on setup failure
+ */
+int efa_test_rtm_read_nack_missing_rxe(struct fid_ep *ep, fi_addr_t peer_addr,
+				       int tagged, ssize_t *ret);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFA_GTEST_RDM_PKE_UTILS_H */


### PR DESCRIPTION
Fix two occurences of a bug where the return of efa_rdm_rxe_map_lookup 
could be NULL and be subsequently dereferenced.
Unit tests have been added to assert this is now handled correctly.