### PR TITLE
prov/efa: fix missing pkt_entry releasse in peer_reorder_msg

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -294,7 +294,8 @@ nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
 	prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.c \
 	prov/efa/test/gtest/efa_gtest_rdm_ope.cc \
 	prov/efa/test/gtest/efa_gtest_cq.cc \
-	prov/efa/test/gtest/efa_gtest_rdm_cntr.cc
+	prov/efa/test/gtest/efa_gtest_rdm_cntr.cc \
+	prov/efa/test/gtest/efa_gtest_rdm_peer.cc
 
 prov_efa_test_gtest_efa_gtest_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
@@ -325,7 +326,8 @@ prov_efa_test_gtest_efa_gtest_LDFLAGS = \
 	-Wl,--wrap=efa_ibv_cq_wc_read_vendor_err \
 	-Wl,--wrap=efa_ibv_cq_wc_read_qp_num \
 	-Wl,--wrap=efa_ibv_cq_wc_read_wc_flags \
-	-Wl,--wrap=efa_ibv_cq_wc_read_byte_len
+	-Wl,--wrap=efa_ibv_cq_wc_read_byte_len \
+	-Wl,--wrap=efa_rdm_pke_clone
 
 prov_efa_test_gtest_efa_gtest_LIBS = $(linkback)
 

--- a/prov/efa/src/rdm/efa_rdm_peer.c
+++ b/prov/efa/src/rdm/efa_rdm_peer.c
@@ -130,15 +130,16 @@ void efa_rdm_peer_destruct(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep)
 /**
  * @brief run incoming packet_entry through reorder buffer
  * queue the packet entry if msg_id is larger than expected.
- * If queue failed, abort the application and print error message.
+ * On error, write an EQ error entry; the caller releases the packet entry.
  *
  * @param[in]		peer		peer
  * @param[in]		ep		endpoint
- * @param[in,out]	pkt_entry	packet entry, will be released if successfully queued
+ * @param[in,out]	pkt_entry	packet entry; consumed when queued, otherwise left for the caller to release
  * @returns
  * 0 if `msg_id` of `pkt_entry` matches expected msg_id.
  * 1 if `msg_id` of `pkt_entry` is larger than expected, and the packet entry is queued successfully
  * -FI_EALREADY if `msg_id` of `pkt_entry` is smaller than expected.
+ * -FI_ENOMEM if queuing the out-of-order packet entry failed due to allocation failure.
  */
 int efa_rdm_peer_reorder_msg(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep,
 			     struct efa_rdm_pke *pkt_entry)
