### PR TITLE
prov/efa: surface mr_map_insert error in rdm_mr_reg_impl

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -288,7 +288,8 @@ nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
 	prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c \
 	prov/efa/test/gtest/efa_gtest_conn.cc \
 	prov/efa/test/gtest/efa_gtest_ah.cc \
-	prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc
+	prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc \
+	prov/efa/test/gtest/efa_gtest_rdm_mr.cc
 
 prov_efa_test_gtest_efa_gtest_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
@@ -311,7 +312,8 @@ prov_efa_test_gtest_efa_gtest_LDFLAGS = \
 	-Wl,--wrap=ibv_create_ah \
 	-Wl,--wrap=ibv_destroy_ah \
 	-Wl,--wrap=efadv_query_ah \
-	-Wl,--wrap=efa_av_reverse_av_add
+	-Wl,--wrap=efa_av_reverse_av_add \
+	-Wl,--wrap=ofi_mr_map_insert
 
 prov_efa_test_gtest_efa_gtest_LIBS = $(linkback)
 

--- a/prov/efa/src/rdm/efa_rdm_mr.c
+++ b/prov/efa/src/rdm/efa_rdm_mr.c
@@ -444,9 +444,12 @@ static int efa_rdm_mr_dereg_impl(struct efa_rdm_mr *efa_rdm_mr)
 	int err;
 
 	if (efa_rdm_mr->shm_mr) {
-		ret = fi_close(&efa_rdm_mr->shm_mr->fid);
-		if (ret)
-			return ret;
+		err = fi_close(&efa_rdm_mr->shm_mr->fid);
+		if (err) {
+			EFA_WARN_FI_ERRNO(FI_LOG_MR,
+				"Unable to close shm MR", -err);
+			ret = err;
+		}
 		efa_rdm_mr->shm_mr = NULL;
 	}
 
