### PR TITLE
prov/efa: Fix typos

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -681,7 +681,7 @@ static int efa_av_lookup(struct fid_av *av_fid, fi_addr_t fi_addr,
  * @param[in]	counter	number of libfabric addresses in the array
  * @param[in]	flags	flags
  * @return	0 if all addresses have been removed successfully,
- * 		negative libfabric error code if error was encoutnered.
+ * 		negative libfabric error code if error was encountered.
  */
 static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 			 size_t count, uint64_t flags)

--- a/prov/efa/src/efa_env.c
+++ b/prov/efa/src/efa_env.c
@@ -222,7 +222,7 @@ void efa_env_define()
 	fi_param_define(&efa_prov, "inter_max_gdrcopy_message_size", FI_PARAM_INT,
 			"The maximum message size to use gdrcopy. If instance support gdrcopy, messages whose size is smaller than this value will be sent by eager/longcts protocol (Default 32768).");
 	fi_param_define(&efa_prov, "inter_min_read_write_size", FI_PARAM_INT,
-			"The mimimum message size for inter EFA write to use read write protocol. If firmware support RDMA read, and FI_EFA_USE_DEVICE_RDMA is 1, write requests whose size is larger than this value will use the read write protocol (Default 65536). If the efa device supports RDMA write, device RDMA write will always be used.");
+			"The minimum message size for inter EFA write to use read write protocol. If firmware support RDMA read, and FI_EFA_USE_DEVICE_RDMA is 1, write requests whose size is larger than this value will use the read write protocol (Default 65536). If the efa device supports RDMA write, device RDMA write will always be used.");
 	fi_param_define(&efa_prov, "inter_read_segment_size", FI_PARAM_INT,
 			"Calls to RDMA read is segmented using this value.");
 	fi_param_define(&efa_prov, "fork_safe", FI_PARAM_BOOL,
@@ -250,7 +250,7 @@ void efa_env_define()
 			"The maximum size of the implicit AV used to store AV "
 			"entries of peers that were not explicitly inserted "
 			"into the AV by the application. Setting this variable "
-			"to a positive value will enforce the the maximum "
+			"to a positive value will enforce the maximum "
 			"size. Setting this value to 0 will allow unbounded "
 			"growth of the implicit AV. (Default: 0)",
 			efa_env.implicit_av_size);

--- a/prov/efa/src/efa_hmem.c
+++ b/prov/efa/src/efa_hmem.c
@@ -450,7 +450,7 @@ int efa_hmem_validate_p2p_opt(enum fi_hmem_iface iface, int p2p_opt, uint32_t ap
 	 * According to fi_setopt() document:
 	 *
 	 *     ENABLED means a provider may use P2P.
-	 *     PREFERED means a provider should prefer P2P if it is available.
+	 *     PREFERRED means a provider should prefer P2P if it is available.
 	 *
 	 * These options does not require that p2p is supported by device,
 	 * nor do they prohibit that p2p is required by implementation.

--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -62,7 +62,7 @@ const struct fi_domain_attr efa_domain_attr = {
  * @param 	prov_info[out]		pointer to prov_info object
  * @param	device[in]		pointer to an efa_device struct, which contains device attributes
  * @param	ep_type[in]		endpoint type, can be FI_EP_RDM or FI_EP_DGRAM
- * @return	0 on sucessess
+ * @return	0 on success
  * 		negative libfabric error code on failure
  */
 static

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -80,7 +80,7 @@ static void efa_rdm_cq_wait_del_signal(struct efa_rdm_cq *cq)
  * @brief close a CQ of EFA RDM endpoint
  *
  * @param[in,out]	fid	fid of the CQ to be closed
- * @returns		0 on sucesss,
+ * @returns		0 on success,
  * 			negative libfabric error code on error
  * @relates efa_rdm_cq
  */
@@ -794,7 +794,7 @@ enum ibv_wc_status efa_rdm_cq_process_wc(struct efa_ibv_cq *cq, struct efa_rdm_e
 				EFA_INFO(FI_LOG_CQ, "Receive error %s (%d) for unsolicited write recv\n",
 					efa_strerror(prov_errno), prov_errno);
 				err_entry.op_context = NULL;
-				/*To be consistent with the succeed path. Although man page only refered to: FI_REMOTE_WRITE | FI_REMOTE_CQ_DATA)*/
+				/*To be consistent with the succeed path. Although man page only referred to: FI_REMOTE_WRITE | FI_REMOTE_CQ_DATA)*/
 				err_entry.flags = FI_REMOTE_CQ_DATA | FI_RMA | FI_REMOTE_WRITE;
 				err_entry.err = to_fi_errno(prov_errno);
 				err_entry.prov_errno = prov_errno;

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -455,7 +455,7 @@ size_t efa_rdm_txe_max_req_data_capacity(struct efa_rdm_ep *ep, struct efa_rdm_o
 /**
  * @brief prepare ope to send the give pkt type
  *
- * For given packet type, calcuate how many packets are going to be
+ * For given packet type, calculate how many packets are going to be
  * sent. If there are more than 1 packet, calculate how many data
  * each packet will carry.
  *

--- a/prov/efa/src/rdm/efa_rdm_pke.c
+++ b/prov/efa/src/rdm/efa_rdm_pke.c
@@ -91,7 +91,7 @@ struct efa_rdm_pke *efa_rdm_pke_alloc(struct efa_rdm_ep *ep,
 	}
 #endif
 	/* Initialize necessary fields in pkt_entry.
-	 * The memory region allocated by ofi_buf_alloc_ex is not initalized.
+	 * The memory region allocated by ofi_buf_alloc_ex is not initialized.
 	 */
 	pkt_entry->ep = ep;
 	pkt_entry->mr = mr;

--- a/prov/efa/src/rdm/efa_rdm_pke_rtw.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtw.c
@@ -271,7 +271,7 @@ void efa_rdm_pke_handle_dc_eager_rtw_recv(struct efa_rdm_pke *pkt_entry)
 }
 
 /**
- * @brief initialize the the header of a LONGCTS RTW packet
+ * @brief initialize the header of a LONGCTS RTW packet
  *
  * This function applies to both EFA_RDM_LONGCTS_RTW_PKT and
  * EFA_RDM_DC_LONGCTS_RTW_PKT


### PR DESCRIPTION
## Summary
Corrects spelling and duplicate-word typos in EFA provider code comments and doxygen strings. Comment-only changes — no functional impact.

## Changes
- efa_env.c:        "mimimum" -> "minimum", "the the maximum" -> "the maximum"
- efa_prov_info.c:  "sucessess" -> "success"
- efa_rdm_cq.c:     "sucesss" -> "success", "refered" -> "referred"
- efa_hmem.c:       "PREFERED" -> "PREFERRED"
- efa_av.c:         "encoutnered" -> "encountered"
- efa_rdm_ope.c:    "calcuate" -> "calculate"
- efa_rdm_pke.c:    "initalized" -> "initialized"
- efa_rdm_pke_rtw.c:"the the header" -> "the header"

## Rationale
Improves readability of inline documentation and doxygen-generated docs.

## Testing
No code paths changed. Comment/string edits only, so no build or runtime behavior is affected.

## Checklist
- [x] Commit is signed off (DCO)
- [x] Changes limited to comments/documentation
- [x] No functional or ABI changes