@@ -147,6 +148,7 @@ int efa_rdm_peer_reorder_msg(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep,
 	struct efa_rdm_rtm_base_hdr *rtm_hdr;
 	struct efa_rdm_pke *ooo_entry;
 	uint32_t msg_id;
+	int ret;
 
 	assert(efa_rdm_pke_get_base_hdr(pkt_entry)->type >= EFA_RDM_REQ_PKT_BEGIN);
 
@@ -185,7 +187,9 @@ int efa_rdm_peer_reorder_msg(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep,
 			         pkt_entry, pkt_entry->gen);
 			efa_rdm_pke_print_debug_info(pkt_entry);
 #endif
-			return -FI_EALREADY;
+			efa_base_ep_write_eq_error(&ep->base_ep, -FI_EALREADY, FI_EFA_ERR_PKT_ALREADY_PROCESSED);
+			ret = -FI_EALREADY;
+			goto out;
 		} else {
 			/* Current receive window size is too small to hold incoming messages.
 			 * Store the overflow messages in a double linked list, and move it
@@ -196,12 +200,17 @@ int efa_rdm_peer_reorder_msg(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep,
 			overflow_pke_list_entry = ofi_buf_alloc(ep->overflow_pke_pool);
 			if (OFI_UNLIKELY(!overflow_pke_list_entry)) {
 				EFA_WARN(FI_LOG_EP_CTRL, "Unable to allocate an overflow_pke_list_entry.\n");
-				return -FI_ENOMEM;
+				efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_OOM);
+				ret = -FI_ENOMEM;
+				goto out;
 			}
 
 			ooo_entry = efa_rdm_pke_get_ooo_pke(pkt_entry);
-			if (!ooo_entry)
-				return -FI_ENOMEM;
+			if (!ooo_entry) {
+				ofi_buf_free(overflow_pke_list_entry);
+				ret = -FI_ENOMEM;
+				goto out;
+			}
 
 			overflow_pke_list_entry->pkt_entry = ooo_entry;
 
@@ -212,15 +221,22 @@ int efa_rdm_peer_reorder_msg(struct efa_rdm_peer *peer, struct efa_rdm_ep *ep,
 				"Storing overflow msg_id %d in overflow_pke_list.\n",
 				msg_id);
 
-			return 1;
+			ret = 1;
+			goto out;
 		}
 	}
 
 	ooo_entry = efa_rdm_pke_get_ooo_pke(pkt_entry);
-	if (!ooo_entry)
-		return -FI_ENOMEM;
+	if (!ooo_entry) {
+		ret = -FI_ENOMEM;
+		goto out;
+	}
 
-	return efa_rdm_peer_recvwin_queue_or_append_pke(ooo_entry, msg_id, robuf);
+	ret = efa_rdm_peer_recvwin_queue_or_append_pke(ooo_entry, msg_id, robuf);
+	assert(ret == 1);
+out:
+	assert(ret >= 0 || ret == -FI_EALREADY || ret == -FI_ENOMEM);
+	return ret;
 }
 
 /**

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -450,7 +450,7 @@ void efa_rdm_pke_handle_rtm_rta_recv(struct efa_rdm_pke *pkt_entry)
 	struct efa_rdm_rtm_base_hdr *rtm_hdr;
 	bool slide_recvwin;
 	int ret;
-	uint32_t msg_id, exp_msg_id;
+	uint32_t exp_msg_id;
 
 	ep = pkt_entry->ep;
 
@@ -480,42 +480,13 @@ void efa_rdm_pke_handle_rtm_rta_recv(struct efa_rdm_pke *pkt_entry)
 		}
 	}
 
-	msg_id = efa_rdm_pke_get_rtm_msg_id(pkt_entry);
 	ret = efa_rdm_peer_reorder_msg(peer, pkt_entry->ep, pkt_entry);
 	if (ret == 1) {
 		/* Packet was queued */
 		return;
 	} else if (OFI_UNLIKELY(ret < 0)) {
-		if (OFI_UNLIKELY(ret == -FI_EALREADY)) {
-			/* Packet with same msg_id has been processed before */
-			EFA_WARN(FI_LOG_EP_CTRL,
-				"Invalid msg_id: %" PRIu32
-				" robuf->exp_msg_id: %" PRIu32 "\n",
-			       msg_id, peer->robuf.exp_msg_id);
-
-#if ENABLE_DEBUG
-			/* Print debug info on reorder error */
-			EFA_WARN(FI_LOG_EP_CTRL,
-			         "  pkt_entry=%p gen=%u\n"
-			         "  Debug info history:\n",
-			         pkt_entry, pkt_entry->gen);
-			efa_rdm_pke_print_debug_info(pkt_entry);
-#endif
-			efa_base_ep_write_eq_error(&ep->base_ep, ret, FI_EFA_ERR_PKT_ALREADY_PROCESSED);
-			efa_rdm_pke_release_rx(pkt_entry);
-			return;
-		}
-
-		if (OFI_UNLIKELY(ret == -FI_ENOMEM)) {
-			/* running out of memory while copy packet */
-			efa_base_ep_write_eq_error(&ep->base_ep, FI_ENOBUFS, FI_EFA_ERR_OOM);
-			return;
-		}
-
-		EFA_WARN(FI_LOG_EP_CTRL,
-			"Unknown error %d processing REQ packet msg_id: %"
-			PRIu32 "\n", ret, msg_id);
-		efa_base_ep_write_eq_error(&ep->base_ep, ret, FI_EFA_ERR_OTHER);
+		/* reorder_msg already reported error to the EQ */
+		efa_rdm_pke_release_rx(pkt_entry);
 		return;
 	}
 

--- a/prov/efa/test/gtest/efa_gtest_common_mocks.h
+++ b/prov/efa/test/gtest/efa_gtest_common_mocks.h
@@ -15,6 +15,8 @@ struct efa_conn;
 struct ofi_mr_map;
 struct fi_mr_attr;
 struct efa_ibv_cq;
+struct efa_rdm_pke;
+struct ofi_bufpool;
 
 /*
  * X macro infrastructure for mock generation.
@@ -51,6 +53,9 @@ struct efa_ibv_cq;
 	struct ofi_mr_map *map, const struct fi_mr_attr *attr,             \
 		uint64_t *key, void *context, uint64_t flags
 #define EFA_MOCK_ARGS_ofi_mr_map_insert map, attr, key, context, flags
+#define EFA_MOCK_PARAMS_efa_rdm_pke_clone                              \
+	struct efa_rdm_pke *src, struct ofi_bufpool *pkt_pool, int alloc_type
+#define EFA_MOCK_ARGS_efa_rdm_pke_clone src, pkt_pool, alloc_type
 
 #define EFA_MOCK_PARAMS_efa_ibv_cq_start_poll \
 	struct efa_ibv_cq *ibv_cq, struct ibv_poll_cq_attr *attr
@@ -88,7 +93,8 @@ struct efa_ibv_cq;
 	X(uint32_t, efa_ibv_cq_wc_read_qp_num)           \
 	X(unsigned int, efa_ibv_cq_wc_read_wc_flags)     \
 	X(uint32_t, efa_ibv_cq_wc_read_byte_len)		\
-	X(int, ofi_mr_map_insert)
+	X(int, ofi_mr_map_insert)						\
+	X(struct efa_rdm_pke *, efa_rdm_pke_clone)
 
 /* --- Generator macros --- */
 

