### PR TITLE
prov/efa: fix buffer overwrite in efa_write_error_msg

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -292,7 +292,8 @@ nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
 	prov/efa/test/gtest/efa_gtest_rdm_mr.cc \
 	prov/efa/test/gtest/efa_gtest_rdm_pke.cc \
 	prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.c \
-	prov/efa/test/gtest/efa_gtest_rdm_ope.cc
+	prov/efa/test/gtest/efa_gtest_rdm_ope.cc \
+	prov/efa/test/gtest/efa_gtest_cq.cc
 
 prov_efa_test_gtest_efa_gtest_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
@@ -316,7 +317,14 @@ prov_efa_test_gtest_efa_gtest_LDFLAGS = \
 	-Wl,--wrap=ibv_destroy_ah \
 	-Wl,--wrap=efadv_query_ah \
 	-Wl,--wrap=efa_av_reverse_av_add \
-	-Wl,--wrap=ofi_mr_map_insert
+	-Wl,--wrap=ofi_mr_map_insert \
+	-Wl,--wrap=efa_ibv_cq_start_poll \
+	-Wl,--wrap=efa_ibv_cq_end_poll \
+	-Wl,--wrap=efa_ibv_cq_wc_read_opcode \
+	-Wl,--wrap=efa_ibv_cq_wc_read_vendor_err \
+	-Wl,--wrap=efa_ibv_cq_wc_read_qp_num \
+	-Wl,--wrap=efa_ibv_cq_wc_read_wc_flags \
+	-Wl,--wrap=efa_ibv_cq_wc_read_byte_len
 
 prov_efa_test_gtest_efa_gtest_LIBS = $(linkback)
 

