### PR TITLE
prov/efa: Protect AH refcounts with util_domain.lock 

### DIFF
--- a/prov/efa/src/efa_ah.c
+++ b/prov/efa/src/efa_ah.c
@@ -29,6 +29,7 @@ void efa_ah_implicit_av_lru_ah_move(struct efa_domain *domain,
 	struct efa_rdm_domain *rdm_domain;
 
 	assert(domain->info_type == EFA_INFO_RDM);
+	assert(ofi_genlock_held(&domain->util_domain.lock));
 
 	rdm_domain = (struct efa_rdm_domain *) domain;
 	assert(ah->implicit_refcnt > 0 || ah->explicit_refcnt > 0);
@@ -47,6 +48,7 @@ static inline int efa_ah_implicit_av_evict_ah(struct efa_domain *domain) {
 	struct efa_rdm_domain *rdm_domain;
 
 	assert(domain->info_type == EFA_INFO_RDM);
+	assert(ofi_genlock_held(&domain->util_domain.lock));
 	rdm_domain = (struct efa_rdm_domain *) domain;
 
 	dlist_foreach_container (&rdm_domain->ah_lru_list, struct efa_ah, ah_tmp,
@@ -139,6 +141,7 @@ struct efa_ah *efa_ah_alloc(struct efa_domain *domain, const uint8_t *gid,
 	if (!efa_ah) {
 		errno = FI_ENOMEM;
 		EFA_WARN(FI_LOG_AV, "cannot allocate memory for efa_ah\n");
+		ofi_genlock_unlock(&domain->util_domain.lock);
 		return NULL;
 	}
 
@@ -149,8 +152,8 @@ struct efa_ah *efa_ah_alloc(struct efa_domain *domain, const uint8_t *gid,
 	if (!efa_ah->ibv_ah) {
 		/* If the failure is because we have too many AH entries, try to
 		 * evict an AH entry with no explicit AV entries and try AH
-		 * creation again. Eviction only applies to RDM domains. */
-		if (errno == FI_ENOMEM && domain->info_type == EFA_INFO_RDM) {
+		 * creation again. Eviction only applies to implicit AV. */
+		if (errno == FI_ENOMEM && insert_implicit_av) {
 			EFA_INFO(
 				FI_LOG_AV,
 				"ibv_create_ah failed with ENOMEM for implicit "

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -219,7 +219,9 @@ void efa_av_implicit_av_lru_conn_move(struct efa_av *av,
 	dlist_insert_tail(&conn->implicit_av_lru_entry,
 			  &av->implicit_av_lru_list);
 
+	ofi_genlock_lock(&av->domain->util_domain.lock);
 	efa_ah_implicit_av_lru_ah_move(av->domain, conn->ah);
+	ofi_genlock_unlock(&av->domain->util_domain.lock);
 }
 
 /*
@@ -431,12 +433,18 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 	if (err)
 		return err;
 
-	/* Handle AH LRU list and refcnt */
+	/* Handle AH LRU list and refcnt.
+	 * AH refcnts are protected by util_domain.lock, which is also
+	 * held by efa_ah_alloc and efa_ah_release. 
+	 * efa_conn_implicit_to_explicit is the slow path so taking 
+	 * an extra lock is fine. */
+	ofi_genlock_lock(&av->domain->util_domain.lock);
 	assert(!dlist_empty(&ah->implicit_conn_list));
 	dlist_remove(&implicit_conn->ah_implicit_conn_list_entry);
 	efa_ah_implicit_av_lru_ah_move(av->domain, ah);
 	ah->implicit_refcnt--;
 	ah->explicit_refcnt++;
+	ofi_genlock_unlock(&av->domain->util_domain.lock);
 
 	EFA_INFO(FI_LOG_AV,
 		 "Peer with implicit fi_addr %" PRIu64

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -331,61 +331,6 @@ out:
 	return FI_EADDRNOTAVAIL;
 }
 
-/**
- * @brief Read peer raw address from packet entry or the EFA device and look up
- * the peer address in explicit and implicit AVs This function should only be
- * called if the peer AH is unknown.
- * @return Pointer to peer struct, or NULL if unavailable.
- */
-static inline struct efa_rdm_peer *
-efa_rdm_cq_lookup_raw_addr(struct efa_rdm_pke *pke,
-			   struct efa_ep_addr *efa_ep_addr)
-{
-	struct efa_rdm_ep *ep;
-	fi_addr_t addr;
-	struct efa_rdm_peer *peer = NULL;
-	bool implicit = false;
-	char gid_str_cdesc[INET6_ADDRSTRLEN];
-
-	ep = pke->ep;
-	assert(ep);
-
-	/* First check the explicit AV */
-	addr = ofi_av_lookup_fi_addr(&ep->base_ep.av->util_av,
-				     (void *) efa_ep_addr);
-	if (addr != FI_ADDR_NOTAVAIL) {
-		implicit = false;
-		peer = efa_rdm_ep_get_peer_explicit(ep, addr);
-		assert(peer);
-		goto out;
-	}
-
-	/* Next check implicit AV */
-	addr = ofi_av_lookup_fi_addr(&ep->base_ep.av->util_av_implicit,
-				     (void *) efa_ep_addr);
-	if (addr != FI_ADDR_NOTAVAIL) {
-		implicit = true;
-		peer = efa_rdm_ep_get_peer_implicit(ep, addr);
-		assert(peer);
-		goto out;
-	}
-
-	return NULL;
-
-out:
-	inet_ntop(AF_INET6, efa_ep_addr->raw, gid_str_cdesc, INET6_ADDRSTRLEN);
-	/* The EFA device may not be able to provide the AHN if the packet
-	 * arrived immediately after the AH creation. So this behavior is
-	 * expected at application startup. */
-	EFA_INFO(FI_LOG_AV,
-		 "Recovered fi_addr for peer:[QPN]:[QKey] = "
-		 "[%s]:[%" PRIu16 "]:[%" PRIu32 "] fi_addr: %" PRIu64
-		 " implicit AV: %s\n",
-		 gid_str_cdesc, efa_ep_addr->qpn, efa_ep_addr->qkey, addr,
-		 implicit ? "true" : "false");
-
-	return peer;
-}
 
 /**
  * @brief Determine peer struct from ibv_cq and packet entry
@@ -406,6 +351,8 @@ efa_rdm_cq_get_peer_for_pkt_entry(struct efa_rdm_ep *ep,
 	struct efa_ep_addr efa_ep_addr = {0};
 	struct efa_ep_addr_hashable *efa_ep_addr_hashable = NULL;
 	struct efa_rdm_peer *peer = NULL;
+	char gid_str_cdesc[INET6_ADDRSTRLEN];
+	bool raw_addr_available = false;
 	int ret;
 	uint32_t gid;
 	uint32_t qpn;
@@ -420,18 +367,23 @@ efa_rdm_cq_get_peer_for_pkt_entry(struct efa_rdm_ep *ep,
 
 	/* To determine the source peer struct, the workflow is the following
 	 * 1. Get GID and QPN from rdma-core and check the explicit AV
-	 * 2. If not found, check the implicit AV with GID and QPN
-	 * 3 (a). If not found, retrieve raw address from the packet header
-	 * 3 (b). If packet header doesn't have raw address, retrieve raw
+	 * 2 (a). If not found, retrieve raw address from the packet header
+	 * 2 (b). If packet header doesn't have raw address, retrieve raw
 	 * address with efadv_wc_read_sgid
-	 * 4. Check explicit and implicit AVs for the raw address retrieved in
-	 * (3)
-	 * 5. If not found and raw address is available, insert raw address into
+	 * 3. Check explicit AVs for the raw address retrieved in (2)
+	 * -------------------------------------------------------------------
+	 * Slow path with implicit AV
+	 * 4. If not found, check the implicit AV with GID and QPN
+	 * 5. If the peer was evicted from implicit AV, drop the packet
+	 * 6. Check implicit AVs for the raw address retrieved in (2)
+	 * 7. If not found and raw address is available, insert raw address into
 	 * the implicit AV
 	 *
 	 * TODO: Remove the usage of efadv_wc_read_sgid after EFA device's
 	 * behavior is fixed
 	 */
+
+	/* Step 1: Check explicit AV with GID and QPN */
 	explicit_fi_addr =
 		efa_av_reverse_lookup_rdm(efa_av, gid, qpn, pkt_entry);
 
@@ -444,6 +396,24 @@ efa_rdm_cq_get_peer_for_pkt_entry(struct efa_rdm_ep *ep,
 		goto out;
 	}
 
+	/* Step 2: Retrieve raw address from packet header or efadv_wc_read_sgid */
+	ret = efa_rdm_cq_populate_src_efa_ep_addr(
+		pkt_entry, efa_ibv_cq,
+		&efa_ep_addr);
+	if (!ret)
+		raw_addr_available = true;
+
+	/* Step 3: Check explicit AV for the raw address */
+	if (raw_addr_available) {
+		explicit_fi_addr = ofi_av_lookup_fi_addr(&ep->base_ep.av->util_av,
+							 (void *) &efa_ep_addr);
+		if (explicit_fi_addr != FI_ADDR_NOTAVAIL) {
+			peer = efa_rdm_ep_get_peer_explicit(ep, explicit_fi_addr);
+			goto raw_addr_found;
+		}
+	}
+
+	/* Step 4: Check implicit AV with GID and QPN (slow path) */
 	implicit_fi_addr =
 		efa_av_reverse_lookup_rdm_implicit(efa_av, gid, qpn, pkt_entry);
 
@@ -456,19 +426,12 @@ efa_rdm_cq_get_peer_for_pkt_entry(struct efa_rdm_ep *ep,
 		goto out;
 	}
 
-	ret = efa_rdm_cq_populate_src_efa_ep_addr(
-		pkt_entry, efa_ibv_cq,
-		&efa_ep_addr);
-	if (ret) {
-		/* Failed to read raw address from packet entry and
-		 * efadv_wc_read_sgid */
+	if (!raw_addr_available)
 		return NULL;
-	}
 
-	/* If the packet is from a peer that we evicted from the implicit AV,
-	 * print a warning and ignore the packet. We do this because we lose
-	 * information about previous communication from the peer when we evict
-	 * the peer from the implicit AV
+	/* Step 5: If the peer was evicted from implicit AV, drop the packet.
+	 * We do this because we lose information about previous communication
+	 * from the peer when we evict the peer from the implicit AV
 	 *
 	 * TODO: continue communication with peer by saving the previous state
 	 * and restoring it
@@ -481,10 +444,15 @@ efa_rdm_cq_get_peer_for_pkt_entry(struct efa_rdm_ep *ep,
 		return NULL;
 	}
 
-	peer = efa_rdm_cq_lookup_raw_addr(pkt_entry, &efa_ep_addr);
-	if (peer)
-		goto out;
+	/* Step 6: Check implicit AV for the raw address */
+	implicit_fi_addr = ofi_av_lookup_fi_addr(&ep->base_ep.av->util_av_implicit,
+						 (void *) &efa_ep_addr);
+	if (implicit_fi_addr != FI_ADDR_NOTAVAIL) {
+		peer = efa_rdm_ep_get_peer_implicit(ep, implicit_fi_addr);
+		goto raw_addr_found;
+	}
 
+	/* Step 7: Insert raw address into implicit AV */
 	EFA_DBG(FI_LOG_CQ,
 		"Peer with gid %d and qpn %d not found in explicit or implicit "
 		"AV. Attempting to insert into implicit AV...\n",
@@ -503,6 +471,23 @@ efa_rdm_cq_get_peer_for_pkt_entry(struct efa_rdm_ep *ep,
 	}
 	assert(implicit_fi_addr != FI_ADDR_NOTAVAIL);
 	peer = efa_rdm_ep_get_peer_implicit(ep, implicit_fi_addr);
+	goto out;
+
+raw_addr_found:
+	assert(peer);
+	inet_ntop(AF_INET6, efa_ep_addr.raw, gid_str_cdesc, INET6_ADDRSTRLEN);
+	/* The EFA device may not be able to provide the AHN if the packet
+	 * arrived immediately after the AH creation. So this behavior is
+	 * expected at application startup. */
+	EFA_INFO(FI_LOG_AV,
+		 "Recovered fi_addr for peer:[QPN]:[QKey] = "
+		 "[%s]:[%" PRIu16 "]:[%" PRIu32 "] fi_addr: %" PRIu64
+		 " implicit AV: %s\n",
+		 gid_str_cdesc, efa_ep_addr.qpn, efa_ep_addr.qkey,
+		 peer->conn->fi_addr != FI_ADDR_NOTAVAIL ?
+			peer->conn->fi_addr : peer->conn->implicit_fi_addr,
+		 peer->conn->implicit_fi_addr != FI_ADDR_NOTAVAIL ?
+			"true" : "false");
 
 out:
 	assert(peer);

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -1092,10 +1092,6 @@ static int efa_rdm_ep_close(struct fid *fid)
 	 * The QP destroy and op entries clean up must be in the same lock,
 	 * otherwise there can be race condition that efa_rdm_domain_progress_peers_and_queues
 	 * (part of fi_cq_read) can access entries that are from a closed QP.
-	 *
-	 * Destroying the self AH also requires the SRX lock
-	 * Destroying the self AH modifies the AH refcnts which can also
-	 * modified in the CQ read path by implicit-to-explicit AV entry conversion
 	 */
 	ofi_genlock_lock(&((struct efa_rdm_domain *) domain)->srx_lock);
 
@@ -1426,13 +1422,9 @@ static int efa_rdm_ep_ctrl(struct fid *fid, int command, void *arg)
 		if (ret)
 			return ret;
 
-		/* Acquire the SRX lock before creating self AH
-		 * Creating the self AH modifies the AH refcnts which can also
-		 * modified in the CQ read path by implicit-to-explicit AV entry
-		 * conversion */
-		ofi_genlock_lock(&efa_rdm_ep_rdm_domain(ep)->srx_lock);
+		/* Self AH creation modifies AH refcnts which are
+		 * protected by util_domain.lock inside efa_ah_alloc */
 		ret = efa_rdm_ep_create_self_ah(ep);
-		ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(ep)->srx_lock);
 		if (ret) {
 			EFA_WARN(FI_LOG_EP_CTRL,
 			 "EFA RDM endpoint cannot create ah for its own address\n");


### PR DESCRIPTION
Restructure efa_rdm_cq_get_peer_for_pkt_entry to prioritize explicit AV lookups before falling back to the implicit AV slow path.
Commit https://github.com/ofiwg/libfabric/commit/73c276943091eb79ea1e88496e78b58a80b5d57e acquire SRX lock before creating self AH to avoid adding util_domain.lock in the cq read path.
efa_conn_implicit_to_explicit is the slow path so adding another lock is fine and srx_lock should not be misused.