### PR TITLE
[v2.4.x] fabtests: add FI_THREAD_COMPLETION support to rdm_bw_mt test

### DIFF
--- a/fabtests/benchmarks/rdm_bw_mt.c
+++ b/fabtests/benchmarks/rdm_bw_mt.c
@@ -595,7 +595,11 @@ static int run_size(void)
 		}
 	}
 
-	show_perf(NULL, xfer_size, opts.iterations, &start, &end, num_eps);
+	if (opts.machr)
+		show_perf_mr(xfer_size, opts.iterations, &start, &end,
+			     num_eps, opts.argc, opts.argv);
+	else
+		show_perf(NULL, xfer_size, opts.iterations, &start, &end, num_eps);
 
 out:
 	for (i = 0; i < num_eps; i++) {

--- a/fabtests/benchmarks/rdm_bw_mt.c
+++ b/fabtests/benchmarks/rdm_bw_mt.c
@@ -39,7 +39,7 @@
  * objects. These objects can be struct ft_fabric_resources which will contain
  * all resources that can be opened under a single fabtest and
  * struct ft_buffer_resouces for all resources associated with a buffer.
- * For the case of this test it will be:
+ * For the FI_THREAD_DOMAIN case of this test it will be:
  *
  * 				fabric
  *			 _________|_________
@@ -61,6 +61,22 @@
  * This test comes with a TODO to refactor the common code to support more tests
  * of this type and enable easier development of future tests with more
  * compatible objects instead of global variables.
+ *
+ * For the FI_THREAD_COMPLETION case:
+ * One shared domain and av; each thread owns its own ep and cq.
+ *
+ *                          fabric
+ *                            |
+ *                       domain (shared)
+ *                            |
+ *                        av (shared)
+ *              _____________|_____________
+ *             /             |             \
+ *        thread_0       thread_1       thread_n
+ *          |                |              |
+ *        ep, cq           ep, cq         ep, cq
+ *        buf, mr          buf, mr        buf, mr
+ *
  * WARNING: Not all options are supported in this test!
  */
 
@@ -99,6 +115,8 @@ struct thread_args {
 };
 
 static struct thread_args *targs = NULL;
+static struct fid_domain *shared_domain = NULL;
+static struct fid_av *shared_av = NULL;
 
 static void cleanup_ofi(void)
 {
@@ -118,18 +136,30 @@ static void cleanup_ofi(void)
 				printf("fi_close(cq[%d]) failed: %d\n", i, ret);
 		}
 
-		if (targs[i].av) {
+		if (targs[i].av && targs[i].av != shared_av) {
 			ret = fi_close(&targs[i].av->fid);
 			if (ret)
 				printf("fi_close(av[%d]) failed: %d\n", i, ret);
 		}
 
-		if (targs[i].domain) {
+		if (targs[i].domain && targs[i].domain != shared_domain) {
 			ret = fi_close(&targs[i].domain->fid);
 			if (ret)
 				printf("fi_close(domain[%d]) failed: %d\n", i,
 					ret);
 		}
+	}
+
+	if (shared_av) {
+		ret = fi_close(&shared_av->fid);
+		if (ret)
+			printf("fi_close(shared_av) failed: %d\n", ret);
+	}
+
+	if (shared_domain) {
+		ret = fi_close(&shared_domain->fid);
+		if (ret)
+			printf("fi_close(shared_domain) failed: %d\n", ret);
 	}
 
 	if (fabric) {
@@ -187,13 +217,12 @@ static int init_ofi(void)
 {
 	struct fi_cq_attr cq_attr;
 	struct fi_av_attr av_attr;
-	struct fi_cntr_attr cntr_attr;
 	int ret = FI_SUCCESS, i;
 
-        ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
-        if (ret) {
+	ret = fi_fabric(fi->fabric_attr, &fabric, NULL);
+	if (ret) {
 		printf("fi_fabric failed: %d\n", ret);
-                return ret;
+		return ret;
 	}
 
 	targs = calloc(num_eps, sizeof(*targs));
@@ -202,15 +231,45 @@ static int init_ofi(void)
 		return -FI_ENOMEM;
 	}
 
+	if (opts.threading == FI_THREAD_COMPLETION) {
+		ret = fi_domain(fabric, fi, &shared_domain, NULL);
+		if (ret) {
+			printf("fi_domain failed: %d\n", ret);
+			return ret;
+		}
+
+		memset(&av_attr, 0, sizeof(av_attr));
+		av_attr.type = FI_AV_UNSPEC;
+		av_attr.count = num_eps;
+		ret = fi_av_open(shared_domain, &av_attr, &shared_av, NULL);
+		if (ret) {
+			printf("fi_av_open failed: %d\n", ret);
+			return ret;
+		}
+	}
+
 	for (i = 0; i < num_eps; i++) {
 		memset(&cq_attr, 0, sizeof(cq_attr));
-		memset(&av_attr, 0, sizeof(av_attr));
-		memset(&cntr_attr, 0, sizeof(cntr_attr));
 
-		ret = fi_domain(fabric, fi, &targs[i].domain, NULL);
-		if (ret) {
-			printf("fi_domain failed ep[%d]: %d\n", i, ret);
-			return ret;
+		if (opts.threading == FI_THREAD_COMPLETION) {
+			targs[i].domain = shared_domain;
+			targs[i].av = shared_av;
+		} else {
+			ret = fi_domain(fabric, fi, &targs[i].domain, NULL);
+			if (ret) {
+				printf("fi_domain failed ep[%d]: %d\n", i, ret);
+				return ret;
+			}
+
+			memset(&av_attr, 0, sizeof(av_attr));
+			av_attr.type = FI_AV_UNSPEC;
+			av_attr.count = 1;
+			ret = fi_av_open(targs[i].domain, &av_attr,
+					 &targs[i].av, NULL);
+			if (ret) {
+				printf("fi_av_open failed: %d\n", ret);
+				return ret;
+			}
 		}
 
 		ret = fi_endpoint(targs[i].domain, fi, &targs[i].ep, NULL);
@@ -224,14 +283,6 @@ static int init_ofi(void)
 		ret = fi_cq_open(targs[i].domain, &cq_attr, &targs[i].cq, NULL);
 		if (ret) {
 			printf("fi_cq_open failed: %d\n", ret);
-			return ret;
-		}
-
-		av_attr.type = FI_AV_UNSPEC;
-		av_attr.count = 1;
-		ret = fi_av_open(targs[i].domain, &av_attr, &targs[i].av, NULL);
-		if (ret) {
-			printf("fi_av_open failed: %d\n", ret);
 			return ret;
 		}
 
@@ -607,6 +658,9 @@ static void usage(void)
 	FT_PRINT_OPTS_USAGE("-n <num endpoints>",
 			    "number of endpoints (threads) to use");
 	FT_PRINT_OPTS_USAGE("-U", "enable FI_DELIVERY_COMPLETE");
+	FT_PRINT_OPTS_USAGE("--threading <model>",
+			    "domain (default): per-thread domain/av; "
+			    "completion: shared domain/av, per-thread cq");
 	fprintf(stderr, "Notice to user: Not all fabtests options are supported"
 		" by this test. If something isn't working check if the option"
 		" is supported before reporting a bug.\n");
@@ -659,7 +713,7 @@ int main(int argc, char **argv)
 
 	hints->ep_attr->type = FI_EP_RDM;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
-	hints->domain_attr->threading = FI_THREAD_DOMAIN;
+	hints->domain_attr->threading = opts.threading;
 	hints->caps = FI_MSG;
 	hints->mode |= FI_CONTEXT | FI_CONTEXT2;
 	hints->domain_attr->mr_mode = opts.mr_mode;
@@ -670,9 +724,9 @@ int main(int argc, char **argv)
 		hints->domain_attr->mr_mode |= FI_MR_HMEM;
 	}
 
-        ret = ft_init_oob();
-        if (ret)
-                goto out;
+	ret = ft_init_oob();
+	if (ret)
+		goto out;
 
 	if (oob_sock >= 0 && opts.dst_addr) {
 		ret = ft_sock_sync(oob_sock, 0);

--- a/fabtests/benchmarks/rdm_bw_mt.c
+++ b/fabtests/benchmarks/rdm_bw_mt.c
@@ -493,6 +493,8 @@ static void *uni_bandwidth(void *context)
 	int i, ret;
 	const struct thread_args *targs = context;
 
+	ft_hmem_init_thread(opts.iface, opts.device);
+
 	pthread_barrier_wait(&barrier);
 	for (i = 0; i < opts.warmup_iterations; i++) {
 		ret = opts.dst_addr ? bw_send(context) : bw_recv(context);
@@ -524,6 +526,8 @@ static void *bi_bandwidth(void *context)
 {
 	int i, ret;
 	struct thread_args *targs = context;
+
+	ft_hmem_init_thread(opts.iface, opts.device);
 
 	pthread_barrier_wait(&barrier);
 	for (i = 0; i < opts.warmup_iterations; i++) {

--- a/fabtests/common/hmem.c
+++ b/fabtests/common/hmem.c
@@ -145,6 +145,16 @@ int ft_hmem_init(enum fi_hmem_iface iface)
 	return ret;
 }
 
+int ft_hmem_init_thread(enum fi_hmem_iface iface, uint64_t device)
+{
+	switch (iface) {
+	case FI_HMEM_CUDA:
+		return ft_cuda_init_thread(device);
+	default:
+		return FI_SUCCESS;
+	}
+}
+
 int ft_hmem_cleanup(enum fi_hmem_iface iface)
 {
 	int ret = FI_SUCCESS;

--- a/fabtests/common/hmem_cuda.c
+++ b/fabtests/common/hmem_cuda.c
@@ -414,6 +414,27 @@ err:
 	return -FI_ENODATA;
 }
 
+int ft_cuda_init_thread(uint64_t device)
+{
+	cudaError_t cuda_ret;
+
+	cuda_ret = cuda_ops.cudaSetDevice(device);
+	if (cuda_ret != cudaSuccess) {
+		CUDA_ERR(cuda_ret, "cudaSetDevice failed");
+		return -FI_EIO;
+	}
+
+	/* cudaFree() forces context activation since cudaSetDevice() alone 
+	 * may do lazy initialization */
+	cuda_ret = cuda_ops.cudaFree(NULL);
+	if (cuda_ret != cudaSuccess) {
+		CUDA_ERR(cuda_ret, "cudaFree failed");
+		return -FI_EIO;
+	}
+
+	return FI_SUCCESS;
+}
+
 int ft_cuda_cleanup(void)
 {
 	dlclose(cudart_handle);
@@ -633,6 +654,11 @@ enum ft_cuda_memory_support ft_cuda_memory_support(void)
 #else
 
 int ft_cuda_init(void)
+{
+	return -FI_ENOSYS;
+}
+
+int ft_cuda_init_thread(uint64_t device)
 {
 	return -FI_ENOSYS;
 }

--- a/fabtests/common/hmem_cuda.c
+++ b/fabtests/common/hmem_cuda.c
@@ -544,22 +544,6 @@ int ft_cuda_copy_from_hmem(uint64_t device, void *dst, const void *src,
 	return -FI_EIO;
 }
 
-/* TODO: Make get_base_addr a general hmem ops API */
-static
-int ft_cuda_get_base_addr(const void *ptr, size_t len, void **base, size_t *size)
-{
-	CUresult cu_result;
-
-	cu_result = cuda_ops.cuMemGetAddressRange(
-				(CUdeviceptr *)base,
-				size, (CUdeviceptr) ptr);
-	if (cu_result == CUDA_SUCCESS)
-		return FI_SUCCESS;
-
-	ft_cuda_driver_api_print_error(cu_result, "cuMemGetAddressRange");
-	return -FI_EIO;
-}
-
 /**
  * @brief Get dmabuf fd and offset for a given cuda memory allocation
  *

--- a/fabtests/include/hmem.h
+++ b/fabtests/include/hmem.h
@@ -180,6 +180,7 @@ int ft_default_alloc_host(void **buf, size_t size);
 int ft_default_free_host(void *buf);
 
 int ft_cuda_init(void);
+int ft_cuda_init_thread(uint64_t device);
 int ft_cuda_cleanup(void);
 int ft_cuda_alloc(uint64_t device, void **buf, size_t size);
 int ft_cuda_alloc_host(void **buf, size_t size);
@@ -241,6 +242,7 @@ int ft_synapseai_copy_from_hmem(uint64_t device, void *dst, const void *src, siz
 int ft_synapseai_get_dmabuf_fd(void *buf, size_t len, int *dmabuf_fd, uint64_t *dmabuf_offset);
 
 int ft_hmem_init(enum fi_hmem_iface iface);
+int ft_hmem_init_thread(enum fi_hmem_iface iface, uint64_t device);
 int ft_hmem_cleanup(enum fi_hmem_iface iface);
 int ft_hmem_alloc(enum fi_hmem_iface iface, uint64_t device, void **buf,
 		  size_t size);

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -350,8 +350,11 @@ def test_rmd_tagged_pingpong_truncate_error(cmdline_args, completion_semantic):
 @pytest.mark.functional
 @pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.parametrize("num_eps", [8, 16, 32])
-def test_rdm_bw_mt_thread_completion(cmdline_args, num_eps, fabric):
+@pytest.mark.parametrize("iteration_type",
+                         [pytest.param("short", marks=pytest.mark.short),
+                          pytest.param("standard", marks=pytest.mark.standard)])
+def test_rdm_bw_mt_thread_completion(cmdline_args, iteration_type, num_eps, fabric):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, f"fi_rdm_bw_mt -g -n {num_eps} --threading completion",
-                            "standard", "transmit_complete", fabric=fabric)
+                            iteration_type, "transmit_complete", fabric=fabric)
     test.run()

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -346,3 +346,12 @@ def test_rmd_tagged_pingpong_truncate_error(cmdline_args, completion_semantic):
                                completion_semantic, "host_to_host",
                                message_size=message_size, fabric="efa",
                                timeout=15, might_fail=might_fail)
+
+@pytest.mark.functional
+@pytest.mark.fabric(params=["efa", "efa-direct"])
+@pytest.mark.parametrize("num_eps", [8, 16, 32])
+def test_rdm_bw_mt_thread_completion(cmdline_args, num_eps, fabric):
+    from common import ClientServerTest
+    test = ClientServerTest(cmdline_args, f"fi_rdm_bw_mt -g -n {num_eps} --threading completion",
+                            "standard", "transmit_complete", fabric=fabric)
+    test.run()

--- a/fabtests/scripts/runfabtests.py
+++ b/fabtests/scripts/runfabtests.py
@@ -41,6 +41,7 @@ def fabtests_testsets_to_pytest_markers(fabtests_testsets, run_mode=None):
 
     test_set = set()
     test_list = fabtests_testsets.split(",")
+    exclude_standard = False
 
     # use set() to remove duplicate test set
     for test in test_list:
@@ -49,6 +50,7 @@ def fabtests_testsets_to_pytest_markers(fabtests_testsets, run_mode=None):
             test_set.add("functional")
             test_set.add("short")
             test_set.add("ubertest_quick")
+            exclude_standard = True
         elif test =="ubertest":
             test_set.add("ubertest_quick")
         elif test == "all":
@@ -68,6 +70,9 @@ def fabtests_testsets_to_pytest_markers(fabtests_testsets, run_mode=None):
             markers = test[:]
         else:
             markers += " or " + test
+
+    if exclude_standard:
+        markers = "(" + markers + ") and (not standard)"
 
     if run_mode:
         if run_mode == "serial":

--- a/fabtests/test_configs/efa/efa.exclude
+++ b/fabtests/test_configs/efa/efa.exclude
@@ -85,6 +85,3 @@ dgram_bw
 
 # Multinode tests failing with an unsupported address format
 multinode
-
-# rdm_bw_mt not supported yet
-rdm_bw_mt


### PR DESCRIPTION
backport https://github.com/ofiwg/libfabric/pull/12441 
https://github.com/ofiwg/libfabric/pull/12447
https://github.com/ofiwg/libfabric/pull/12479