### PR TITLE
fabtests/common: ft_backoff - thread backoff function

### DIFF
--- a/fabtests/benchmarks/rdm_bw_mt.c
+++ b/fabtests/benchmarks/rdm_bw_mt.c
@@ -413,10 +413,17 @@ static int read_cq(struct fid_cq *cqueue)
 {
 	struct fi_cq_entry cq_entry;
 	int ret;
+	unsigned retry_count = 0;
 
 	do {
 		ret = fi_cq_read(cqueue, &cq_entry, 1);
-		if (ret < 0 && ret != -FI_EAGAIN)
+		if (ret == -FI_EAGAIN) {
+			ret = ft_backoff(retry_count++, timeout*1000000, true);
+			if (ret)
+				return ret;
+			continue;
+		}
+		if (ret < 0)
 			return ret;
 		if (ret == 1)
 			return 0;
@@ -427,6 +434,7 @@ static int post_send(void *context)
 {
 	int ret;
 	struct thread_args *targs = context;
+	unsigned retry_count = 0;
 
 	do {
 		ret = fi_send(targs->ep, targs->tx_buf, xfer_size,
@@ -434,6 +442,9 @@ static int post_send(void *context)
 		if (ret != -FI_EAGAIN)
 			return ret;
 
+		ret = ft_backoff(retry_count++, 1, false);
+		if (ret)
+			return ret;
 		force_progress(targs->cq);
 	} while (1);
 }
@@ -442,6 +453,7 @@ static int post_recv(void *context)
 {
 	int ret;
 	struct thread_args *targs = context;
+	unsigned retry_count = 0;
 
 	do {
 		ret = fi_recv(targs->ep, targs->rx_buf, xfer_size,
@@ -449,6 +461,9 @@ static int post_recv(void *context)
 		if (ret != -FI_EAGAIN)
 			return ret;
 
+		ret = ft_backoff(retry_count++, 1, false);
+		if (ret)
+			return ret;
 		force_progress(targs->cq);
 	} while (1);
 }

--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -4681,3 +4681,46 @@ int ft_parse_long_opts(int op, char *optarg)
 		return EXIT_FAILURE;
 	}
 }
+
+/**
+ * ft_backoff - interrupt execution of current thread
+ * @backoff_count: count of previously done calls in the same loop
+ * @max_delay_us: the maximum allowed sleep period in microseconds
+ * @giveup_after_max_delay: boolean flag whatever backoff should timout
+ *                        after reaching max waiting period
+ *
+ * Backoff strategy depends on backoff count
+ * 1-999:     pause CPU core
+ * 1000:      relinquish the CPU
+ * 1000-...:  exponential sleeps until hard timeout (defined by fabtests)
+ *
+ * Returns: 0 on success, -FI_ETIMEDOUT if hard timeout reached
+ */
+int ft_backoff(unsigned backoff_count,
+		unsigned max_delay_us,
+		bool giveup_after_max_delay) {
+	const unsigned long_backoff_threshold = 10;
+	_Thread_local static unsigned last_backoff_count = 0;
+	_Thread_local static unsigned last_delay_us = 0;
+	assert(backoff_count == 0 || backoff_count == last_backoff_count + 1);
+	last_backoff_count = backoff_count;
+	if(backoff_count < long_backoff_threshold) {
+#if defined(__x86_64__)
+		asm volatile("pause" ::: "memory");
+#elif defined(__aarch64__)
+		asm volatile("yield" ::: "memory");
+#endif
+	} else if (backoff_count == long_backoff_threshold) {
+		sched_yield();
+		last_delay_us = 0;
+	} else {
+		last_delay_us = last_delay_us ? last_delay_us*2 : 1;
+		if(last_delay_us > max_delay_us) {
+			if (giveup_after_max_delay)
+				return -FI_ETIMEDOUT;
+			last_delay_us = max_delay_us;
+		}
+		usleep(last_delay_us);
+	}
+	return 0;
+}

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -710,6 +710,8 @@ extern struct option long_opts[];
 int ft_parse_long_opts(int op, char *optarg);
 void ft_longopts_usage();
 
+int ft_backoff(unsigned backoff_count, unsigned max_delay_us, bool giveup_after_max_delay);
+
 #define ft_assert(expr)					\
 	do {						\
 		if (!debug_assert) {			\

--- a/fabtests/prov/efa/src/multi_ep_stress.c
+++ b/fabtests/prov/efa/src/multi_ep_stress.c
@@ -449,6 +449,7 @@ static int wait_for_comp(struct fid_cq *cq, int num_completions)
 		}
 	}
 
+	unsigned retry_count = 0;
 	while (completed < num_completions) {
 		ret = fi_cq_read(cq, &comp, 1);
 		if (ret > 0) {
@@ -489,7 +490,8 @@ static int wait_for_comp(struct fid_cq *cq, int num_completions)
 				break;
 			}
 		}
-		sched_yield();
+		ret = ft_backoff(retry_count++, timeout*1000000, false);
+		assert(ret == 0);
 	}
 
 	if (topts.shared_cq) {
@@ -526,6 +528,7 @@ static void *run_sender_worker(void *arg)
 	memset(ops_posted_for_peer, 0, sizeof(ops_posted_for_peer));
 
 	bool should_reset_cycle = true;
+	unsigned retry_count = 0;
 	while(ops_posted < total_ops) {
 		if (should_reset_cycle) {
 			// Start a new endpoint cycle
@@ -627,13 +630,14 @@ static void *run_sender_worker(void *arg)
 			|| ops_posted_for_peer[peer_idx] == topts.msgs_per_sender) {
 			if (++peer_idx == ctx->num_peers)
 				peer_idx = 0;
-			// Relinquish current CPU core to break busy-wait loop
-			// on the current thread. Main thread will be scheduled
-			// before current thread, therefore it would likely push
-			// an update to worker's control queue if the one was pending.
-			sched_yield();
+			ret = ft_backoff(retry_count++, timeout*1000000, true);
+			if (ret) {
+				FT_PRINTERR("ft_backoff", ret);
+				goto out;
+			}
 			continue;
 		}
+		retry_count = 0;
 
 		// Post one operation
 		struct fi_context2 *fi_ctx;


### PR DESCRIPTION
rdm_bw_mt might run very slow due to internal lock contention

Implementing an backoff function which has three stages:

1) pause CPU core (to sync CPU caches)
2) relinquish CPU core (to allow other threads make some progress) 3) sleeps with exponational duration increase (to allow other threads to catch-up)

The new common function is utilized in rdm_bw_mt and efa/multi_ep_stress fabtests