@@ -547,7 +550,7 @@ static void efa_rdm_mr_hmem_setup(struct efa_rdm_mr *efa_rdm_mr,
 static int efa_rdm_mr_reg_impl(struct efa_rdm_mr *efa_rdm_mr, uint64_t flags,
 			       const struct fi_mr_attr *mr_attr)
 {
-	int ret;
+	int ret, err;
 
 	/* RDM-specific: MR cache flush */
 	{
@@ -585,7 +588,11 @@ static int efa_rdm_mr_reg_impl(struct efa_rdm_mr *efa_rdm_mr, uint64_t flags,
 	assert(efa_rdm_mr->efa_mr.mr_fid.key != FI_KEY_NOTAVAIL);
 	ret = efa_rdm_mr_update_domain_mr_map(efa_rdm_mr, (struct fi_mr_attr *)mr_attr, flags);
 	if (ret) {
-		ret = efa_rdm_mr_dereg_impl(efa_rdm_mr);
+		err = efa_rdm_mr_dereg_impl(efa_rdm_mr);
+		if (err)
+			EFA_WARN_FI_ERRNO(FI_LOG_MR,
+					"MR registration failed, then deregistering "
+					"the partially created MR failed with", -err);
 		return ret;
 	}
 
@@ -626,27 +633,15 @@ static void efa_rdm_mr_close_check_inflight_ope(struct efa_mr *efa_mr)
 static int efa_rdm_mr_close(fid_t fid)
 {
 	struct efa_rdm_mr *efa_rdm_mr;
-	int ret = 0, err;
+	int ret = 0;
 
 	efa_rdm_mr = container_of(fid, struct efa_rdm_mr, efa_mr.mr_fid.fid);
 	if (efa_env.track_mr)
 		efa_rdm_mr_close_check_inflight_ope(&efa_rdm_mr->efa_mr);
 
-	if (efa_rdm_mr->shm_mr) {
-		err = fi_close(&efa_rdm_mr->shm_mr->fid);
-		if (err) {
-			EFA_WARN_FI_ERRNO(FI_LOG_MR,
-				"Unable to close shm MR", -err);
-			ret = err;
-		}
-		efa_rdm_mr->shm_mr = NULL;
-	}
-
-	err = efa_rdm_mr_dereg_impl(efa_rdm_mr);
-	if (err) {
-		EFA_WARN_FI_ERRNO(FI_LOG_MR, "Unable to close efa_rdm_mr", -err);
-		ret = ret ? ret : err;
-	}
+	ret = efa_rdm_mr_dereg_impl(efa_rdm_mr);
+	if (ret)
+		EFA_WARN_FI_ERRNO(FI_LOG_MR, "Unable to close efa_rdm_mr", -ret);
 
 	efa_rdm_mr_free(efa_rdm_mr);
 

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.c
@@ -79,3 +79,22 @@ struct ibv_ah *efa_test_implicit_addr_to_ibv_ah(struct fid_av *av,
 
 	return conn ? conn->ah->ibv_ah : NULL;
 }
+
+static struct efa_rdm_domain *efa_test_rdm_domain(struct fid_domain *domain)
+{
+	struct efa_domain *efa_domain = container_of(
+		domain, struct efa_domain, util_domain.domain_fid);
+
+	return container_of(efa_domain, struct efa_rdm_domain, efa_domain);
+}
+
+struct fid_domain *efa_test_get_shm_domain(struct fid_domain *domain)
+{
+	return efa_test_rdm_domain(domain)->shm_domain;
+}
+
+void efa_test_set_shm_domain(struct fid_domain *domain,
+			     struct fid_domain *shm_domain)
+{
+	efa_test_rdm_domain(domain)->shm_domain = shm_domain;
+}

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.h
@@ -53,6 +53,13 @@ struct ibv_ah;
 struct ibv_ah *efa_test_implicit_addr_to_ibv_ah(struct fid_av *av,
 						fi_addr_t fi_addr);
 
+/**
+ * @brief Get/set an RDM domain's shm_domain.
+ */
+struct fid_domain *efa_test_get_shm_domain(struct fid_domain *domain);
+void efa_test_set_shm_domain(struct fid_domain *domain,
+			     struct fid_domain *shm_domain);
+
 #ifdef __cplusplus
 }
 #endif

--- a/prov/efa/test/gtest/efa_gtest_common_mocks.h
+++ b/prov/efa/test/gtest/efa_gtest_common_mocks.h
@@ -12,6 +12,8 @@ struct efa_av;
 struct efa_cur_reverse_av;
 struct efa_prv_reverse_av;
 struct efa_conn;
+struct ofi_mr_map;
+struct fi_mr_attr;
 
 /*
  * X macro infrastructure for mock generation.
@@ -44,13 +46,19 @@ struct efa_conn;
 #define EFA_MOCK_ARGS_efa_av_reverse_av_add \
 	av, cur_reverse_av, prv_reverse_av, conn
 
+#define EFA_MOCK_PARAMS_ofi_mr_map_insert                                  \
+	struct ofi_mr_map *map, const struct fi_mr_attr *attr,             \
+		uint64_t *key, void *context, uint64_t flags
+#define EFA_MOCK_ARGS_ofi_mr_map_insert map, attr, key, context, flags
+
 /* --- Function list --- */
 
 #define EFA_MOCK_FUNCTIONS(X)             \
 	X(struct ibv_ah *, ibv_create_ah) \
 	X(int, ibv_destroy_ah)            \
 	X(int, efadv_query_ah)            \
-	X(int, efa_av_reverse_av_add)
+	X(int, efa_av_reverse_av_add)     \
+	X(int, ofi_mr_map_insert)
 
 /* --- Generator macros --- */
 

--- a/prov/efa/test/gtest/efa_gtest_rdm_mr.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_mr.cc
@@ -1,0 +1,70 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_common_helpers.h"
+#include "efa_gtest_common_mocks.h"
+#include "efa_gtest_common_resource.h"
+#include <gtest/gtest.h>
+
+using testing::Return;
+using testing::StrictMock;
+using testing::Test;
+
+class EfaRdmMrTest : public Test
+{
+	protected:
+	struct efa_resource resource = {};
+	StrictMock<MockEfa> mock_efa;
+
+	void SetUp() override
+	{
+		memset(&resource, 0, sizeof(resource));
+
+		efa_test_resource_construct(
+			&resource, efa_test_alloc_default_hints(
+					   FI_EP_RDM, EFA_FABRIC_NAME));
+		ASSERT_NE(resource.domain, nullptr);
+
+		MockEfa::set(&mock_efa);
+	}
+
+	void TearDown() override
+	{
+		MockEfa::set(nullptr);
+		efa_test_resource_destruct(&resource);
+	}
+};
+
+/**
+ * @brief A failed domain mr_map insert error must propagate out of registration.
+ */
+TEST_F(EfaRdmMrTest, reg_map_insert_failure_propagates_error)
+{
+	char buf[64];
+	struct iovec iov = {};
+	struct fi_mr_attr attr = {};
+	struct fid_mr *mr = nullptr;
+	struct fid_domain *saved_shm_domain;
+	int ret;
+
+	iov.iov_base = buf;
+	iov.iov_len = sizeof(buf);
+	attr.mr_iov = &iov;
+	attr.iov_count = 1;
+	attr.access = FI_SEND | FI_RECV;
+	attr.iface = FI_HMEM_SYSTEM;
+
+	EXPECT_CALL(mock_efa, ofi_mr_map_insert)
+		.Times(1)
+		.WillOnce(Return(-FI_ENOMEM));
+
+	/* Detach shm to skip the irrelevant shm block in mr_regattr. */
+	saved_shm_domain = efa_test_get_shm_domain(resource.domain);
+	efa_test_set_shm_domain(resource.domain, nullptr);
+	ret = fi_mr_regattr(resource.domain, &attr, 0, &mr);
+	efa_test_set_shm_domain(resource.domain, saved_shm_domain);
+	EXPECT_EQ(ret, -FI_ENOMEM);
+
+	if (mr)
+		fi_close(&mr->fid);
+}

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc
@@ -10,6 +10,7 @@
 using testing::Bool;
 using testing::StrictMock;
 using testing::TestWithParam;
+using testing::Invoke;
 
 class EfaRtmTest : public TestWithParam<bool>
 {
@@ -47,6 +48,9 @@ class EfaRtmTest : public TestWithParam<bool>
 TEST_P(EfaRtmTest, read_nack_missing_rxe_no_null_deref)
 {
 	ssize_t ret = 0;
+
+	EXPECT_CALL(mock_efa, ofi_mr_map_insert)
+		.WillOnce(Invoke(__real_ofi_mr_map_insert));
 
 	ASSERT_EQ(efa_test_rtm_read_nack_missing_rxe(resource.ep, peer_addr,
 						     GetParam(), &ret),


### PR DESCRIPTION
If `efa_rdm_mr_update_domain_mr_map` returns a nonzero errno, 
mr_dereg is called and its return (most likely 0) is returned instead. 
This causes callers to assume mr registration is successful and will 
only fail later in the data path. 
This commit surfaces the error at registration time.

A unit test is added to assert this behavior.