### PR TITLE
prov/efa: fix use-after-free in rdm_pke_release_cloned

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -289,7 +289,8 @@ nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
 	prov/efa/test/gtest/efa_gtest_conn.cc \
 	prov/efa/test/gtest/efa_gtest_ah.cc \
 	prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc \
-	prov/efa/test/gtest/efa_gtest_rdm_mr.cc
+	prov/efa/test/gtest/efa_gtest_rdm_mr.cc \
+	prov/efa/test/gtest/efa_gtest_rdm_pke.cc
 
 prov_efa_test_gtest_efa_gtest_CPPFLAGS = \
 	$(AM_CPPFLAGS) \

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -382,8 +382,8 @@ void efa_rdm_pke_release_cloned(struct efa_rdm_pke *pkt_entry)
 	while (pkt_entry) {
 		assert(pkt_entry->alloc_type == EFA_RDM_PKE_FROM_OOO_POOL ||
 		       pkt_entry->alloc_type == EFA_RDM_PKE_FROM_UNEXP_POOL);
-		efa_rdm_pke_release(pkt_entry);
 		next = pkt_entry->next;
+		efa_rdm_pke_release(pkt_entry);
 		pkt_entry = next;
 	}
 }

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke.cc
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_common_resource.h"
+#include "efa_gtest_rdm_pke_utils.h"
+#include <gtest/gtest.h>
+
+using testing::Test;
+using testing::WithParamInterface;
+using testing::Range;
+
+class EfaRdmPkeTest : public Test
+{
+	protected:
+	struct efa_resource resource = {};
+
+	void SetUp() override
+	{
+		memset(&resource, 0, sizeof(resource));
+		efa_test_resource_construct(
+			&resource,
+			efa_test_alloc_default_hints(FI_EP_RDM, EFA_FABRIC_NAME));
+		ASSERT_NE(resource.ep, nullptr);
+	}
+
+	void TearDown() override
+	{
+		efa_test_resource_destruct(&resource);
+	}
+};
+
+/* pke_release_cloned must release arbitrary length packet list correctly */
+class EfaRdmPkeChainTest : public EfaRdmPkeTest,
+			   public WithParamInterface<size_t>
+{
+};
+
+TEST_P(EfaRdmPkeChainTest, release_cloned_frees_whole_chain)
+{
+	size_t n = GetParam();
+	struct efa_rdm_pke *head;
+
+	head = efa_test_pke_build_unexp_chain(resource.ep, n);
+	ASSERT_EQ(head == nullptr, n == 0);
+	ASSERT_EQ(efa_test_ep_unexp_pool_outstanding(resource.ep), n);
+
+	efa_test_pke_release_cloned(head);
+
+	EXPECT_EQ(efa_test_ep_unexp_pool_outstanding(resource.ep), 0u);
+}
+
+INSTANTIATE_TEST_SUITE_P(ChainLengths, EfaRdmPkeChainTest, Range<size_t>(0, 6));

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c
@@ -1,10 +1,13 @@
 /* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
 /* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
 
-#include "efa_gtest_rdm_pke_utils.h"
+#include "ofi_mem.h"
+#include "rdm/efa_rdm_ep.h"
+#include "rdm/efa_rdm_pke.h"
 #include "efa.h"
 #include "rdm/efa_rdm_ep.h"
 #include "rdm/efa_rdm_pke_rtm.h"
+#include "efa_gtest_rdm_pke_utils.h"
 
 int efa_test_rtm_read_nack_missing_rxe(struct fid_ep *ep, fi_addr_t peer_addr,
 				       int tagged, ssize_t *ret)
@@ -38,4 +41,47 @@ int efa_test_rtm_read_nack_missing_rxe(struct fid_ep *ep, fi_addr_t peer_addr,
 
 	*ret = efa_rdm_pke_proc_rtm_rta(pke, peer);
 	return 1;
+}
+
+struct efa_rdm_pke *efa_test_pke_build_unexp_chain(struct fid_ep *ep, size_t n)
+{
+	struct efa_rdm_ep *efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	struct efa_rdm_pke *head = NULL, *prev = NULL, *pke;
+	size_t i;
+
+	for (i = 0; i < n; i++) {
+		pke = efa_rdm_pke_alloc(efa_rdm_ep,
+					efa_rdm_ep->rx_unexp_pkt_pool,
+					EFA_RDM_PKE_FROM_UNEXP_POOL);
+		if (!pke)
+			return NULL;
+		if (prev)
+			prev->next = pke;
+		else
+			head = pke;
+		prev = pke;
+	}
+
+	return head;
+}
+
+/* no header prototype */
+void efa_rdm_pke_release_cloned(struct efa_rdm_pke *pkt_entry);
+
+void efa_test_pke_release_cloned(struct efa_rdm_pke *head)
+{
+	efa_rdm_pke_release_cloned(head);
+}
+
+size_t efa_test_ep_unexp_pool_outstanding(struct fid_ep *ep)
+{
+	struct efa_rdm_ep *efa_rdm_ep = container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	struct ofi_bufpool *pool = efa_rdm_ep->rx_unexp_pkt_pool;
+	struct slist_entry *item;
+	size_t free_cnt = 0;
+
+	for (item = pool->free_list.entries.head; item; item = item->next)
+		free_cnt++;
+
+	return pool->entry_cnt - free_cnt;
 }

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.h
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.h
@@ -27,6 +27,21 @@ extern "C" {
  */
 int efa_test_rtm_read_nack_missing_rxe(struct fid_ep *ep, fi_addr_t peer_addr,
 				       int tagged, ssize_t *ret);
+struct efa_rdm_pke;
+
+/**
+ * @brief Allocate a linked list of n unexpected packet entries from the
+ * endpoint's unexpected packet pool.
+ * @return head of the chain, or NULL on allocation failure.
+ */
+struct efa_rdm_pke *efa_test_pke_build_unexp_chain(struct fid_ep *ep, size_t n);
+
+void efa_test_pke_release_cloned(struct efa_rdm_pke *head);
+
+/**
+ * @brief Count allocated buffers in the unexpected packet pool.
+ */
+size_t efa_test_ep_unexp_pool_outstanding(struct fid_ep *ep);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
fix the logic in linked-list deallocation so that there's 
no potential use-after-free here for a list of length > 1.

a unit test has been added to assert correctness.