--- a/prov/efa/src/efa_cq.c
+++ b/prov/efa/src/efa_cq.c
@@ -110,6 +110,7 @@ static inline void efa_cq_write_error_data(struct efa_cq *efa_cq, struct efa_bas
 		err_msg = (char *)buf->err_data;
 	} else {
 		err_msg = efa_cq->err_buf;
+		buf->err_data_size = EFA_ERROR_MSG_BUFFER_LENGTH;
 	}
 
 	if (efa_write_error_msg(base_ep, addr, prov_errno, err_msg, &buf->err_data_size) != 0) {

--- a/prov/efa/src/efa_cq.h
+++ b/prov/efa/src/efa_cq.h
@@ -200,7 +200,9 @@ const char *efa_cq_strerror(struct fid_cq *cq_fid, int prov_errno,
  * @param[in]    prov_errno  EFA provider * error code(must be positive)
  * @param[out]   err_msg     Pointer to the address of error message written by
  * this function
- * @param[out]   buflen      Pointer to the returned error data size
+ * @param[in,out] buflen     On input, the capacity of err_msg in bytes. On
+ * output, the byte length of the message written.
+ * The message could be truncated to fit the input capacity.
  * @return       A status code. 0 if the error data was written successfully,
  * otherwise a negative FI error code.
  */
@@ -212,10 +214,11 @@ static inline int efa_write_error_msg(struct efa_base_ep *ep, fi_addr_t addr,
 	char peer_host_id_str[EFA_HOST_ID_STRING_LENGTH + 1] = {0};
 	char local_host_id_str[EFA_HOST_ID_STRING_LENGTH + 1] = {0};
 	const char *base_msg = efa_strerror(prov_errno);
+
 	size_t len = 0;
 	uint64_t local_host_id;
 
-	*buflen = 0;
+	size_t buflen_in = *buflen;
 
 	len = sizeof(ep_addr_str);
 	efa_base_ep_raw_addr_str(ep, ep_addr_str, &len);
@@ -233,21 +236,16 @@ static inline int efa_write_error_msg(struct efa_base_ep *ep, fi_addr_t addr,
 	/* efa-raw cannot get peer host id without a handshake */
 	strcpy(peer_host_id_str, "N/A");
 
-	int ret = snprintf(err_msg, EFA_ERROR_MSG_BUFFER_LENGTH,
+	int ret = snprintf(err_msg, buflen_in,
 			   "%s My EFA addr: %s My host id: %s Peer EFA addr: "
 			   "%s Peer host id: %s",
 			   base_msg, ep_addr_str, local_host_id_str,
 			   peer_addr_str, peer_host_id_str);
 
-	if (ret < 0 || ret > EFA_ERROR_MSG_BUFFER_LENGTH - 1) {
+	if (ret < 0) {
 		return -FI_EINVAL;
 	}
-
-	if (strlen(err_msg) >= EFA_ERROR_MSG_BUFFER_LENGTH) {
-		return -FI_ENOBUFS;
-	}
-
-	*buflen = EFA_ERROR_MSG_BUFFER_LENGTH;
+	*buflen = MIN((size_t) ret + 1, buflen_in);
 
 	return 0;
 }

--- a/prov/efa/test/gtest/efa_gtest_ah.cc
+++ b/prov/efa/test/gtest/efa_gtest_ah.cc
@@ -41,10 +41,11 @@ class EfaAhTest : public Test
 
 	void TearDown() override
 	{
+		/* ep_close calls this wrapped function */
+		EXPECT_CALL(mock_efa, efa_ibv_cq_start_poll)
+			.WillRepeatedly(Return(ENOENT));
+
 		efa_test_resource_destruct(&resource);
-		// It's necessary to uninstall the mock after destruct
-		// because the tests have dummy AHs that cannot be given
-		// to the real ibv_destroy_ah
 		MockEfa::set(nullptr);
 	}
 };

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.c
@@ -1,10 +1,11 @@
 /* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
 /* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
 
-#include "efa_gtest_common_helpers.h"
 #include "efa.h"
 #include "efa_av.h"
+#include "efa_cq.h"
 #include "rdm/efa_rdm_ep.h"
+#include "efa_gtest_common_helpers.h"
 
 void efa_test_fabricate_addr(struct fid_ep *ep, struct efa_ep_addr *addr)
 {
@@ -84,6 +85,51 @@ fi_addr_t efa_test_insert_self_gid_peer(struct fid_ep *ep, struct fid_av *av)
 	if (fi_av_insert(av, &raw_addr, 1, &peer_addr, 0, NULL) != 1)
 		return FI_ADDR_NOTAVAIL;
 	return peer_addr;
+}
+
+struct efa_context *efa_test_alloc_context(uint64_t completion_flags,
+					   fi_addr_t addr)
+{
+	struct efa_context *ctx = calloc(1, sizeof(*ctx));
+
+	if (!ctx)
+		return NULL;
+	ctx->completion_flags = completion_flags;
+	ctx->addr = addr;
+	return ctx;
+}
+
+struct efa_ibv_cq *efa_test_get_ibv_cq(struct fid_cq *cq_fid)
+{
+	struct efa_cq *efa_cq;
+
+	efa_cq = container_of(cq_fid, struct efa_cq, util_cq.cq_fid);
+	return &efa_cq->ibv_cq;
+}
+
+char *efa_test_get_cq_err_buf(struct fid_cq *cq_fid)
+{
+	struct efa_cq *efa_cq;
+
+	efa_cq = container_of(cq_fid, struct efa_cq, util_cq.cq_fid);
+	return efa_cq->err_buf;
+}
+
+const size_t efa_test_cq_err_buf_len = EFA_ERROR_MSG_BUFFER_LENGTH;
+
+uint32_t efa_test_get_qp_num(struct fid_ep *ep)
+{
+	struct efa_base_ep *base_ep;
+
+	base_ep = container_of(ep, struct efa_base_ep, util_ep.ep_fid);
+	return base_ep->qp->qp_num;
+}
+
+void efa_test_set_ibv_cq_ex(struct efa_ibv_cq *ibv_cq, int status,
+			    uint64_t wr_id)
+{
+	ibv_cq->ibv_cq_ex->status = status;
+	ibv_cq->ibv_cq_ex->wr_id = wr_id;
 }
 
 struct ibv_ah *efa_test_implicit_addr_to_ibv_ah(struct fid_av *av,

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.h
@@ -49,6 +49,43 @@ fi_addr_t efa_test_insert_peer_new_gid(struct fid_ep *ep, struct fid_av *av);
  * @return the fi_addr, or FI_ADDR_NOTAVAIL on failure
  */
 fi_addr_t efa_test_insert_self_gid_peer(struct fid_ep *ep, struct fid_av *av);
+struct efa_ibv_cq;
+struct efa_context;
+
+/**
+ * @brief Allocate an efa_context
+ */
+struct efa_context *efa_test_alloc_context(uint64_t completion_flags,
+					   fi_addr_t addr);
+
+/**
+ * @brief Get the efa_ibv_cq embedded in a fid_cq (opaque from C++).
+ */
+struct efa_ibv_cq *efa_test_get_ibv_cq(struct fid_cq *cq_fid);
+
+/**
+ * @brief Get a CQ's internal err_buf
+ */
+char *efa_test_get_cq_err_buf(struct fid_cq *cq_fid);
+
+/**
+ * @brief Capacity of the CQ's internal err_buf (EFA_ERROR_MSG_BUFFER_LENGTH),
+ * the upper bound on err_data_size the fallback error path can report.
+ */
+extern const size_t efa_test_cq_err_buf_len;
+
+/**
+ * @brief Get the QP number of the endpoint's underlying EFA QP. Works for the
+ * bare efa_base_ep endpoint used by the efa-direct fabric.
+ */
+uint32_t efa_test_get_qp_num(struct fid_ep *ep);
+
+/**
+ * @brief Set status and wr_id on the ibv_cq_ex inside efa_ibv_cq, to simulate a
+ * polled completion.
+ */
+void efa_test_set_ibv_cq_ex(struct efa_ibv_cq *ibv_cq, int status,
+			    uint64_t wr_id);
 
 struct ibv_ah;
 

--- a/prov/efa/test/gtest/efa_gtest_common_mocks.h
+++ b/prov/efa/test/gtest/efa_gtest_common_mocks.h
@@ -14,6 +14,7 @@ struct efa_prv_reverse_av;
 struct efa_conn;
 struct ofi_mr_map;
 struct fi_mr_attr;
+struct efa_ibv_cq;
 
 /*
  * X macro infrastructure for mock generation.
@@ -51,13 +52,42 @@ struct fi_mr_attr;
 		uint64_t *key, void *context, uint64_t flags
 #define EFA_MOCK_ARGS_ofi_mr_map_insert map, attr, key, context, flags
 
+#define EFA_MOCK_PARAMS_efa_ibv_cq_start_poll \
+	struct efa_ibv_cq *ibv_cq, struct ibv_poll_cq_attr *attr
+#define EFA_MOCK_ARGS_efa_ibv_cq_start_poll ibv_cq, attr
+
+#define EFA_MOCK_PARAMS_efa_ibv_cq_end_poll struct efa_ibv_cq *ibv_cq
+#define EFA_MOCK_ARGS_efa_ibv_cq_end_poll   ibv_cq
+
+#define EFA_MOCK_PARAMS_efa_ibv_cq_wc_read_opcode struct efa_ibv_cq *ibv_cq
+#define EFA_MOCK_ARGS_efa_ibv_cq_wc_read_opcode	  ibv_cq
+
+#define EFA_MOCK_PARAMS_efa_ibv_cq_wc_read_vendor_err struct efa_ibv_cq *ibv_cq
+#define EFA_MOCK_ARGS_efa_ibv_cq_wc_read_vendor_err   ibv_cq
+
+#define EFA_MOCK_PARAMS_efa_ibv_cq_wc_read_qp_num struct efa_ibv_cq *ibv_cq
+#define EFA_MOCK_ARGS_efa_ibv_cq_wc_read_qp_num	  ibv_cq
+
+#define EFA_MOCK_PARAMS_efa_ibv_cq_wc_read_wc_flags struct efa_ibv_cq *ibv_cq
+#define EFA_MOCK_ARGS_efa_ibv_cq_wc_read_wc_flags   ibv_cq
+
+#define EFA_MOCK_PARAMS_efa_ibv_cq_wc_read_byte_len struct efa_ibv_cq *ibv_cq
+#define EFA_MOCK_ARGS_efa_ibv_cq_wc_read_byte_len   ibv_cq
+
 /* --- Function list --- */
 
-#define EFA_MOCK_FUNCTIONS(X)             \
-	X(struct ibv_ah *, ibv_create_ah) \
-	X(int, ibv_destroy_ah)            \
-	X(int, efadv_query_ah)            \
-	X(int, efa_av_reverse_av_add)     \
+#define EFA_MOCK_FUNCTIONS(X)                            \
+	X(struct ibv_ah *, ibv_create_ah)                \
+	X(int, ibv_destroy_ah)                           \
+	X(int, efadv_query_ah)                           \
+	X(int, efa_av_reverse_av_add)                    \
+	X(int, efa_ibv_cq_start_poll)                    \
+	X(void, efa_ibv_cq_end_poll)                     \
+	X(enum ibv_wc_opcode, efa_ibv_cq_wc_read_opcode) \
+	X(uint32_t, efa_ibv_cq_wc_read_vendor_err)       \
+	X(uint32_t, efa_ibv_cq_wc_read_qp_num)           \
+	X(unsigned int, efa_ibv_cq_wc_read_wc_flags)     \
+	X(uint32_t, efa_ibv_cq_wc_read_byte_len)		\
 	X(int, ofi_mr_map_insert)
 
 /* --- Generator macros --- */

--- a/prov/efa/test/gtest/efa_gtest_conn.cc
+++ b/prov/efa/test/gtest/efa_gtest_conn.cc
@@ -9,7 +9,6 @@
 using testing::Test;
 using testing::_;
 using testing::Return;
-using testing::Invoke;
 using testing::StrictMock;
 
 class EfaConnTest : public Test
@@ -25,8 +24,11 @@ class EfaConnTest : public Test
 
 	void TearDown() override
 	{
-		efa_test_resource_destruct(&resource);
+		/* Uninstall the mock before destruct: ep close drains the RDM
+		 * CQ, whose efa_ibv_cq_* calls are globally wrapped and would
+		 * otherwise route into the (now-irrelevant) mock. */
 		MockEfa::set(nullptr);
+		efa_test_resource_destruct(&resource);
 	}
 };
 
@@ -47,17 +49,9 @@ TEST_F(EfaConnTest, alloc_reverse_av_add_failure_rdm_cleanup)
 	MockEfa::set(&mock_efa);
 	EXPECT_CALL(mock_efa, ibv_create_ah)
 		.WillOnce(Return(&dummy_ibv_ah));
-	/*
-	 * Fake the dummy ah destroy but route
-	 * the self_ah to the real destroy so it and its PD are not leaked.
-	 */
-	EXPECT_CALL(mock_efa, ibv_destroy_ah(_))
-		.Times(2)
-		.WillRepeatedly(Invoke([](struct ibv_ah *ah) -> int {
-			if (ah == &dummy_ibv_ah)
-				return 0;
-			return __real_ibv_destroy_ah(ah);
-		}));
+	/* The unwind releases only the peer's dummy AH; self_ah is destroyed
+	 * in teardown after the mock is uninstalled (real destroy). */
+	EXPECT_CALL(mock_efa, ibv_destroy_ah(&dummy_ibv_ah)).WillOnce(Return(0));
 	EXPECT_CALL(mock_efa, efadv_query_ah)
 		.WillRepeatedly(Return(0));
 	EXPECT_CALL(mock_efa, efa_av_reverse_av_add)
@@ -87,13 +81,9 @@ TEST_F(EfaConnTest, alloc_reverse_av_add_failure_explicit_insert)
 	MockEfa::set(&mock_efa);
 	EXPECT_CALL(mock_efa, ibv_create_ah(_, _))
 		.WillOnce(Return(&dummy_ibv_ah));
-	EXPECT_CALL(mock_efa, ibv_destroy_ah(_))
-		.Times(2)
-		.WillRepeatedly(Invoke([](struct ibv_ah *ah) -> int {
-			if (ah == &dummy_ibv_ah)
-				return 0;
-			return __real_ibv_destroy_ah(ah);
-		}));
+	/* The unwind releases only the peer's dummy AH; self_ah is destroyed
+	 * in teardown after the mock is uninstalled (real destroy). */
+	EXPECT_CALL(mock_efa, ibv_destroy_ah(&dummy_ibv_ah)).WillOnce(Return(0));
 	EXPECT_CALL(mock_efa, efadv_query_ah)
 		.WillRepeatedly(Return(0));
 	EXPECT_CALL(mock_efa, efa_av_reverse_av_add)

--- a/prov/efa/test/gtest/efa_gtest_cq.cc
+++ b/prov/efa/test/gtest/efa_gtest_cq.cc
@@ -1,0 +1,143 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_common_helpers.h"
+#include "efa_gtest_common_mocks.h"
+#include "efa_gtest_common_resource.h"
+#include <cstdlib>
+#include <errno.h>
+#include <gtest/gtest.h>
+
+using testing::Return;
+using testing::StrictMock;
+using testing::Test;
+
+
+class EfaCqTest : public Test
+{
+	protected:
+	struct efa_resource resource = {};
+	StrictMock<MockEfa> mock_efa;
+	struct efa_ibv_cq *ibv_cq = nullptr;
+	uint32_t qp_num = 0;
+
+	void SetUp() override
+	{
+		memset(&resource, 0, sizeof(resource));
+		efa_test_resource_construct(
+			&resource, efa_test_alloc_default_hints(
+					   FI_EP_RDM, EFA_DIRECT_FABRIC_NAME));
+		ASSERT_NE(resource.cq, nullptr);
+		ibv_cq = efa_test_get_ibv_cq(resource.cq);
+		ASSERT_NE(ibv_cq, nullptr);
+		qp_num = efa_test_get_qp_num(resource.ep);
+
+		MockEfa::set(&mock_efa);
+	}
+
+	void TearDown() override
+	{
+		MockEfa::set(nullptr);
+		efa_test_resource_destruct(&resource);
+	}
+
+	static constexpr uint32_t kProvErrno = 1;
+
+	/* Set up expectations to get an error cqe */
+	void set_expectations_for_cq_err()
+	{
+		EXPECT_CALL(mock_efa, efa_ibv_cq_start_poll).WillOnce(Return(0));
+		EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_qp_num)
+			.WillOnce(Return(qp_num));
+		EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_opcode)
+			.WillOnce(Return(IBV_WC_SEND));
+		EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_vendor_err)
+			.WillOnce(Return(kProvErrno));
+		EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_byte_len)
+			.WillOnce(Return(64));
+		EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_wc_flags)
+			.WillOnce(Return(0));
+		EXPECT_CALL(mock_efa, efa_ibv_cq_end_poll).Times(1);
+	}
+
+	void drive_error_cqe(struct efa_context *ctx,
+			     struct fi_cq_err_entry *err_entry)
+	{
+		struct fi_cq_data_entry data_entry = {};
+
+		efa_test_set_ibv_cq_ex(ibv_cq, 1, (uint64_t) (uintptr_t) ctx);
+
+		ssize_t ret = fi_cq_readfrom(resource.cq, &data_entry, 1,
+					     nullptr);
+		ASSERT_EQ(ret, -FI_EAVAIL);
+
+		ssize_t readerr_ret = fi_cq_readerr(resource.cq, err_entry, 0);
+		ASSERT_EQ(readerr_ret, 1);
+
+		EXPECT_EQ(err_entry->prov_errno, kProvErrno);
+		EXPECT_NE(err_entry->err, 0);
+	}
+};
+
+/**
+ * @brief fi_cq_readerr must not write past the caller's err_data buffer.
+ */
+TEST_F(EfaCqTest, readerr_respects_small_err_data_buffer)
+{
+	struct fi_cq_err_entry err_entry = {};
+
+	struct efa_context *ctx =
+		efa_test_alloc_context(FI_SEND | FI_MSG, FI_ADDR_NOTAVAIL);
+	ASSERT_NE(ctx, nullptr);
+
+	// only allow the provider to write 16 bytes,
+	// and use backing buffer to catch overwrites
+	constexpr size_t kDeclared = 16;
+	constexpr size_t kBacking = 1024;
+	constexpr unsigned char kCanary = 0xA5;
+	unsigned char buf[kBacking];
+	memset(buf, kCanary, sizeof(buf));
+
+	err_entry.err_data = buf;
+	err_entry.err_data_size = kDeclared;
+
+	set_expectations_for_cq_err();
+	drive_error_cqe(ctx, &err_entry);
+
+	/* no byte at or beyond the declared size may be written. */
+	for (size_t i = kDeclared; i < kBacking; i++)
+		ASSERT_EQ(buf[i], kCanary)
+			<< "err_data written out of bounds at offset " << i;
+
+	/* reported size must not exceed the caller's buffer. */
+	EXPECT_LE(err_entry.err_data_size, kDeclared);
+
+	free(ctx);
+}
+
+/**
+ * @brief fi_cq_readerr will use provider-owned buffer if error_data_size == 0.
+ */
+TEST_F(EfaCqTest, readerr_falls_back_to_internal_err_buf)
+{
+	struct fi_cq_err_entry err_entry = {};
+
+	struct efa_context *ctx =
+		efa_test_alloc_context(FI_SEND | FI_MSG, FI_ADDR_NOTAVAIL);
+	ASSERT_NE(ctx, nullptr);
+
+	err_entry.err_data = nullptr;
+	err_entry.err_data_size = 0;
+
+	set_expectations_for_cq_err();
+	drive_error_cqe(ctx, &err_entry);
+
+	/* err_data is set to the efa-owned buffer */
+	ASSERT_EQ(err_entry.err_data, efa_test_get_cq_err_buf(resource.cq));
+	ASSERT_GT(err_entry.err_data_size, 0u);
+	ASSERT_LE(err_entry.err_data_size, efa_test_cq_err_buf_len);
+	EXPECT_EQ(((const char *) err_entry.err_data)[err_entry.err_data_size - 1],
+		  '\0');
+
+	free(ctx);
+}


### PR DESCRIPTION
`efa_write_error_msg` used to always write `EFA_ERROR_MSG_BUFFER_LENGTH` (1024) 
bytes to the err_msg buffer, despite the [man page allowing different sized buffers to be passed in](https://github.com/ofiwg/libfabric/blob/d1c24b918bfd0f80fe3018c05e7c3c610f7f893b/man/fi_cq.3.md?plain=1#L548). 
This potentially will cause the buffer to overflow. A unit test has been added to assert this doesn't happen.