### PR TITLE
fabtests/pytest: filter memory types at collection via a shape marker

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -927,3 +927,22 @@ def test_selected_by_marker(config, test_markers, name):
     without_marker = expr.evaluate(lambda n: n in (test_markers - {name}))
     # true only when `name` is the reason this test got selected
     return with_marker and not without_marker
+
+
+def client_server_have_device(memory_token, server_id, client_id):
+    """
+    Return True if both client and server endpoints named in a memory-type
+    token have the hmem device that token requires.
+
+    Any SSH/detection failure propagates to the caller,
+    which falls back to including all candidate memory types.
+    """
+    client_memory_type, server_memory_type = memory_token.split("_to_")
+    for memory_type_name, ip in ((client_memory_type, client_id),
+                                 (server_memory_type, server_id)):
+        if memory_type_name == "host":
+            # host memory needs no accelerator device
+            continue
+        if num_hmem_devices(ip, memory_type_name) <= 0:
+            return False
+    return True

--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -4,6 +4,7 @@ import subprocess
 import time
 from retrying import retry
 from common import (
+    client_server_have_device,
     num_hmem_devices,
     test_selected_by_marker,
     has_ssh_connection_err_msg,
@@ -101,25 +102,6 @@ def add_fabric_and_message_size_parametrization(metafunc, fabric_marker, sizes_m
             f"no kwarg naming {test_type!r} (have {sorted(sizes_marker.kwargs)})"
         )
     metafunc.parametrize("message_sizes", sizes)
-
-
-def client_server_have_device(memory_token, server_id, client_id):
-    """
-    Return True if both client and server endpoints named in a memory-type
-    token have the hmem device that token requires.
-
-    Any SSH/detection failure propagates to the caller,
-    which falls back to including all candidate memory types.
-    """
-    client_memory_type, server_memory_type = memory_token.split("_to_")
-    for memory_type_name, ip in ((client_memory_type, client_id),
-                                 (server_memory_type, server_id)):
-        if memory_type_name == "host":
-            # host memory needs no accelerator device
-            continue
-        if num_hmem_devices(ip, memory_type_name) <= 0:
-            return False
-    return True
 
 
 def add_memory_type_parametrization(metafunc, memory_type_marker):

--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -4,16 +4,18 @@ import subprocess
 import time
 from retrying import retry
 from common import (
+    num_hmem_devices,
     test_selected_by_marker,
     has_ssh_connection_err_msg,
     is_ssh_connection_error,
     SshConnectionError,
 )
 from efa_common import (
-    has_rdma, 
+    has_rdma,
     support_cq_interrupts,
     CudaMemorySupport,
     get_cuda_memory_support,
+    memory_type_list_bi_dir,
 )
 
 # Message size lists are defined in efa_common.py and imported by test files directly.
@@ -101,16 +103,80 @@ def add_fabric_and_message_size_parametrization(metafunc, fabric_marker, sizes_m
     metafunc.parametrize("message_sizes", sizes)
 
 
+def client_server_have_device(memory_token, server_id, client_id):
+    """
+    Return True if both client and server endpoints named in a memory-type
+    token have the hmem device that token requires.
+
+    Any SSH/detection failure propagates to the caller,
+    which falls back to including all candidate memory types.
+    """
+    client_memory_type, server_memory_type = memory_token.split("_to_")
+    for memory_type_name, ip in ((client_memory_type, client_id),
+                                 (server_memory_type, server_id)):
+        if memory_type_name == "host":
+            # host memory needs no accelerator device
+            continue
+        if num_hmem_devices(ip, memory_type_name) <= 0:
+            return False
+    return True
+
+
+def add_memory_type_parametrization(metafunc, memory_type_marker):
+    """
+    Parametrize the memory_type fixture at collection time from the test's
+    @pytest.mark.memory_type(...) declaration, dropping any permutation whose
+    device is absent on the owning endpoint.
+
+    Fallback (no coverage regression): if --server-id/--client-id are not
+    provided or device detection fails, every candidate memory type is
+    included and the runtime skip in common.py remains the safety net.
+    """
+
+    if "memory_type" not in metafunc.fixturenames:
+        return
+
+    # A test consuming the memory_type fixture must declare a memory_type marker
+    # whose argument is a memory_type_list_* from efa_common.
+    if memory_type_marker is None:
+        raise ValueError(
+            f"{metafunc.definition.nodeid} consumes the memory_type fixture "
+            f"but is missing @pytest.mark.memory_type(...)"
+        )
+
+    candidates = memory_type_marker.args[0]
+
+    server_id = metafunc.config.getoption("--server-id", default=None)
+    client_id = metafunc.config.getoption("--client-id", default=None)
+
+    if not server_id or not client_id:
+        params = candidates
+    else:
+        try:
+            params = [
+                param for param in candidates
+                if client_server_have_device(param.values[0], server_id, client_id)
+            ]
+        except Exception:
+            # Fallback to all memory types when detection/SSH fails
+            params = candidates
+
+    metafunc.parametrize("memory_type", params, scope="module")
+
+
 def pytest_generate_tests(metafunc):
     """
     Derive parametrization from markers
       - @pytest.mark.pr_ci
       - @pytest.mark.fabric(params=[...])
       - @pytest.mark.message_sizes(<test_type>_<fabric>=..., ...)
+      - @pytest.mark.memory_type(memory_type_list_*)
+    the last also filtering by endpoint device availability.
     """
     # get all markers
     fabric_marker = next(metafunc.definition.iter_markers("fabric"), None)
     sizes_marker  = next(metafunc.definition.iter_markers("message_sizes"), None)
+    memory_type_marker = next(metafunc.definition.iter_markers("memory_type"), None)
 
     # find out the test type running from markers (currently pr_ci or default)
     test_markers = {m.name for m in metafunc.definition.iter_markers()}
@@ -119,30 +185,9 @@ def pytest_generate_tests(metafunc):
     # generate parametrization based on found markers and test type
     add_fabric_and_message_size_parametrization(metafunc, fabric_marker, sizes_marker, test_type)
 
-# The memory types for bi-directional tests.
-memory_type_list_bi_dir = [
-    pytest.param("host_to_host"),
-    pytest.param("host_to_cuda", marks=pytest.mark.cuda_memory),
-    pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
-    pytest.param("host_to_neuron", marks=pytest.mark.neuron_memory),
-    pytest.param("neuron_to_neuron", marks=pytest.mark.neuron_memory),
-    pytest.param("host_to_rocr", marks=pytest.mark.rocr_memory),
-    pytest.param("rocr_to_rocr", marks=pytest.mark.rocr_memory),
-]
-
-# Add more memory types that are useful for uni-directional tests.
-memory_type_list_all = memory_type_list_bi_dir + [
-    pytest.param("cuda_to_host", marks=pytest.mark.cuda_memory),
-    pytest.param("neuron_to_host", marks=pytest.mark.neuron_memory),
-    pytest.param("rocr_to_host", marks=pytest.mark.rocr_memory),
-]
-
-memory_type_list_symm = [
-    pytest.param("host_to_host"),
-    pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
-    pytest.param("neuron_to_neuron", marks=pytest.mark.neuron_memory),
-    pytest.param("rocr_to_rocr", marks=pytest.mark.rocr_memory),
-]
+    # parametrize memory_type from its marker, dropping permutations
+    # whose device is absent on the owning endpoint
+    add_memory_type_parametrization(metafunc, memory_type_marker)
 
 hmem_type_list = [
     pytest.param("cuda", marks=pytest.mark.cuda_memory),
@@ -151,18 +196,6 @@ hmem_type_list = [
 
 @pytest.fixture(scope="module", params=hmem_type_list)
 def hmem_type(request):
-    return request.param
-
-@pytest.fixture(scope="module", params=memory_type_list_all)
-def memory_type(request):
-    return request.param
-
-@pytest.fixture(scope="module", params=memory_type_list_bi_dir)
-def memory_type_bi_dir(request):
-    return request.param
-
-@pytest.fixture(scope="module", params=memory_type_list_symm)
-def memory_type_symm(request):
     return request.param
 
 @pytest.fixture(scope="module", params=["read", "writedata", "write"])

--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -9,6 +9,31 @@ from collections import deque
 from common import SshConnectionError, is_ssh_connection_error, has_ssh_connection_err_msg, ClientServerTest
 from retrying import retry
 
+# EFA-specific memory type lists for the @pytest.mark.memory_type decorator.
+# The bi-directional set; uni-directional tests add the *_to_host entries.
+memory_type_list_bi_dir = [
+    pytest.param("host_to_host"),
+    pytest.param("host_to_cuda", marks=pytest.mark.cuda_memory),
+    pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
+    pytest.param("host_to_neuron", marks=pytest.mark.neuron_memory),
+    pytest.param("neuron_to_neuron", marks=pytest.mark.neuron_memory),
+    pytest.param("host_to_rocr", marks=pytest.mark.rocr_memory),
+    pytest.param("rocr_to_rocr", marks=pytest.mark.rocr_memory),
+]
+
+memory_type_list_all = memory_type_list_bi_dir + [
+    pytest.param("cuda_to_host", marks=pytest.mark.cuda_memory),
+    pytest.param("neuron_to_host", marks=pytest.mark.neuron_memory),
+    pytest.param("rocr_to_host", marks=pytest.mark.rocr_memory),
+]
+
+memory_type_list_symm = [
+    pytest.param("host_to_host"),
+    pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
+    pytest.param("neuron_to_neuron", marks=pytest.mark.neuron_memory),
+    pytest.param("rocr_to_rocr", marks=pytest.mark.rocr_memory),
+]
+
 # EFA-specific message size lists for @pytest.mark.message_sizes decorator.
 # Generic (shared) size lists live in fabtests/pytest/common.py.
 DIRECT_SIZES = ["r:0,4,32", "r:0,1024,8192"]

--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -34,6 +34,15 @@ memory_type_list_symm = [
     pytest.param("rocr_to_rocr", marks=pytest.mark.rocr_memory),
 ]
 
+# Single memory type lists for tests that run only one.
+memory_type_list_cuda_to_cuda = [
+    pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
+]
+
+memory_type_list_neuron_to_neuron = [
+    pytest.param("neuron_to_neuron", marks=pytest.mark.neuron_memory),
+]
+
 # EFA-specific message size lists for @pytest.mark.message_sizes decorator.
 # Generic (shared) size lists live in fabtests/pytest/common.py.
 DIRECT_SIZES = ["r:0,4,32", "r:0,1024,8192"]

--- a/fabtests/pytest/efa/test_mr_abort.py
+++ b/fabtests/pytest/efa/test_mr_abort.py
@@ -1,5 +1,6 @@
 import pytest
 from common import ClientServerTest
+from efa.efa_common import memory_type_list_symm
 
 
 pytestmark = pytest.mark.pre_release
@@ -66,10 +67,11 @@ def combined_msg_size_params():
 @pytest.mark.parametrize("cancel_order", ["reverse", "random"])
 @pytest.mark.parametrize("close_side", ["initiator", "target"])
 @pytest.mark.parametrize("ops_per_mr", [1, 4])
+@pytest.mark.memory_type(memory_type_list_symm)
 @pytest.mark.parametrize("message_size, rma_op, high_pps, sl_low_latency",
                          list(combined_msg_size_params()))
 def test_mr_abort(cmdline_args, rma_fabric, rma_op, cancel_order, close_side, ops_per_mr,
-                  high_pps, sl_low_latency, message_size, memory_type_symm):
+                  high_pps, sl_low_latency, message_size, memory_type):
     if rma_fabric == "efa" and cmdline_args.server_id == cmdline_args.client_id:
         pytest.skip("fi_mr_abort not supported with efa with SHM")
 
@@ -79,7 +81,6 @@ def test_mr_abort(cmdline_args, rma_fabric, rma_op, cancel_order, close_side, op
     command = (f"fi_mr_abort -T abort -o {rma_op} -C {cancel_order}"
                f" -R {close_side} -N {ops_per_mr} -W {MR_ABORT_NUM_MRS}"
                f" -S {message_size}")
-
     if high_pps:
         assert(rma_op != "read")
         command += " --high-pps"
@@ -89,17 +90,18 @@ def test_mr_abort(cmdline_args, rma_fabric, rma_op, cancel_order, close_side, op
         assert(message_size < 128)
         command += " --sl-low-latency"
 
-    test = ClientServerTest(cmdline_args, command, timeout=300, fabric=rma_fabric, memory_type=memory_type_symm)
+    test = ClientServerTest(cmdline_args, command, timeout=300, fabric=rma_fabric, memory_type=memory_type)
     test.run()
 
 
 # --- Test: partial (2 MRs on same buffer) ---
 @pytest.mark.functional
 @pytest.mark.fabric(params=["efa-direct"]) # TODO add test for efa fabric
+@pytest.mark.memory_type(memory_type_list_symm)
 @pytest.mark.parametrize("message_size, rma_op, high_pps, sl_low_latency",
                          list(combined_msg_size_params()))
 def test_mr_abort_partial(cmdline_args, rma_fabric, rma_op, high_pps,
-                          sl_low_latency, message_size, memory_type_symm):
+                          sl_low_latency, message_size, memory_type):
     if rma_fabric == "efa" and cmdline_args.server_id == cmdline_args.client_id:
         pytest.skip("fi_mr_abort not supported with efa with SHM")
 
@@ -114,11 +116,11 @@ def test_mr_abort_partial(cmdline_args, rma_fabric, rma_op, high_pps,
         assert(message_size < 128)
         command += " --sl-low-latency"
 
-    test = ClientServerTest(cmdline_args, command, timeout=300, fabric=rma_fabric, memory_type=memory_type_symm)
+    test = ClientServerTest(cmdline_args, command, timeout=300, fabric=rma_fabric, memory_type=memory_type)
     test.run()
 
 
-def determine_settings_for_proto(protocol, memory_type_symm, fabric):
+def determine_settings_for_proto(protocol, memory_type, fabric):
     """
     Return the (env, message_size) needed to exercise a specific EFA RDM
     two-sided wire protocol with fi_mr_abort.
@@ -170,7 +172,7 @@ def determine_settings_for_proto(protocol, memory_type_symm, fabric):
 
     # Fallback: HMEM or efa-direct. Protocol pinning via the host RDM
     # thresholds does not apply; return a representative size and no env.
-    if fabric != "efa" or memory_type_symm != "host_to_host":
+    if fabric != "efa" or memory_type != "host_to_host":
         return "", proto_size[protocol]
 
     # Host + efa: pin the protocol deterministically via env-var thresholds.
@@ -265,9 +267,9 @@ def abort_owes_rx_completion(protocol):
 @pytest.mark.parametrize("ops_per_mr", [1, 4])
 @pytest.mark.parametrize("tagged", [True, False])
 @pytest.mark.parametrize("protocol", ["EAGER", "MEDIUM", "LONGCTS", "LONGREAD", "RUNTREAD-LONGREAD", "RUNTREAD-NOREAD"])
+@pytest.mark.memory_type(memory_type_list_symm)
 def test_mr_abort_send(cmdline_args, fabric, cancel_order, close_side,
-                       ops_per_mr, tagged, protocol, memory_type_symm):
-
+                       ops_per_mr, tagged, protocol, memory_type):
     if fabric == "efa" and cmdline_args.server_id == cmdline_args.client_id:
         pytest.skip("fi_mr_abort not supported with efa with SHM")
 
@@ -280,7 +282,7 @@ def test_mr_abort_send(cmdline_args, fabric, cancel_order, close_side,
             pytest.skip("efa-direct does not support tagged sends")
         send_op = "tagged"
 
-    env, message_size = determine_settings_for_proto(protocol, memory_type_symm, fabric)
+    env, message_size = determine_settings_for_proto(protocol, memory_type, fabric)
 
     # efa-direct max message size is 8k
     if fabric == "efa-direct" and message_size > 8192:
@@ -299,5 +301,6 @@ def test_mr_abort_send(cmdline_args, fabric, cancel_order, close_side,
                f" -R {close_side} -N {ops_per_mr} -W {MR_ABORT_NUM_MRS}"
                f" -S {message_size}{owe_flag}{homogeneous_flag}  -A ep_first")
     test = ClientServerTest(cmdline_args, command, timeout=360, fabric=fabric,
-                            memory_type=memory_type_symm, additional_env=env)
+                            memory_type=memory_type, additional_env=env)
     test.run()
+

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -1,4 +1,5 @@
-from efa.efa_common import efa_run_client_server_test, DIRECT_SIZES
+from efa.efa_common import (efa_run_client_server_test, DIRECT_SIZES,
+                            memory_type_list_all, memory_type_list_bi_dir)
 from common import (perf_progress_model_cli,
                     PERF_SIZES, PERF_PR_CI, RANGE_SIZES, INJECT_SIZES)
 
@@ -38,20 +39,22 @@ def test_rdm_bw_functional_efa(cmdline_args, completion_semantic):
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
+@pytest.mark.memory_type(memory_type_list_bi_dir)
 def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic,
-                      memory_type_bi_dir, completion_type, fabric, message_sizes):
+                      memory_type, completion_type, fabric, message_sizes):
     command = "fi_rdm_pingpong"  + " " + perf_progress_model_cli
     efa_run_client_server_test(cmdline_args, command, iteration_type,
-                               completion_semantic, memory_type_bi_dir,
+                               completion_semantic, memory_type,
                                message_sizes,
                                completion_type=completion_type, fabric=fabric)
 
 @pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.message_sizes(default_efa=RANGE_SIZES, default_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
-def test_rdm_pingpong_range(cmdline_args, completion_semantic, memory_type_bi_dir, message_sizes, fabric):
+@pytest.mark.memory_type(memory_type_list_bi_dir)
+def test_rdm_pingpong_range(cmdline_args, completion_semantic, memory_type, message_sizes, fabric):
     efa_run_client_server_test(cmdline_args, "fi_rdm_pingpong", "short",
-                               completion_semantic, memory_type_bi_dir,
+                               completion_semantic, memory_type,
                                message_sizes, fabric=fabric)
 
 @pytest.mark.fabric(params=["efa", "efa-direct"])
@@ -68,23 +71,26 @@ def test_rdm_pingpong_no_inject_range(cmdline_args, completion_semantic, message
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
-def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type_bi_dir, completion_type, message_sizes):
+@pytest.mark.memory_type(memory_type_list_bi_dir)
+def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type, message_sizes):
     command = "fi_rdm_tagged_pingpong"  + " " + perf_progress_model_cli
     efa_run_client_server_test(cmdline_args, command, iteration_type,
-                               completion_semantic, memory_type_bi_dir, message_sizes, completion_type=completion_type,
+                               completion_semantic, memory_type, message_sizes, completion_type=completion_type,
                                fabric="efa")
 
 @pytest.mark.message_sizes(default_efa=RANGE_SIZES)
 @pytest.mark.functional
-def test_rdm_tagged_pingpong_range(cmdline_args, completion_semantic, memory_type_bi_dir, message_sizes):
+@pytest.mark.memory_type(memory_type_list_bi_dir)
+def test_rdm_tagged_pingpong_range(cmdline_args, completion_semantic, memory_type, message_sizes):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_pingpong", "short",
-                               completion_semantic, memory_type_bi_dir, message_sizes,
+                               completion_semantic, memory_type, message_sizes,
                                fabric="efa")
 
 @pytest.mark.message_sizes(default_efa=PERF_SIZES)
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type, message_sizes):
     command = "fi_rdm_tagged_bw"  + " " + perf_progress_model_cli
     efa_run_client_server_test(cmdline_args, command, iteration_type,
@@ -93,6 +99,7 @@ def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory
 
 @pytest.mark.message_sizes(default_efa=RANGE_SIZES)
 @pytest.mark.functional
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_tagged_bw_range(cmdline_args, completion_semantic, memory_type, message_sizes):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw", "short",
                                completion_semantic, memory_type, message_sizes, fabric="efa")
@@ -106,6 +113,7 @@ def test_rdm_tagged_bw_no_inject_range(cmdline_args, completion_semantic, messag
 # Testing both power-2 and non-power-2 sizes
 @pytest.mark.functional
 @pytest.mark.parametrize("env_vars", [["FI_EFA_TX_SIZE=64"], ["FI_EFA_RX_SIZE=64"], ["FI_EFA_TX_SIZE=64", "FI_EFA_RX_SIZE=64"], ["FI_EFA_TX_SIZE=43", "FI_EFA_RX_SIZE=51"]])
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_tagged_bw_small_tx_rx(cmdline_args, completion_semantic, memory_type, completion_type, env_vars):
     cmdline_args_copy = copy.copy(cmdline_args)
     for env_var in env_vars:
@@ -116,6 +124,7 @@ def test_rdm_tagged_bw_small_tx_rx(cmdline_args, completion_semantic, memory_typ
                                fabric="efa")
 
 @pytest.mark.functional
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_tagged_bw_small_recv_window(cmdline_args, completion_semantic, memory_type, completion_type):
     cmdline_args_copy = copy.copy(cmdline_args)
     cmdline_args_copy.append_environ("FI_EFA_RECVWIN_SIZE=1")
@@ -125,6 +134,7 @@ def test_rdm_tagged_bw_small_recv_window(cmdline_args, completion_semantic, memo
 
 @pytest.mark.message_sizes(default_efa=RANGE_SIZES)
 @pytest.mark.functional
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_tagged_bw_use_fi_more(cmdline_args, completion_semantic, memory_type, message_sizes):
     command = "fi_rdm_tagged_bw -w 0 --use-fi-more --sync-comp " + completion_semantic
     efa_run_client_server_test(cmdline_args, command,
@@ -135,6 +145,7 @@ def test_rdm_tagged_bw_use_fi_more(cmdline_args, completion_semantic, memory_typ
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic, memory_type):
     from copy import copy
 
@@ -177,7 +188,8 @@ def test_rdm_pingpong_1G(cmdline_args, completion_semantic):
 @pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("comp_method", ["sread", "fd"])
-def test_rdm_pingpong_sread(cmdline_args, completion_semantic, memory_type_bi_dir,
+@pytest.mark.memory_type(memory_type_list_bi_dir)
+def test_rdm_pingpong_sread(cmdline_args, completion_semantic, memory_type,
                             support_sread, comp_method, fabric, message_sizes):
     if not support_sread:
         pytest.skip("sread not supported by efa device.")
@@ -187,7 +199,7 @@ def test_rdm_pingpong_sread(cmdline_args, completion_semantic, memory_type_bi_di
             pytest.skip("FI_WAIT_FD not supported for EFA protocol with SHM enabled")
         additional_env = "FI_EFA_ENABLE_SHM_TRANSFER=0"
     efa_run_client_server_test(cmdline_args, f"fi_rdm_pingpong -c {comp_method}", "short",
-                               completion_semantic, memory_type_bi_dir,
+                               completion_semantic, memory_type,
                                message_sizes,
                                fabric=fabric, additional_env=additional_env)
 
@@ -211,8 +223,9 @@ def test_mr_exhaustion_rdm_pingpong(cmdline_args, completion_semantic):
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
+@pytest.mark.memory_type(memory_type_list_bi_dir)
 def test_rdm_pingpong_no_mr_local(cmdline_args, iteration_type, completion_semantic,
-                      memory_type_bi_dir, completion_type, mr_cache, message_sizes):
+                      memory_type, completion_type, mr_cache, message_sizes):
     command = "fi_rdm_pingpong -M mr_local"  + " " + perf_progress_model_cli
 
     additional_env = ''
@@ -220,7 +233,7 @@ def test_rdm_pingpong_no_mr_local(cmdline_args, iteration_type, completion_seman
         additional_env = 'FI_EFA_MR_CACHE_ENABLE=0'
 
     efa_run_client_server_test(cmdline_args, command, iteration_type,
-                               completion_semantic, memory_type_bi_dir, message_sizes,
+                               completion_semantic, memory_type, message_sizes,
                                completion_type=completion_type, fabric="efa",
                                additional_env=additional_env)
 
@@ -230,8 +243,9 @@ def test_rdm_pingpong_no_mr_local(cmdline_args, iteration_type, completion_seman
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
+@pytest.mark.memory_type(memory_type_list_bi_dir)
 def test_rma_pingpong_no_mr_local(cmdline_args, iteration_type, completion_semantic,
-                      memory_type_bi_dir, mr_cache, message_sizes):
+                      memory_type, mr_cache, message_sizes):
     command = "fi_rma_pingpong -o writedata -M mr_local"  + " " + perf_progress_model_cli
 
     additional_env = ''
@@ -239,7 +253,7 @@ def test_rma_pingpong_no_mr_local(cmdline_args, iteration_type, completion_seman
         additional_env = 'FI_EFA_MR_CACHE_ENABLE=0'
 
     efa_run_client_server_test(cmdline_args, command, iteration_type,
-                               completion_semantic, memory_type_bi_dir, message_sizes,
+                               completion_semantic, memory_type, message_sizes,
                                completion_type="queue", fabric="efa",
                                additional_env=additional_env)
 

--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -1,4 +1,5 @@
-from efa.efa_common import efa_run_client_server_test, DIRECT_SIZES
+from efa.efa_common import (efa_run_client_server_test, DIRECT_SIZES,
+                            memory_type_list_all)
 from common import (perf_progress_model_cli, ClientServerTest,
                     PERF_SIZES, PERF_PR_CI, RANGE_SIZES, INJECT_SIZES)
 import pytest
@@ -12,6 +13,7 @@ import copy
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rma_bw(cmdline_args, iteration_type, rma_operation_type, rma_bw_completion_semantic, rma_bw_memory_type, rma_fabric, rx_cq_data_cli, message_sizes):
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + rma_operation_type + " " + perf_progress_model_cli + rx_cq_data_cli
@@ -24,6 +26,7 @@ def test_rma_bw(cmdline_args, iteration_type, rma_operation_type, rma_bw_complet
 @pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_SIZES)
 @pytest.mark.parametrize("env_vars", [["FI_EFA_TX_SIZE=64"], ["FI_EFA_RX_SIZE=64"], ["FI_EFA_TX_SIZE=64", "FI_EFA_RX_SIZE=64"]])
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, rma_bw_completion_semantic, rma_bw_memory_type, env_vars, rma_fabric, message_sizes):
     cmdline_args_copy = copy.copy(cmdline_args)
     for env_var in env_vars:
@@ -40,6 +43,7 @@ def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, rma_bw_completion_
 @pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.message_sizes(default_efa=RANGE_SIZES, default_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rma_bw_range(cmdline_args, rma_operation_type, rma_bw_completion_semantic, message_sizes, rma_bw_memory_type, rma_fabric):
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + rma_operation_type
@@ -124,6 +128,7 @@ def test_rma_bw_use_fi_more(cmdline_args, operation_type, iteration_type, rma_bw
                            pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("comp_method", ["sread", "fd"])
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rma_bw_sread(cmdline_args, rma_operation_type, rma_bw_completion_semantic,
                       rma_bw_memory_type, support_sread, comp_method,
                       rma_fabric, message_sizes):

--- a/fabtests/pytest/efa/test_rma_pingpong.py
+++ b/fabtests/pytest/efa/test_rma_pingpong.py
@@ -1,4 +1,5 @@
-from efa.efa_common import efa_run_client_server_test, DIRECT_SIZES
+from efa.efa_common import (efa_run_client_server_test, DIRECT_SIZES,
+                            memory_type_list_bi_dir)
 from common import perf_progress_model_cli, PERF_SIZES, PERF_PR_CI, RMA_PINGPONG_SIZES
 import pytest
 
@@ -11,34 +12,37 @@ import pytest
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rma_pingpong(cmdline_args, iteration_type, operation_type, rma_bw_completion_semantic, memory_type_bi_dir, rma_fabric, message_sizes):
+@pytest.mark.memory_type(memory_type_list_bi_dir)
+def test_rma_pingpong(cmdline_args, iteration_type, operation_type, rma_bw_completion_semantic, memory_type, rma_fabric, message_sizes):
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type + " " + perf_progress_model_cli
     efa_run_client_server_test(cmdline_args, command, iteration_type, rma_bw_completion_semantic,
-                                memory_type_bi_dir, message_sizes, fabric=rma_fabric)
+                                memory_type, message_sizes, fabric=rma_fabric)
 
 
 @pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.message_sizes(default_efa=RMA_PINGPONG_SIZES, default_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata"])
+@pytest.mark.memory_type(memory_type_list_bi_dir)
 def test_rma_pingpong_range(cmdline_args, operation_type, rma_bw_completion_semantic, message_sizes,
-                            memory_type_bi_dir, rma_fabric):
+                            memory_type, rma_fabric):
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type
     efa_run_client_server_test(cmdline_args, command, "short", rma_bw_completion_semantic,
-                               memory_type_bi_dir, message_sizes, fabric=rma_fabric)
+                               memory_type, message_sizes, fabric=rma_fabric)
 
 
 @pytest.mark.fabric(params=["efa"])
 @pytest.mark.message_sizes(default_efa=RMA_PINGPONG_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata"])
-def test_rma_pingpong_range_no_inject(cmdline_args, operation_type, rma_bw_completion_semantic, message_sizes, memory_type_bi_dir, rma_fabric):
+@pytest.mark.memory_type(memory_type_list_bi_dir)
+def test_rma_pingpong_range_no_inject(cmdline_args, operation_type, rma_bw_completion_semantic, message_sizes, memory_type, rma_fabric):
     command = "fi_rma_pingpong -e rdm -j 0"
     command = command + " -o " + operation_type
     efa_run_client_server_test(cmdline_args, command, "short", rma_bw_completion_semantic,
-                                memory_type_bi_dir, message_sizes, fabric=rma_fabric)
+                                memory_type, message_sizes, fabric=rma_fabric)
 
 
 @pytest.mark.fabric(params=["efa-direct"])

--- a/fabtests/pytest/efa/test_runt.py
+++ b/fabtests/pytest/efa/test_runt.py
@@ -1,19 +1,12 @@
 from efa.efa_common import (efa_retrieve_hw_counter_value,
-                            efa_run_client_server_test, has_gdrcopy)
+                            efa_run_client_server_test, has_gdrcopy,
+                            memory_type_list_cuda_to_cuda,
+                            memory_type_list_neuron_to_neuron)
 
 import pytest
 
 
-# this test must be run in serial mode because it check hw counter
-# efa-direct does not have runt read so skip this test
-@pytest.mark.serial
-@pytest.mark.functional
-@pytest.mark.parametrize("memory_type,copy_method", [
-    pytest.param("cuda_to_cuda", "gdrcopy", marks=pytest.mark.cuda_memory),
-    pytest.param("cuda_to_cuda", "localread", marks=pytest.mark.cuda_memory),
-    pytest.param("neuron_to_neuron", None, marks=pytest.mark.neuron_memory)])
-@pytest.mark.pr_ci
-def test_runt_read_functional(cmdline_args, memory_type, copy_method):
+def run_runt_read_functional(cmdline_args, memory_type, copy_method):
     """
     Verify runt read protocol works with FI_OPT_EFA_HOMOGENEOUS_PEERS set,
     which skips the handshake. This sends 1 message of 256 KB using
@@ -104,3 +97,22 @@ def test_runt_read_functional(cmdline_args, memory_type, copy_method):
         # for which the server (receiver) will issue 1 read request.
         assert server_read_wrs == 1
         assert server_read_bytes == 196608
+
+
+# this test must be run in serial mode because it checks hw counters
+# efa-direct does not have runt read so skip this test
+@pytest.mark.serial
+@pytest.mark.functional
+@pytest.mark.memory_type(memory_type_list_cuda_to_cuda)
+@pytest.mark.parametrize("copy_method", ["gdrcopy", "localread"])
+@pytest.mark.pr_ci
+def test_runt_read_functional_cuda(cmdline_args, memory_type, copy_method):
+    run_runt_read_functional(cmdline_args, memory_type, copy_method)
+
+
+@pytest.mark.serial
+@pytest.mark.functional
+@pytest.mark.memory_type(memory_type_list_neuron_to_neuron)
+@pytest.mark.pr_ci
+def test_runt_read_functional_neuron(cmdline_args, memory_type):
+    run_runt_read_functional(cmdline_args, memory_type, copy_method=None)

--- a/fabtests/pytest/efa/test_unexpected_msg.py
+++ b/fabtests/pytest/efa/test_unexpected_msg.py
@@ -1,5 +1,5 @@
 import pytest
-from efa.efa_common import efa_run_client_server_test
+from efa.efa_common import efa_run_client_server_test, memory_type_list_all
 
 
 SHM_DEFAULT_MAX_INJECT_SIZE = 4096
@@ -11,6 +11,7 @@ SHM_DEFAULT_RX_SIZE = 1024
 @pytest.mark.functional
 @pytest.mark.parametrize("msg_size", [1, 512, 9000, 1048576]) # cover various switch points of shm/efa protocols
 @pytest.mark.parametrize("msg_count", [1, 1024, 2048]) # below and above shm's default rx size
+@pytest.mark.memory_type(memory_type_list_all)
 def test_unexpected_msg(cmdline_args, msg_size, msg_count, memory_type, completion_semantic):
     from common import ClientServerTest
     if cmdline_args.server_id == cmdline_args.client_id:

--- a/fabtests/pytest/pytest.ini
+++ b/fabtests/pytest/pytest.ini
@@ -16,6 +16,7 @@ markers =
     pr_ci: test is included in the PR CI suite
     message_sizes: decorator specifying default and pr_ci message size lists
     fabric: decorator declaring the set of libfabric fabric values a test runs on
+    memory_type: decorator declaring the memory type a test runs on (a memory_type_list_* from efa_common)
     hw_cntr: test requires fi_efa_hw_cntr binary (built with efadv_create_comp_cntr)
     gda: test requires fi_efa_gda binary (built with --enable-efagda)
     pre_release: test requires pre-release firmware, skip unless explicitly requested

--- a/fabtests/pytest/shm/conftest.py
+++ b/fabtests/pytest/shm/conftest.py
@@ -1,9 +1,40 @@
 import pytest
 
-from common import test_selected_by_marker
+from common import (
+    client_server_have_device,
+    test_selected_by_marker,
+)
+
+memory_type_list = [
+    pytest.param("host_to_host"),
+    pytest.param("host_to_cuda", marks=pytest.mark.cuda_memory),
+    pytest.param("cuda_to_host", marks=pytest.mark.cuda_memory),
+    pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
+]
+
+
+def add_memory_type_parametrization(metafunc):
+    # Drop permutations whose device is absent on the owning endpoint so they
+    # are never collected. Fall back to all candidates when ids are absent or
+    # detection fails; the runtime skip in common.py is the safety net.
+    if "memory_type" not in metafunc.fixturenames:
+        return
+    server_id = metafunc.config.getoption("--server-id", default=None)
+    client_id = metafunc.config.getoption("--client-id", default=None)
+    if not server_id or not client_id:
+        params = memory_type_list
+    else:
+        try:
+            params = [p for p in memory_type_list
+                      if client_server_have_device(p.values[0], server_id, client_id)]
+        except Exception:
+            params = memory_type_list
+    metafunc.parametrize("memory_type", params, scope="module")
 
 
 def pytest_generate_tests(metafunc):
+    add_memory_type_parametrization(metafunc)
+
     if "message_sizes" not in metafunc.fixturenames:
         return
 
@@ -17,11 +48,3 @@ def pytest_generate_tests(metafunc):
     pr_ci = marker.kwargs.get("pr_ci", default)
 
     metafunc.parametrize("message_sizes", pr_ci if is_pr_ci else default)
-
-
-@pytest.fixture(scope="module", params=["host_to_host",
-                                        pytest.param("host_to_cuda", marks=pytest.mark.cuda_memory),
-                                        pytest.param("cuda_to_host", marks=pytest.mark.cuda_memory),
-                                        pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory)])
-def memory_type(request):
-    return request.param

--- a/fabtests/pytest/sm2/conftest.py
+++ b/fabtests/pytest/sm2/conftest.py
@@ -1,8 +1,29 @@
 import pytest
 
-@pytest.fixture(scope="module", params=["host_to_host",
-                                        pytest.param("host_to_cuda", marks=pytest.mark.cuda_memory),
-                                        pytest.param("cuda_to_host", marks=pytest.mark.cuda_memory),
-                                        pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory)])
-def memory_type(request):
-    return request.param
+from common import client_server_have_device
+
+memory_type_list = [
+    pytest.param("host_to_host"),
+    pytest.param("host_to_cuda", marks=pytest.mark.cuda_memory),
+    pytest.param("cuda_to_host", marks=pytest.mark.cuda_memory),
+    pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
+]
+
+
+def pytest_generate_tests(metafunc):
+    # Drop permutations whose device is absent on the owning endpoint so they
+    # are never collected. Fall back to all candidates when ids are absent or
+    # detection fails; the runtime skip in common.py is the safety net.
+    if "memory_type" not in metafunc.fixturenames:
+        return
+    server_id = metafunc.config.getoption("--server-id", default=None)
+    client_id = metafunc.config.getoption("--client-id", default=None)
+    if not server_id or not client_id:
+        params = memory_type_list
+    else:
+        try:
+            params = [p for p in memory_type_list
+                      if client_server_have_device(p.values[0], server_id, client_id)]
+        except Exception:
+            params = memory_type_list
+    metafunc.parametrize("memory_type", params, scope="module")


### PR DESCRIPTION
The efa memory-type fixtures parametrized over the full candidate pool
regardless of the accelerators the target endpoints actually have, so on
a cuda-only host every neuron_* and rocr_* permutation was generated only
to be skipped at runtime with "no <hmem> device", inflating collected case
counts and per-case SSH/setup overhead.

Replace the memory_type/memory_type_bi_dir/memory_type_symm fixtures with
a single passthrough memory_type fixture parametrized at collection from a
new @pytest.mark.memory_type("<shape>") declaration, mirroring the
@pytest.mark.fabric pattern. The shape (host_and_hmem_memory_all/
_bi_dir_only/_symm_only, or params=[...]) resolves to the curated pool, and
permutations whose device is absent on the owning endpoint are dropped so
they are never collected. If server/client ids are absent or detection
fails, all candidates are kept (no coverage regression); the common.py
runtime skip remains the safety net.

Do the same for shm and sm2 providers