### PR TITLE
prov/efa: fix leak in rdm_cntr_open

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -293,7 +293,8 @@ nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
 	prov/efa/test/gtest/efa_gtest_rdm_pke.cc \
 	prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.c \
 	prov/efa/test/gtest/efa_gtest_rdm_ope.cc \
-	prov/efa/test/gtest/efa_gtest_cq.cc
+	prov/efa/test/gtest/efa_gtest_cq.cc \
+	prov/efa/test/gtest/efa_gtest_rdm_cntr.cc
 
 prov_efa_test_gtest_efa_gtest_CPPFLAGS = \
 	$(AM_CPPFLAGS) \

--- a/prov/efa/src/rdm/efa_rdm_cntr.c
+++ b/prov/efa/src/rdm/efa_rdm_cntr.c
@@ -155,10 +155,10 @@ int efa_rdm_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 
 	ret = efa_cntr_construct(&cntr->efa_cntr, domain, attr,
 				 efa_rdm_cntr_progress, context);
-	if (ret)
+	if (ret) {
 		goto free;
+	}
 
-	*cntr_fid = &cntr->efa_cntr.util_cntr.cntr_fid;
 	cntr->efa_cntr.util_cntr.cntr_fid.ops = &efa_rdm_cntr_ops;
 	cntr->efa_cntr.util_cntr.cntr_fid.fid.ops = &efa_rdm_cntr_fi_ops;
 
@@ -172,10 +172,12 @@ int efa_rdm_cntr_open(struct fid_domain *domain, struct fi_cntr_attr *attr,
 				   &cntr->shm_cntr, &peer_cntr_context);
 		if (ret) {
 			EFA_WARN(FI_LOG_CNTR, "Unable to open shm cntr, err: %s\n", fi_strerror(-ret));
+			efa_cntr_destruct(&cntr->efa_cntr);
 			goto free;
 		}
 	}
 
+	*cntr_fid = &cntr->efa_cntr.util_cntr.cntr_fid;
 	return FI_SUCCESS;
 
 free:

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.c
@@ -160,3 +160,11 @@ void efa_test_set_shm_domain(struct fid_domain *domain,
 {
 	efa_test_rdm_domain(domain)->shm_domain = shm_domain;
 }
+
+int efa_test_get_util_domain_ref(struct fid_domain *domain)
+{
+	struct efa_domain *efa_domain = container_of(
+		domain, struct efa_domain, util_domain.domain_fid);
+
+	return ofi_atomic_get32(&efa_domain->util_domain.ref);
+}

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.h
@@ -104,6 +104,11 @@ struct fid_domain *efa_test_get_shm_domain(struct fid_domain *domain);
 void efa_test_set_shm_domain(struct fid_domain *domain,
 			     struct fid_domain *shm_domain);
 
+/**
+ * @brief Get util_domain's refcount.
+ */
+int efa_test_get_util_domain_ref(struct fid_domain *domain);
+
 #ifdef __cplusplus
 }
 #endif

--- a/prov/efa/test/gtest/efa_gtest_rdm_cntr.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_cntr.cc
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_common_helpers.h"
+#include "efa_gtest_common_mocks.h"
+#include "efa_gtest_common_resource.h"
+#include <gtest/gtest.h>
+
+using testing::StrictMock;
+using testing::Test;
+
+class EfaRdmCntrTest : public Test
+{
+	protected:
+	struct efa_resource resource = {};
+	StrictMock<MockEfa> mock_efa;
+
+	void SetUp() override
+	{
+		memset(&resource, 0, sizeof(resource));
+
+		efa_test_resource_construct(
+			&resource, efa_test_alloc_default_hints(
+					   FI_EP_RDM, EFA_FABRIC_NAME));
+		ASSERT_NE(resource.domain, nullptr);
+
+		MockEfa::set(&mock_efa);
+	}
+
+	void TearDown() override
+	{
+		MockEfa::set(nullptr);
+		efa_test_resource_destruct(&resource);
+	}
+};
+
+static int fake_shm_cntr_open(struct fid_domain *domain,
+			      struct fi_cntr_attr *attr,
+			      struct fid_cntr **cntr, void *context)
+{
+	return -FI_ENOMEM;
+}
+
+/**
+ * @brief Asserts that rdm_cntr_open cleans up properly after shm_cntr open fails
+ */
+TEST_F(EfaRdmCntrTest, shm_cntr_open_failure_does_not_leak_domain_ref)
+{
+	struct fi_ops_domain fake_ops = {};
+	struct fid_domain fake_shm_domain = {};
+	struct fi_cntr_attr attr = {};
+	struct fid_cntr *cntr_fid = nullptr;
+	struct fid_domain *saved_shm_domain;
+	int ref_before, ref_after, ret;
+
+	fake_ops.size = sizeof(fake_ops);
+	fake_ops.cntr_open = fake_shm_cntr_open;
+	fake_shm_domain.ops = &fake_ops;
+
+	attr.wait_obj = FI_WAIT_NONE;
+
+	saved_shm_domain = efa_test_get_shm_domain(resource.domain);
+	efa_test_set_shm_domain(resource.domain, &fake_shm_domain);
+
+	ref_before = efa_test_get_util_domain_ref(resource.domain);
+	ret = fi_cntr_open(resource.domain, &attr, &cntr_fid, NULL);
+	ref_after = efa_test_get_util_domain_ref(resource.domain);
+
+	efa_test_set_shm_domain(resource.domain, saved_shm_domain);
+
+	EXPECT_EQ(ret, -FI_ENOMEM);
+	/* util_domain's refcount should not increment if cntr_open failed */
+	EXPECT_EQ(ref_after, ref_before);
+
+	if (cntr_fid)
+		fi_close(&cntr_fid->fid);
+}


### PR DESCRIPTION
In the shm cntr_open branch in rdm_cntr_open, when fi_cntr_open 
fails, previously only the owning cntr object is freed, not the 
underlying efa_cntr, which makes the refcount of util_domain 
higher by one, which in turn means ofi_domain_close on util_domain 
will return -FI_EBUSY.
A unit test has been added to assert that appropriate cleanup is done.