--- a/prov/efa/test/gtest/efa_gtest_rdm_peer.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_peer.cc
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_common_helpers.h"
+#include "efa_gtest_common_mocks.h"
+#include "efa_gtest_common_resource.h"
+#include "efa_gtest_rdm_pke_utils.h"
+#include <gtest/gtest.h>
+
+using testing::Return;
+using testing::StrictMock;
+using testing::Invoke;
+
+class EfaRdmPeerTest : public testing::Test
+{
+	protected:
+	struct efa_resource resource = {};
+	StrictMock<MockEfa> mock_efa;
+	fi_addr_t peer_addr = FI_ADDR_UNSPEC;
+
+	void SetUp() override
+	{
+		memset(&resource, 0, sizeof(resource));
+		efa_test_resource_construct(
+			&resource, efa_test_alloc_default_hints(
+					   FI_EP_RDM, EFA_FABRIC_NAME));
+		ASSERT_NE(resource.ep, nullptr);
+
+		peer_addr =
+			efa_test_insert_self_gid_peer(resource.ep, resource.av);
+		ASSERT_NE(peer_addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
+
+		MockEfa::set(&mock_efa);
+	}
+
+	void TearDown() override
+	{
+		MockEfa::set(nullptr);
+		efa_test_resource_destruct(&resource);
+	}
+};
+
+/**
+ * @brief Asserts that a efa_rdm_peer_reorder_msg failure on the ooo_clone path releases the rx_pkt
+ */
+TEST_F(EfaRdmPeerTest, failed_reorder_msg_releases_rx_pkt)
+{
+	size_t to_post_before = 0, to_post_after = 0;
+
+	EXPECT_CALL(mock_efa, ofi_mr_map_insert).WillRepeatedly(Invoke(__real_ofi_mr_map_insert));
+	EXPECT_CALL(mock_efa, efa_rdm_pke_clone).WillOnce(Return(nullptr));
+
+	ASSERT_EQ(efa_test_failed_reorder_msg_releases_rx_pkt(
+			  resource.ep, peer_addr, &to_post_before,
+			  &to_post_after),
+		  0);
+
+	EXPECT_EQ(to_post_after, to_post_before + 1);
+}
+
+/**
+ * @brief Asserts that a efa_rdm_peer_reorder_msg failure on the overflow path
+ * releases the rx_pkt and frees the overflow_pke_list_entry
+ */
+TEST_F(EfaRdmPeerTest, failed_reorder_msg_overflow_releases_rx_pkt_and_entry)
+{
+	size_t to_post_before = 0, to_post_after = 0;
+	size_t overflow_free_before = 0, overflow_free_after = 0;
+
+	EXPECT_CALL(mock_efa, ofi_mr_map_insert).WillRepeatedly(Invoke(__real_ofi_mr_map_insert));
+	EXPECT_CALL(mock_efa, efa_rdm_pke_clone).WillOnce(Return(nullptr));
+
+	ASSERT_EQ(efa_test_failed_reorder_msg_overflow_releases_rx_pkt_and_entry(
+			  resource.ep, peer_addr, &to_post_before,
+			  &to_post_after, &overflow_free_before,
+			  &overflow_free_after),
+		  0);
+
+	EXPECT_EQ(to_post_after, to_post_before + 1);
+	EXPECT_EQ(overflow_free_after, overflow_free_before);
+}

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c
@@ -85,3 +85,101 @@ size_t efa_test_ep_unexp_pool_outstanding(struct fid_ep *ep)
 
 	return pool->entry_cnt - free_cnt;
 }
