### PR TITLE
prov/efa: add Clang thread safety analysis tooling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,6 +157,27 @@ AS_IF([test x"$enable_debug" != x"no"],
 AC_DEFINE_UNQUOTED([ENABLE_DEBUG],[$dbg],
                    [defined to 1 if libfabric was configured with --enable-debug, 0 otherwise])
 
+# Clang Thread Safety Analysis. Off by default; enable with
+# --enable-thread-safety-analysis. Only then, and only if the compiler
+# supports it, add -Wthread-safety and define OFI_THREAD_SAFETY_ANALYSIS.
+AC_ARG_ENABLE([thread_safety_analysis],
+	[AS_HELP_STRING([--enable-thread-safety-analysis],
+		[Enable Clang thread safety analysis @<:@default=no@:>@])],
+	[],
+	[enable_thread_safety_analysis=no])
+
+AS_IF([test x"$enable_thread_safety_analysis" != x"no"], [
+	AC_MSG_CHECKING([whether $CC supports -Wthread-safety])
+	CFLAGS_save="$CFLAGS"
+	CFLAGS="-Werror -Wthread-safety $CFLAGS_save"
+	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
+			  [AC_MSG_RESULT([yes])
+			   CFLAGS="-Wthread-safety -DOFI_THREAD_SAFETY_ANALYSIS $CFLAGS_save"],
+			  [AC_MSG_RESULT([no])
+			   CFLAGS="$CFLAGS_save"])
+	unset CFLAGS_save
+])
+
 AC_ARG_ENABLE([profile],
               [AS_HELP_STRING([--enable-profile],
                               [Enable profiling @<:@default=no@:>@])],

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -99,6 +99,7 @@ _efa_headers = \
 	prov/efa/src/efa_shm.h \
 	prov/efa/src/efa_hmem.h \
 	prov/efa/src/efa_device.h \
+	prov/efa/src/efa_thread_annotations.h \
 	prov/efa/src/efa_domain.h \
 	prov/efa/src/efa_domain_util.h \
 	prov/efa/src/efa_fabric_util.h \

--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -65,11 +65,11 @@ int efa_base_ep_destruct_qp(struct efa_base_ep *base_ep)
 	 *
 	 * Lock ordering: device lock -> CQ locks -> QP operations
 	 */
-	ofi_genlock_lock(&base_ep->domain->device->qp_table_lock);
+	EFA_GENLOCK_LOCK(&base_ep->domain->device->qp_table_lock, efa_qp_table_lock_sym);
 	efa_base_ep_lock_cq(base_ep);
 	efa_base_ep_destruct_qp_unsafe(base_ep);
 	efa_base_ep_unlock_cq(base_ep);
-	ofi_genlock_unlock(&base_ep->domain->device->qp_table_lock);
+	EFA_GENLOCK_UNLOCK(&base_ep->domain->device->qp_table_lock, efa_qp_table_lock_sym);
 	return 0;
 }
 
