### PR TITLE
fabtests/pytest: Correctly handle dmabuf registrations with gdrcopy

### DIFF
--- a/fabtests/pytest/efa/test_efa_protocol_selection.py
+++ b/fabtests/pytest/efa/test_efa_protocol_selection.py
@@ -65,7 +65,9 @@ def test_transfer_with_read_protocol_cuda(cmdline_args, fabtest_name, cntrl_env_
     # The hw counter should record:
     # - The exact message size if gdrcopy is enabled, or
     # - More if gdrcopy is disabled and localread is used.
-    if (has_gdrcopy(cmdline_args.server_id)):
+    # Under dmabuf registration the EFA provider does not use gdrcopy even when
+    # it is installed on the host, so the copy falls back to localread.
+    if (has_gdrcopy(cmdline_args.server_id) and not cmdline_args.do_dmabuf_reg_for_hmem):
         assert bytes_read == message_size
         assert server_read_wrs_after_test == server_read_wrs_before_test + 1
     else:

--- a/fabtests/pytest/efa/test_runt.py
+++ b/fabtests/pytest/efa/test_runt.py
@@ -36,6 +36,8 @@ def test_runt_read_functional(cmdline_args, memory_type, copy_method):
         additional_env += " FI_EFA_INTER_MIN_READ_MESSAGE_SIZE=65536"
 
     if copy_method == "gdrcopy":
+        if cmdline_args.do_dmabuf_reg_for_hmem:
+            pytest.skip("gdrcopy is not used under dmabuf registration")
         if not has_gdrcopy(cmdline_args.server_id) or not has_gdrcopy(cmdline_args.client_id):
             pytest.skip("No gdrcopy")
         additional_env += " FI_HMEM_CUDA_USE_GDRCOPY=1"


### PR DESCRIPTION
GDRCopy is not enabled for dmabuf registrations. The tests need to handle this case correctly.