+
+int efa_test_failed_reorder_msg_releases_rx_pkt(struct fid_ep *ep,
+						fi_addr_t peer_addr,
+						size_t *to_post_before,
+						size_t *to_post_after)
+{
+	struct efa_rdm_ep *efa_rdm_ep =
+		container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	struct efa_rdm_pke *pke;
+	struct efa_rdm_rtm_base_hdr *rtm_hdr;
+	uint32_t msg_id;
+
+	if (!peer)
+		return -FI_EINVAL;
+
+	pke = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool,
+				EFA_RDM_PKE_FROM_EFA_RX_POOL);
+	if (!pke)
+		return -FI_ENOMEM;
+	pke->peer = peer;
+	pke->ep = efa_rdm_ep;
+
+	/* a valid (in-window) but unexpected msg_id */
+	msg_id = ofi_recvwin_next_exp_id(&peer->robuf) + 1;
+
+	rtm_hdr = (struct efa_rdm_rtm_base_hdr *) pke->wiredata;
+	memset(rtm_hdr, 0, sizeof(*rtm_hdr));
+	rtm_hdr->type = EFA_RDM_LONGCTS_MSGRTM_PKT;
+	rtm_hdr->version = EFA_RDM_PROTOCOL_VERSION;
+	rtm_hdr->flags = EFA_RDM_REQ_MSG;
+	rtm_hdr->msg_id = msg_id;
+
+	/* efa_rx_pkts_to_post should be incremented by pke_release_rx */
+	*to_post_before = efa_rdm_ep->efa_rx_pkts_to_post;
+	efa_rdm_pke_handle_rtm_rta_recv(pke);
+	*to_post_after = efa_rdm_ep->efa_rx_pkts_to_post;
+	return 0;
+}
+
+static size_t efa_test_bufpool_free_count(struct ofi_bufpool *pool)
+{
+	struct slist_entry *item;
+	size_t count = 0;
+
+	for (item = pool->free_list.entries.head; item; item = item->next)
+		count++;
+	return count;
+}
+
+int efa_test_failed_reorder_msg_overflow_releases_rx_pkt_and_entry(
+	struct fid_ep *ep, fi_addr_t peer_addr, size_t *to_post_before,
+	size_t *to_post_after, size_t *overflow_free_before,
+	size_t *overflow_free_after)
+{
+	struct efa_rdm_ep *efa_rdm_ep =
+		container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	struct efa_rdm_pke *pke;
+	struct efa_rdm_rtm_base_hdr *rtm_hdr;
+	uint32_t msg_id;
+	void *warmup;
+
+	if (!peer)
+		return -FI_EINVAL;
+
+	/* triggers resize of the empty pool */
+	warmup = ofi_buf_alloc(efa_rdm_ep->overflow_pke_pool);
+	if (!warmup)
+		return -FI_ENOMEM;
+	ofi_buf_free(warmup);
+
+	pke = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool,
+				EFA_RDM_PKE_FROM_EFA_RX_POOL);
+	if (!pke)
+		return -FI_ENOMEM;
+	pke->peer = peer;
+	pke->ep = efa_rdm_ep;
+
+	/* unexpected and out-of-window msg_id -> overflow branch */
+	msg_id = ofi_recvwin_next_exp_id(&peer->robuf) + peer->robuf.win_size;
+
+	rtm_hdr = (struct efa_rdm_rtm_base_hdr *) pke->wiredata;
+	memset(rtm_hdr, 0, sizeof(*rtm_hdr));
+	rtm_hdr->type = EFA_RDM_LONGCTS_MSGRTM_PKT;
+	rtm_hdr->version = EFA_RDM_PROTOCOL_VERSION;
+	rtm_hdr->flags = EFA_RDM_REQ_MSG;
+	rtm_hdr->msg_id = msg_id;
+
+	*to_post_before = efa_rdm_ep->efa_rx_pkts_to_post;
+	*overflow_free_before =
+		efa_test_bufpool_free_count(efa_rdm_ep->overflow_pke_pool);
+	efa_rdm_pke_handle_rtm_rta_recv(pke);
+	*to_post_after = efa_rdm_ep->efa_rx_pkts_to_post;
+	*overflow_free_after =
+		efa_test_bufpool_free_count(efa_rdm_ep->overflow_pke_pool);
+	return 0;
+}

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.h
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.h
@@ -43,6 +43,16 @@ void efa_test_pke_release_cloned(struct efa_rdm_pke *head);
  */
 size_t efa_test_ep_unexp_pool_outstanding(struct fid_ep *ep);
 
+int efa_test_failed_reorder_msg_releases_rx_pkt(struct fid_ep *ep,
+						fi_addr_t peer_addr,
+						size_t *to_post_before,
+						size_t *to_post_after);
+
+int efa_test_failed_reorder_msg_overflow_releases_rx_pkt_and_entry(
+	struct fid_ep *ep, fi_addr_t peer_addr, size_t *to_post_before,
+	size_t *to_post_after, size_t *overflow_free_before,
+	size_t *overflow_free_after);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
previously a few error paths in this function didn't properly release 
the pkt_entry, and one also didn't release an overflow_pke_list_entry.

this commit fixes these error paths and adds two unit tests 
to assert that this function now cleans up properly.