### PR TITLE
fabtests/efa/multi_ep_stress: fix default threading mode

### DIFF
--- a/fabtests/prov/efa/src/multi_ep_stress.c
+++ b/fabtests/prov/efa/src/multi_ep_stress.c
@@ -1442,6 +1442,7 @@ int main(int argc, char **argv)
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
+	opts.threading = FI_THREAD_SAFE;
 	timeout = 10;
 
 	hints = fi_allocinfo();
@@ -1453,8 +1454,6 @@ int main(int argc, char **argv)
 		goto out;
 
 	// Set up hints
-	if (!opts.threading)
-		opts.threading = FI_THREAD_SAFE;
 	if (opts.threading == FI_THREAD_COMPLETION && topts.shared_cq) {
 		fprintf(stderr, "--shared-cq is incompatible with "
 			"--threading completion\n");


### PR DESCRIPTION
Commit e00e3611438e3492c56c4b581c507679f3ca4ffd introduces a bug which sets threading mode to domain if no `--threading` argument had been specified in cmdline.
The test is not designed to work with domain model (INIT_OPTS sets it to DOMAIN). This fix restores the default to thread-safe model.