### PR TITLE
[v2.4.x]fabtests/sm2,fabtests/shm: Only run av xfer test on rdm eps

### DIFF
--- a/fabtests/pytest/shm/test_av.py
+++ b/fabtests/pytest/shm/test_av.py
@@ -1,1 +1,9 @@
-from default.test_av import test_av_xfer
+import pytest
+
+# shm only supports RDM EPs
+@pytest.mark.functional
+@pytest.mark.parametrize("endpoint_type", ["rdm"])
+def test_av_xfer(cmdline_args, endpoint_type):
+    from common import ClientServerTest
+    test = ClientServerTest(cmdline_args, "fi_av_xfer -e " + endpoint_type)
+    test.run()

--- a/fabtests/pytest/sm2/test_av.py
+++ b/fabtests/pytest/sm2/test_av.py
@@ -1,1 +1,9 @@
-from default.test_av import test_av_xfer
+import pytest
+
+# sm2 only supports RDM EPs
+@pytest.mark.functional
+@pytest.mark.parametrize("endpoint_type", ["rdm"])
+def test_av_xfer(cmdline_args, endpoint_type):
+    from common import ClientServerTest
+    test = ClientServerTest(cmdline_args, "fi_av_xfer -e " + endpoint_type)
+    test.run()


### PR DESCRIPTION
sm2 and shm don't support dgram eps, so we should not be testing them.


(cherry picked from commit https://github.com/ofiwg/libfabric/commit/561972b724d7ebd6628a0287e6c9ccf89951317e)