@@ -507,6 +507,7 @@ static int efa_base_ep_attach_comp_cntrs(struct efa_base_ep *base_ep,
 
 static
 int efa_base_ep_enable_qp(struct efa_base_ep *base_ep, struct efa_qp *qp)
+	OFI_TSA_REQUIRES(efa_qp_table_lock_sym)
 {
 	int err;
 
@@ -1025,7 +1026,7 @@ int efa_base_ep_create_and_enable_qp(struct efa_base_ep *ep)
 	 *
 	 * Lock ordering: device lock -> CQ locks -> QP operations
 	 */
-	ofi_genlock_lock(&ep->domain->device->qp_table_lock);
+	EFA_GENLOCK_LOCK(&ep->domain->device->qp_table_lock, efa_qp_table_lock_sym);
 	efa_base_ep_lock_cq(ep);
 	err = efa_base_ep_create_qp(ep, &scq->ibv_cq, &rcq->ibv_cq);
 	if (err)
@@ -1035,7 +1036,7 @@ int efa_base_ep_create_and_enable_qp(struct efa_base_ep *ep)
 
 out:
 	efa_base_ep_unlock_cq(ep);
-	ofi_genlock_unlock(&ep->domain->device->qp_table_lock);
+	EFA_GENLOCK_UNLOCK(&ep->domain->device->qp_table_lock, efa_qp_table_lock_sym);
 	return err;
 }
 

--- a/prov/efa/src/efa_base_ep.h
+++ b/prov/efa/src/efa_base_ep.h
@@ -11,6 +11,7 @@
 #include "ofi.h"
 #include "ofi_util.h"
 #include "efa_av.h"
+#include "efa_thread_annotations.h"
 #include "rdm/efa_rdm_protocol.h"
 #include "efa_data_path_direct_structs.h"
 
@@ -106,7 +107,8 @@ int efa_base_ep_bind_av(struct efa_base_ep *base_ep, struct efa_av *av);
 
 int efa_base_ep_destruct(struct efa_base_ep *base_ep);
 
-int efa_base_ep_enable(struct efa_base_ep *base_ep);
+int efa_base_ep_enable(struct efa_base_ep *base_ep)
+	OFI_TSA_REQUIRES(efa_qp_table_lock_sym);
 
 int efa_base_ep_construct(struct efa_base_ep *base_ep,
 			  struct fid_domain* domain_fid,
@@ -128,7 +130,8 @@ void efa_base_ep_close_util_ep(struct efa_base_ep *base_ep);
 
 int efa_base_ep_destruct_qp(struct efa_base_ep *base_ep);
 
-int efa_base_ep_destruct_qp_unsafe(struct efa_base_ep *base_ep);
+int efa_base_ep_destruct_qp_unsafe(struct efa_base_ep *base_ep)
+	OFI_TSA_REQUIRES(efa_qp_table_lock_sym);
 
 bool efa_qp_support_op_in_order_aligned_128_bytes(struct efa_qp *qp,
 						       enum ibv_wr_opcode op);

--- a/prov/efa/src/efa_data_path_ops.h
+++ b/prov/efa/src/efa_data_path_ops.h
@@ -541,6 +541,8 @@ static inline void efa_cq_end_poll(struct efa_ibv_cq *cq)
 }
 
 static inline struct efa_base_ep *efa_ibv_cq_get_base_ep_from_cur_cqe(struct efa_ibv_cq *cq, struct efa_domain *efa_domain)
+	/* No lock analysis: completion path is guarded by the CQ lock. */
+	OFI_TSA_NO_ANALYSIS
 {
 	struct efa_qp *qp = efa_domain->device->qp_table[efa_ibv_cq_wc_read_qp_num(cq) & efa_domain->device->qp_table_sz_m1];
 

--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -28,6 +28,11 @@
 #include "efawin.h"
 #endif
 
+/* Storage for the device QP-table lock analysis symbol. TODO: once a
+ * second lock is added, these should be moved to a separate thread safety
+ * .c file */
+OFI_TSA_LOCK_SYMBOL_DEFINE(efa_qp_table_lock_sym);
+
 /**
  * @brief initialize data members of a struct of efa_device until the gid
  *
@@ -161,6 +166,7 @@ static void efa_device_set_cntr_max_values(struct efa_device *efa_device)
  */
 int efa_device_construct_data(struct efa_device *efa_device,
 			 struct ibv_device *ibv_device)
+	OFI_TSA_NO_ANALYSIS
 {
 	int err;
 	size_t qp_table_size;
@@ -249,6 +255,8 @@ err_close:
  * @param	device[in,out]		pointer to an efa_device struct
  */
 void efa_device_destruct(struct efa_device *device)
+	/* No lock analysis: teardown is guarded by device->ref_cnt. */
+	OFI_TSA_NO_ANALYSIS
 {
 	int err;
 

--- a/prov/efa/src/efa_device.h
+++ b/prov/efa/src/efa_device.h
@@ -10,6 +10,7 @@
 #include <stdbool.h>
 #include "ofi_lock.h"
 #include "ofi_atom.h"
+#include "efa_thread_annotations.h"
 
 struct efa_qp;
 
@@ -24,7 +25,7 @@ struct efa_device {
 	struct fi_info		*rdm_info;
 	struct fi_info		*dgram_info;
 	/* QP table and lock for device-level QP management */
-	struct efa_qp		**qp_table;
+	struct efa_qp		**qp_table OFI_TSA_GUARDED_BY(efa_qp_table_lock_sym);
 	uint8_t			*qp_gen_table;
 	size_t			qp_table_sz_m1;
 	struct ofi_genlock		qp_table_lock;

--- a/prov/efa/src/efa_thread_annotations.h
+++ b/prov/efa/src/efa_thread_annotations.h
@@ -91,5 +91,7 @@ efa_genlock_held(struct ofi_genlock *lock, struct ofi_tsa_lock_symbol *sym)
 
 #endif /* OFI_THREAD_SAFETY_ANALYSIS */
 
+/* EFA lock symbols (one per lock role). */
+OFI_TSA_LOCK_SYMBOL_DECLARE(efa_qp_table_lock_sym);
 
 #endif /* EFA_THREAD_ANNOTATIONS_H */

--- a/prov/efa/src/efa_thread_annotations.h
+++ b/prov/efa/src/efa_thread_annotations.h
@@ -1,0 +1,95 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#ifndef EFA_THREAD_ANNOTATIONS_H
+#define EFA_THREAD_ANNOTATIONS_H
+
+#include <ofi_lock.h>
+
+/*
+ * Clang Thread Safety Analysis for the EFA provider.
+ *
+ * Active only in the analysis build (OFI_THREAD_SAFETY_ANALYSIS defined and
+ * clang with capability support); expands to nothing otherwise.
+ */
+
+#if defined(OFI_THREAD_SAFETY_ANALYSIS) && defined(__clang__) && \
+	defined(__has_attribute)
+#  if __has_attribute(capability)
+#    define OFI_TSA_ANNOTATION(x)	__attribute__((x))
+#  endif
+#endif
+
+#ifndef OFI_TSA_ANNOTATION
+#  define OFI_TSA_ANNOTATION(x)
+#endif
+
+#define OFI_TSA_CAPABILITY(name)	OFI_TSA_ANNOTATION(capability(name))
+#define OFI_TSA_GUARDED_BY(x)		OFI_TSA_ANNOTATION(guarded_by(x))
+#define OFI_TSA_PT_GUARDED_BY(x)	OFI_TSA_ANNOTATION(pt_guarded_by(x))
+#define OFI_TSA_REQUIRES(...)		OFI_TSA_ANNOTATION(requires_capability(__VA_ARGS__))
+#define OFI_TSA_REQUIRES_SHARED(...)	OFI_TSA_ANNOTATION(requires_shared_capability(__VA_ARGS__))
+#define OFI_TSA_EXCLUDES(...)		OFI_TSA_ANNOTATION(locks_excluded(__VA_ARGS__))
+#define OFI_TSA_ACQUIRE(...)		OFI_TSA_ANNOTATION(acquire_capability(__VA_ARGS__))
+#define OFI_TSA_RELEASE(...)		OFI_TSA_ANNOTATION(release_capability(__VA_ARGS__))
+#define OFI_TSA_ASSERT_CAPABILITY(x)	OFI_TSA_ANNOTATION(assert_capability(x))
+#define OFI_TSA_NO_ANALYSIS		OFI_TSA_ANNOTATION(no_thread_safety_analysis)
+
+/*
+ * Lock symbols.
+ *
+ * Each lock role is represented by a global dummy capability object.
+ * Annotations reference the symbol; the wrappers lock the real genlock and
+ * bind it to a symbol.  Declare a symbol once in a header and define it once
+ * in a .c; use EFA_GENLOCK_LOCK/UNLOCK/HELD to take, drop, and assert it.
+ */
+#ifdef OFI_THREAD_SAFETY_ANALYSIS
+
+struct OFI_TSA_CAPABILITY("mutex") ofi_tsa_lock_symbol { char dummy; };
+
+#define OFI_TSA_LOCK_SYMBOL_DECLARE(name) \
+	extern struct ofi_tsa_lock_symbol name
+#define OFI_TSA_LOCK_SYMBOL_DEFINE(name) \
+	struct ofi_tsa_lock_symbol name
+
+static inline void
+efa_genlock_acquire(struct ofi_genlock *lock, struct ofi_tsa_lock_symbol *sym)
+	OFI_TSA_ACQUIRE(*sym) OFI_TSA_NO_ANALYSIS
+{
+	(void) sym;
+	ofi_genlock_lock(lock);
+}
+
+static inline void
+efa_genlock_release(struct ofi_genlock *lock, struct ofi_tsa_lock_symbol *sym)
+	OFI_TSA_RELEASE(*sym) OFI_TSA_NO_ANALYSIS
+{
+	(void) sym;
+	ofi_genlock_unlock(lock);
+}
+
+static inline int
+efa_genlock_held(struct ofi_genlock *lock, struct ofi_tsa_lock_symbol *sym)
+	OFI_TSA_ASSERT_CAPABILITY(*sym) OFI_TSA_NO_ANALYSIS
+{
+	(void) sym;
+	return ofi_genlock_held(lock);
+}
+
+#define EFA_GENLOCK_LOCK(lock, sym)	efa_genlock_acquire((lock), &(sym))
+#define EFA_GENLOCK_UNLOCK(lock, sym)	efa_genlock_release((lock), &(sym))
+#define EFA_GENLOCK_HELD(lock, sym)	efa_genlock_held((lock), &(sym))
+
+#else /* !OFI_THREAD_SAFETY_ANALYSIS */
+
+#define OFI_TSA_LOCK_SYMBOL_DECLARE(name)	struct ofi_tsa_lock_symbol_unused_##name
+#define OFI_TSA_LOCK_SYMBOL_DEFINE(name)	struct ofi_tsa_lock_symbol_unused_##name
+
+#define EFA_GENLOCK_LOCK(lock, sym)	ofi_genlock_lock(lock)
+#define EFA_GENLOCK_UNLOCK(lock, sym)	ofi_genlock_unlock(lock)
+#define EFA_GENLOCK_HELD(lock, sym)	ofi_genlock_held(lock)
+
+#endif /* OFI_THREAD_SAFETY_ANALYSIS */
+
+
+#endif /* EFA_THREAD_ANNOTATIONS_H */


### PR DESCRIPTION
    prov/efa: add Clang thread safety analysis tooling

    Add OFI_TSA_* annotation macros and per-role lock symbols in
    prov/efa/src/efa_thread_annotations.h, and enable -Wthread-safety and
    OFI_THREAD_SAFETY_ANALYSIS through configure when the compiler supports it.
    Active only in the analysis build; no effect on real builds.

    Building and running the check (requires clang; sudo apt/dnf/yum install clang):

        ./autogen.sh
        CC=clang ./configure --enable-thread-safety-analysis
        make clean && make -j 2>&1 | grep -i thread-safety

    configure adds -Wthread-safety under clang; the analysis runs during make and
    warnings print inline (plain warning, not -Werror). make clean is needed on an
    already-built tree so files recompile.