### PR TITLE
prov/efa: do not copy rxe op_context into cq error if unexpected

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -290,7 +290,9 @@ nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
 	prov/efa/test/gtest/efa_gtest_ah.cc \
 	prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc \
 	prov/efa/test/gtest/efa_gtest_rdm_mr.cc \
-	prov/efa/test/gtest/efa_gtest_rdm_pke.cc
+	prov/efa/test/gtest/efa_gtest_rdm_pke.cc \
+	prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.c \
+	prov/efa/test/gtest/efa_gtest_rdm_ope.cc
 
 prov_efa_test_gtest_efa_gtest_CPPFLAGS = \
 	$(AM_CPPFLAGS) \

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -590,6 +590,7 @@ void efa_rdm_rxe_handle_error(struct efa_rdm_ope *rxe, int err, int prov_errno)
 	struct util_cq *util_cq;
 	struct dlist_entry *tmp;
 	struct efa_rdm_pke *pkt_entry;
+	enum efa_rdm_ope_state prev_state;
 	char err_msg[EFA_ERROR_MSG_BUFFER_LENGTH] = {0};
 
 	assert(rxe->type == EFA_RDM_RXE);
@@ -624,6 +625,7 @@ void efa_rdm_rxe_handle_error(struct efa_rdm_ope *rxe, int err, int prov_errno)
 		assert(0 && "rxe unknown state");
 	}
 
+	prev_state = rxe->state;
 	rxe->state = EFA_RDM_OPE_ERR;
 
 	dlist_foreach_container_safe(&rxe->queued_pkts,
@@ -642,7 +644,7 @@ void efa_rdm_rxe_handle_error(struct efa_rdm_ope *rxe, int err, int prov_errno)
 	}
 
 	err_entry.flags = rxe->cq_entry.flags;
-	if (rxe->state != EFA_RDM_RXE_UNEXP)
+	if (prev_state != EFA_RDM_RXE_UNEXP)
 		err_entry.op_context = rxe->cq_entry.op_context;
 	err_entry.buf = rxe->cq_entry.buf;
 	err_entry.data = rxe->cq_entry.data;

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.c
@@ -30,6 +30,22 @@ int efa_test_explicit_av_insert(struct fid_ep *ep, struct fid_av *av,
 	return fi_av_insert(av, &raw_addr, 1, addr, 0, NULL);
 }
 
