### PR TITLE
prov/sm2: Fix NULL ipc_cache crash in host-to-device CMA path

### DIFF
--- a/prov/sm2/src/sm2_progress.c
+++ b/prov/sm2/src/sm2_progress.c
@@ -133,6 +133,12 @@ static int sm2_cma_hmem_memcpy(struct sm2_ep *ep,
 	domain = container_of(ep->util_ep.domain, struct sm2_domain,
 			      util_domain);
 
+	/* ipc_cache is only allocated when IPC is enabled for the iface; guard
+	 * against a NULL cache so a mis-selected IPC path fails cleanly instead
+	 * of dereferencing NULL. */
+	if (!domain->ipc_cache)
+		return -FI_EOPNOTSUPP;
+
 	ipc_info = &cma_data->ipc_info;
 	ret = ofi_ipc_cache_search(domain->ipc_cache,
 				   xfer_entry->hdr.sender_gid, ipc_info,
@@ -208,6 +214,19 @@ static int sm2_progress_cma(struct sm2_ep *ep,
 		 * device memory, so we open the IPC handle,
 		 * return the handle to the sender for the
 		 * sender to a device memcpy */
+
+		/* This path requires IPC (the peer maps our device buffer via
+		 * the IPC cache). When IPC is disabled (e.g. multiple CUDA
+		 * devices without peer access), the IPC cache is never
+		 * allocated, so refuse the transfer instead of proceeding and
+		 * dereferencing a NULL cache. */
+		if (!ofi_hmem_is_ipc_enabled(iface)) {
+			FI_WARN(&sm2_prov, FI_LOG_EP_CTRL,
+				"host-to-device CMA transfer requires IPC, "
+				"which is disabled for hmem iface %d\n",
+				iface);
+			return -FI_EOPNOTSUPP;
+		}
 
 		/* TODO - multiple IOV support - update protocol selection logic
 		 * to use SAR for multiple IOVs */


### PR DESCRIPTION
When CUDA IPC is disabled (e.g. multiple CUDA devices without peer access, such as 4x T4 on g4dn.12xlarge), ofi_ipc_cache_open() returns success without allocating the cache, leaving sm2_domain->ipc_cache NULL. sm2_progress_cma() still selected the host-to-device IPC path for device receive buffers, and sm2_cma_hmem_memcpy() then dereferenced the NULL cache in ofi_ipc_cache_search() -> ofi_mr_cache_search(), crashing with SIGSEGV. The crashed peer left its partner spinning on completion until timeout.

Guard the host-to-device CMA path with ofi_hmem_is_ipc_enabled() (matching the check sm2_select_proto() already does for sm2_proto_ipc) so the transfer returns -FI_EOPNOTSUPP instead of proceeding, and add a defensive NULL check in sm2_cma_hmem_memcpy().

Confirmed on g4dn.12xlarge (4x T4, IPC disabled): sm2 CUDA transfers previously SIGSEGV'd; with this change they fail gracefully with a warning and no crash. Single-GPU instances (IPC enabled) are unaffected.