+int efa_test_insert_self_peer(struct fid_ep *ep, struct fid_av *av,
+			      fi_addr_t *addr)
+{
+	struct efa_ep_addr raw_addr = {0};
+	size_t raw_addr_len = sizeof(raw_addr);
+	int ret;
+
+	ret = fi_getname(&ep->fid, &raw_addr, &raw_addr_len);
+	if (ret)
+		return ret;
+	raw_addr.qpn = 0;
+	raw_addr.qkey = 0x1234;
+
+	return fi_av_insert(av, &raw_addr, 1, addr, 0, NULL);
+}
+
 fi_addr_t efa_test_insert_peer_new_gid(struct fid_ep *ep, struct fid_av *av)
 {
 	struct efa_rdm_ep *efa_rdm_ep;

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.h
@@ -31,6 +31,13 @@ int efa_test_explicit_av_insert(struct fid_ep *ep, struct fid_av *av,
 				fi_addr_t *addr);
 
 /**
+ * @brief Insert the ep's own address as a peer via an (explicit) fi_av_insert.
+ * @return Number of addresses inserted (1 on success), or negative on error.
+ */
+int efa_test_insert_self_peer(struct fid_ep *ep, struct fid_av *av,
+			      fi_addr_t *addr);
+
+/**
  * @brief Insert a peer with a fabricated GID that won't be in the ah_map.
  * This forces efa_ah_alloc to call ibv_create_ah for a new GID.
  * @return The fi_addr, or FI_ADDR_NOTAVAIL on failure.

--- a/prov/efa/test/gtest/efa_gtest_rdm_ope.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_ope.cc
@@ -1,0 +1,51 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_common_resource.h"
+#include "efa_gtest_rdm_ope_helpers.h"
+#include <gtest/gtest.h>
+#include <rdma/fi_errno.h>
+
+using testing::Test;
+
+class EfaRdmOpeTest : public Test
+{
+	protected:
+	struct efa_resource resource = {};
+
+	void SetUp() override
+	{
+		memset(&resource, 0, sizeof(resource));
+
+		efa_test_resource_construct(
+			&resource, efa_test_alloc_default_hints(
+					   FI_EP_RDM, EFA_FABRIC_NAME));
+		ASSERT_NE(resource.ep, nullptr);
+	}
+
+	void TearDown() override
+	{
+		efa_test_resource_destruct(&resource);
+	}
+};
+
+/**
+ * @brief Assert that the context for an unexpected
+ * packet is not copied into the error entry
+ */
+TEST_F(EfaRdmOpeTest, rxe_unexp_error_suppresses_op_context)
+{
+	int prov_errno = 0;
+	void *sentinel = (void *) 0xdeadbeef;
+	struct fi_cq_err_entry err_entry = {};
+
+	ASSERT_EQ(efa_test_drive_rxe_unexp_handle_error(
+			  resource.ep, sentinel, FI_ENOTCONN, &prov_errno),
+		  0);
+
+	ASSERT_EQ(fi_cq_readerr(resource.cq, &err_entry, 0), 1);
+	EXPECT_EQ(err_entry.err, FI_ENOTCONN);
+	EXPECT_EQ(err_entry.prov_errno, prov_errno);
+	/* The sentinel should not be here */
+	EXPECT_EQ(err_entry.op_context, nullptr);
+}

--- a/prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.c
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_rdm_ope_helpers.h"
+#include "efa_gtest_common_helpers.h"
+#include "efa.h"
+#include "efa_av.h"
+#include "rdm/efa_rdm_ep.h"
+
+int efa_test_drive_rxe_unexp_handle_error(struct fid_ep *ep, void *op_context,
+					  int err, int *prov_errno_out)
+{
+	struct efa_rdm_ep *efa_rdm_ep =
+		container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	fi_addr_t peer_addr = 0;
+	struct efa_rdm_peer *peer;
+	struct efa_rdm_ope *rxe;
+	int prov_errno = EFA_IO_COMP_STATUS_LOCAL_ERROR_UNREACH_REMOTE;
+	int ret;
+
+	ret = efa_test_insert_self_peer(
+		ep, &efa_rdm_ep->base_ep.util_ep.av->av_fid, &peer_addr);
+	if (ret != 1)
+		return -FI_EINVAL;
+
+	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	if (!peer)
+		return -FI_EINVAL;
+
+	rxe = efa_rdm_ep_alloc_rxe(efa_rdm_ep, peer, ofi_op_tagged);
+	if (!rxe)
+		return -FI_ENOMEM;
+
+	rxe->state = EFA_RDM_RXE_UNEXP;
+	rxe->cq_entry.op_context = op_context;
+
+	efa_rdm_rxe_handle_error(rxe, err, prov_errno);
+	efa_rdm_rxe_release(rxe);
+
+	if (prov_errno_out)
+		*prov_errno_out = prov_errno;
+
+	return 0;
+}

--- a/prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#ifndef EFA_GTEST_RDM_OPE_HELPERS_H
+#define EFA_GTEST_RDM_OPE_HELPERS_H
+
+#include <rdma/fabric.h>
+#include <rdma/fi_endpoint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int efa_test_drive_rxe_unexp_handle_error(struct fid_ep *ep, void *op_context,
+					  int err, int *prov_errno_out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFA_GTEST_RDM_OPE_HELPERS_H */


### PR DESCRIPTION
The man page says [this](https://github.com/ofiwg/libfabric/blob/ca12db7716ad204d59f3cfb882a3c534cd3f12ef/man/fi_cq.3.md?plain=1#L481) about `fi_cq_err_entry.op_context`:
> For completion events that are not associated with a posted operation, this field will be set to NULL. 

This PR fixes the unconditional copying of op_context in rdm_rxe_handle_error. 
now if a rxe packet is unexpected, its op_context is not copied in and left as NULL.

a unit test is added to assert this behavior.