### PR TITLE
prov/efa: fix erroneous direct_ope release on post success

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -295,7 +295,9 @@ nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
 	prov/efa/test/gtest/efa_gtest_rdm_ope.cc \
 	prov/efa/test/gtest/efa_gtest_cq.cc \
 	prov/efa/test/gtest/efa_gtest_rdm_cntr.cc \
-	prov/efa/test/gtest/efa_gtest_rdm_peer.cc
+	prov/efa/test/gtest/efa_gtest_rdm_peer.cc \
+	prov/efa/test/gtest/efa_gtest_msg.cc \
+	prov/efa/test/gtest/efa_gtest_rma.cc
 
 prov_efa_test_gtest_efa_gtest_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
@@ -327,7 +329,11 @@ prov_efa_test_gtest_efa_gtest_LDFLAGS = \
 	-Wl,--wrap=efa_ibv_cq_wc_read_qp_num \
 	-Wl,--wrap=efa_ibv_cq_wc_read_wc_flags \
 	-Wl,--wrap=efa_ibv_cq_wc_read_byte_len \
-	-Wl,--wrap=efa_rdm_pke_clone
+	-Wl,--wrap=efa_rdm_pke_clone \
+	-Wl,--wrap=efa_qp_post_recv \
+	-Wl,--wrap=efa_qp_post_send \
+	-Wl,--wrap=efa_qp_post_read \
+	-Wl,--wrap=efa_qp_post_write
 
 prov_efa_test_gtest_efa_gtest_LIBS = $(linkback)
 

--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -333,10 +333,16 @@ post:
 	ret = efa_qp_post_send(qp, sg_list, inline_data_list, iov_count,
 			       use_inline, wr_id, msg->data, flags,
 			       conn->ah, conn->ep_addr->qpn, conn->ep_addr->qkey);
-	if (OFI_UNLIKELY(ret))
+	if (OFI_UNLIKELY(ret)) {
 		ret = (ret == ENOMEM) ? -FI_EAGAIN : -ret;
+		goto out_err;
+	}
 
 	efa_tracepoint(post_send, wr_id, (uintptr_t)msg->context);
+
+	ofi_genlock_unlock(&base_ep->util_ep.lock);
+
+	return ret;
 
 out_err:
 	if (direct_ope)

--- a/prov/efa/src/efa_rma.c
+++ b/prov/efa/src/efa_rma.c
@@ -111,10 +111,16 @@ static inline ssize_t efa_rma_post_read(struct efa_base_ep *base_ep,
 			       msg->rma_iov[0].key, msg->rma_iov[0].addr,
 			       wr_id, flags,
 			       conn->ah, conn->ep_addr->qpn, conn->ep_addr->qkey);
-	if (OFI_UNLIKELY(err))
+	if (OFI_UNLIKELY(err)) {
 		err = (err == ENOMEM) ? -FI_EAGAIN : -err;
+		goto out_err;
+	}
 
 	efa_tracepoint(post_read, wr_id, (uintptr_t)msg->context);
+
+	ofi_genlock_unlock(&base_ep->util_ep.lock);
+
+	return err;
 
 out_err:
 	if (direct_ope)
@@ -303,10 +309,16 @@ static inline ssize_t efa_rma_post_write(struct efa_base_ep *base_ep,
 				msg->rma_iov[0].key, msg->rma_iov[0].addr,
 				wr_id, msg->data, flags,
 				conn->ah, conn->ep_addr->qpn, conn->ep_addr->qkey);
-	if (OFI_UNLIKELY(err))
+	if (OFI_UNLIKELY(err)) {
 		err = (err == ENOMEM) ? -FI_EAGAIN : -err;
+		goto out_err;
+	}
 
 	efa_tracepoint(post_write, wr_id, (uintptr_t)msg->context);
+
+	ofi_genlock_unlock(&base_ep->util_ep.lock);
+
+	return err;
 
 out_err:
 	if (direct_ope)

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.c
@@ -132,6 +132,36 @@ void efa_test_set_ibv_cq_ex(struct efa_ibv_cq *ibv_cq, int status,
 	ibv_cq->ibv_cq_ex->wr_id = wr_id;
 }
 
+int efa_test_set_track_mr(int value)
+{
+	int prev = efa_env.track_mr;
+
+	efa_env.track_mr = value;
+	return prev;
+}
+
+int efa_test_device_supports_rma(void)
+{
+	if (g_efa_selected_device_cnt <= 0)
+		return 0;
+
+	return efa_device_support_rdma_read() &&
+	       efa_device_support_rdma_write();
+}
+
+size_t efa_test_ope_list_count(struct fid_ep *ep)
+{
+	struct efa_base_ep *base_ep =
+		container_of(ep, struct efa_base_ep, util_ep.ep_fid);
+	struct dlist_entry *item;
+	size_t count = 0;
+
+	dlist_foreach(&base_ep->ope_list, item)
+		count++;
+
+	return count;
+}
+
 struct ibv_ah *efa_test_implicit_addr_to_ibv_ah(struct fid_av *av,
 						fi_addr_t fi_addr)
 {

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.h
@@ -97,6 +97,12 @@ struct ibv_ah;
 struct ibv_ah *efa_test_implicit_addr_to_ibv_ah(struct fid_av *av,
 						fi_addr_t fi_addr);
 
+int efa_test_set_track_mr(int value);
+
+int efa_test_device_supports_rma(void);
+
+size_t efa_test_ope_list_count(struct fid_ep *ep);
+
 /**
  * @brief Get/set an RDM domain's shm_domain.
  */

--- a/prov/efa/test/gtest/efa_gtest_common_mocks.h
+++ b/prov/efa/test/gtest/efa_gtest_common_mocks.h
@@ -17,6 +17,8 @@ struct fi_mr_attr;
 struct efa_ibv_cq;
 struct efa_rdm_pke;
 struct ofi_bufpool;
+struct efa_qp;
+struct efa_ah;
 
 /*
  * X macro infrastructure for mock generation.
@@ -57,6 +59,36 @@ struct ofi_bufpool;
 	struct efa_rdm_pke *src, struct ofi_bufpool *pkt_pool, int alloc_type
 #define EFA_MOCK_ARGS_efa_rdm_pke_clone src, pkt_pool, alloc_type
 
+#define EFA_MOCK_PARAMS_efa_qp_post_recv \
+	struct efa_qp *qp, struct ibv_recv_wr *wr, struct ibv_recv_wr **bad
+#define EFA_MOCK_ARGS_efa_qp_post_recv qp, wr, bad
+
+#define EFA_MOCK_PARAMS_efa_qp_post_send                                        \
+	struct efa_qp *qp, const struct ibv_sge *sge_list,                     \
+		const struct ibv_data_buf *inline_data_list, size_t iov_count, \
+		bool use_inline, uintptr_t wr_id, uint64_t data,               \
+		uint64_t flags, struct efa_ah *ah, uint32_t qpn, uint32_t qkey
+#define EFA_MOCK_ARGS_efa_qp_post_send                                        \
+	qp, sge_list, inline_data_list, iov_count, use_inline, wr_id, data,   \
+		flags, ah, qpn, qkey
+
+#define EFA_MOCK_PARAMS_efa_qp_post_read                                       \
+	struct efa_qp *qp, const struct ibv_sge *sge_list, size_t sge_count,  \
+		uint32_t remote_key, uint64_t remote_addr, uintptr_t wr_id,   \
+		uint64_t flags, struct efa_ah *ah, uint32_t qpn, uint32_t qkey
+#define EFA_MOCK_ARGS_efa_qp_post_read \
+	qp, sge_list, sge_count, remote_key, remote_addr, wr_id, flags, ah, qpn, qkey
+
+#define EFA_MOCK_PARAMS_efa_qp_post_write                                      \
+	struct efa_qp *qp, const struct ibv_sge *sge_list, size_t sge_count,  \
+		const struct ibv_data_buf *inline_data_list, bool use_inline, \
+		uint32_t remote_key, uint64_t remote_addr, uintptr_t wr_id,   \
+		uint64_t data, uint64_t flags, struct efa_ah *ah,             \
+		uint32_t qpn, uint32_t qkey
+#define EFA_MOCK_ARGS_efa_qp_post_write                                  \
+	qp, sge_list, sge_count, inline_data_list, use_inline, remote_key, \
+		remote_addr, wr_id, data, flags, ah, qpn, qkey
+
 #define EFA_MOCK_PARAMS_efa_ibv_cq_start_poll \
 	struct efa_ibv_cq *ibv_cq, struct ibv_poll_cq_attr *attr
 #define EFA_MOCK_ARGS_efa_ibv_cq_start_poll ibv_cq, attr
@@ -81,11 +113,15 @@ struct ofi_bufpool;
 
 /* --- Function list --- */
 
-#define EFA_MOCK_FUNCTIONS(X)                            \
-	X(struct ibv_ah *, ibv_create_ah)                \
-	X(int, ibv_destroy_ah)                           \
-	X(int, efadv_query_ah)                           \
-	X(int, efa_av_reverse_av_add)                    \
+#define EFA_MOCK_FUNCTIONS(X)             \
+	X(struct ibv_ah *, ibv_create_ah) \
+	X(int, ibv_destroy_ah)            \
+	X(int, efadv_query_ah)            \
+	X(int, efa_av_reverse_av_add)     \
+	X(int, efa_qp_post_recv)          \
+	X(int, efa_qp_post_send)          \
+	X(int, efa_qp_post_read)          \
+	X(int, efa_qp_post_write)		\
 	X(int, efa_ibv_cq_start_poll)                    \
 	X(void, efa_ibv_cq_end_poll)                     \
 	X(enum ibv_wc_opcode, efa_ibv_cq_wc_read_opcode) \

--- a/prov/efa/test/gtest/efa_gtest_msg.cc
+++ b/prov/efa/test/gtest/efa_gtest_msg.cc
@@ -1,0 +1,119 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_common_helpers.h"
+#include "efa_gtest_common_mocks.h"
+#include "efa_gtest_common_resource.h"
+#include <gtest/gtest.h>
+
+using testing::_;
+using testing::Return;
+using testing::StrictMock;
+using testing::Test;
+using testing::Truly;
+
+class EfaMsgTest : public Test
+{
+	protected:
+	struct efa_resource resource = {};
+	StrictMock<MockEfa> mock_efa;
+	fi_addr_t peer_addr = FI_ADDR_NOTAVAIL;
+	uint8_t *local_buf = nullptr;
+	struct fid_mr *local_mr = nullptr;
+	void *local_desc = nullptr;
+	int prev_track_mr = 0;
+
+	void construct(size_t buf_size)
+	{
+		int ret;
+		struct fi_info *hints = efa_test_alloc_default_hints(
+			FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
+		ASSERT_NE(hints, nullptr);
+
+		efa_test_resource_construct(&resource, hints);
+		ASSERT_NE(resource.ep, nullptr);
+
+		local_buf = (uint8_t *) calloc(buf_size, 1);
+		ASSERT_NE(local_buf, nullptr);
+		ret = fi_mr_reg(resource.domain, local_buf, buf_size,
+				FI_SEND | FI_RECV, 0, 0, 0, &local_mr, NULL);
+		ASSERT_EQ(ret, 0) << "fi_mr_reg failed: " << fi_strerror(-ret);
+		local_desc = fi_mr_desc(local_mr);
+
+		peer_addr = efa_test_insert_self_gid_peer(resource.ep,
+							  resource.av);
+		ASSERT_NE(peer_addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
+
+		MockEfa::set(&mock_efa);
+	}
+
+	void SetUp() override
+	{
+		memset(&resource, 0, sizeof(resource));
+	}
+
+	void TearDown() override
+	{
+		MockEfa::set(nullptr);
+
+		if (local_mr) {
+			EXPECT_EQ(fi_close(&local_mr->fid), 0);
+			local_mr = nullptr;
+		}
+		free(local_buf);
+		local_buf = nullptr;
+
+		efa_test_resource_destruct(&resource);
+		efa_test_set_track_mr(prev_track_mr);
+	}
+};
+
+/**
+ * @brief Asserts that efa_post_send with track_mr posts a direct_ope which persists
+ */
+TEST_F(EfaMsgTest, send_success_keeps_direct_ope_alive)
+{
+	struct fi_context2 ctx = {};
+
+	prev_track_mr = efa_test_set_track_mr(1);
+
+	ASSERT_NO_FATAL_FAILURE(construct(4096));
+
+	auto wr_id_is_not_ctx = Truly([&ctx](uintptr_t wr_id) {
+		return wr_id != 0 && wr_id != (uintptr_t) &ctx;
+	});
+	EXPECT_CALL(mock_efa,
+		    efa_qp_post_send(_, _, _, 1, _, wr_id_is_not_ctx, _, _,
+				     _, _, _))
+		.WillOnce(Return(0));
+
+	int ret = fi_send(resource.ep, local_buf, 4096, local_desc, peer_addr,
+			  &ctx);
+	EXPECT_EQ(ret, 0);
+
+	EXPECT_EQ(efa_test_ope_list_count(resource.ep), 1u);
+}
+
+/**
+ * @brief Asserts that efa_post_recv with track_mr posts a direct_ope which persists
+ */
+TEST_F(EfaMsgTest, recv_success_keeps_direct_ope_alive)
+{
+	struct fi_context2 ctx = {};
+
+	prev_track_mr = efa_test_set_track_mr(1);
+
+	ASSERT_NO_FATAL_FAILURE(construct(4096));
+
+	auto wr_id_is_not_ctx = Truly([&ctx](const struct ibv_recv_wr *wr) {
+		return wr->wr_id != 0 && wr->wr_id != (uintptr_t) &ctx;
+	});
+	EXPECT_CALL(mock_efa, efa_qp_post_recv(_, wr_id_is_not_ctx, _))
+		.WillOnce(Return(0));
+
+	int ret = fi_recv(resource.ep, local_buf, 4096, local_desc, peer_addr,
+			  &ctx);
+	EXPECT_EQ(ret, 0);
+
+	EXPECT_EQ(efa_test_ope_list_count(resource.ep), 1u);
+}

--- a/prov/efa/test/gtest/efa_gtest_rma.cc
+++ b/prov/efa/test/gtest/efa_gtest_rma.cc
@@ -1,0 +1,132 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_common_helpers.h"
+#include "efa_gtest_common_mocks.h"
+#include "efa_gtest_common_resource.h"
+#include <gtest/gtest.h>
+#include <rdma/fi_rma.h>
+
+using testing::_;
+using testing::Return;
+using testing::StrictMock;
+using testing::Test;
+using testing::Truly;
+
+static constexpr uint64_t kRemoteAddr = 0x87654321;
+static constexpr uint32_t kRemoteKey = 123456;
+
+class EfaRmaTest : public Test
+{
+	protected:
+	struct efa_resource resource = {};
+	StrictMock<MockEfa> mock_efa;
+	fi_addr_t peer_addr = FI_ADDR_NOTAVAIL;
+	uint8_t *local_buf = nullptr;
+	struct fid_mr *local_mr = nullptr;
+	void *local_desc = nullptr;
+	int prev_track_mr = 0;
+
+	void construct(size_t buf_size)
+	{
+		int ret;
+		struct fi_info *hints = efa_test_alloc_default_hints(
+			FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
+		ASSERT_NE(hints, nullptr);
+		hints->caps |= FI_RMA;
+		hints->mode |= FI_RX_CQ_DATA;
+
+		efa_test_resource_construct(&resource, hints);
+		ASSERT_NE(resource.ep, nullptr);
+
+		local_buf = (uint8_t *) calloc(buf_size, 1);
+		ASSERT_NE(local_buf, nullptr);
+		ret = fi_mr_reg(resource.domain, local_buf, buf_size,
+				FI_SEND | FI_RECV | FI_READ | FI_WRITE, 0, 0, 0,
+				&local_mr, NULL);
+		ASSERT_EQ(ret, 0) << "fi_mr_reg failed: " << fi_strerror(-ret);
+		local_desc = fi_mr_desc(local_mr);
+
+		peer_addr = efa_test_insert_self_gid_peer(resource.ep,
+							  resource.av);
+		ASSERT_NE(peer_addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
+
+		MockEfa::set(&mock_efa);
+	}
+
+	void SetUp() override
+	{
+		if (!efa_test_device_supports_rma())
+			GTEST_SKIP()
+				<< "device does not support RDMA read+write";
+
+		memset(&resource, 0, sizeof(resource));
+	}
+
+	void TearDown() override
+	{
+		MockEfa::set(nullptr);
+
+		if (local_mr) {
+			EXPECT_EQ(fi_close(&local_mr->fid), 0);
+			local_mr = nullptr;
+		}
+		free(local_buf);
+		local_buf = nullptr;
+
+		efa_test_resource_destruct(&resource);
+		efa_test_set_track_mr(prev_track_mr);
+	}
+};
+
+/**
+ * @brief Asserts that efa_rma_post_read with track_mr posts a direct_ope which persists
+ */
+TEST_F(EfaRmaTest, read_success_keeps_direct_ope_alive)
+{
+	struct fi_context2 ctx = {};
+
+	prev_track_mr = efa_test_set_track_mr(1);
+
+	ASSERT_NO_FATAL_FAILURE(construct(4096));
+
+	auto wr_id_is_not_ctx = Truly([&ctx](uintptr_t wr_id) {
+		return wr_id != 0 && wr_id != (uintptr_t) &ctx;
+	});
+	EXPECT_CALL(mock_efa,
+		    efa_qp_post_read(_, _, 1, kRemoteKey, kRemoteAddr,
+				     wr_id_is_not_ctx, _, _, _, _))
+		.WillOnce(Return(0));
+
+	int ret = fi_read(resource.ep, local_buf, 4096, local_desc, peer_addr,
+			  kRemoteAddr, kRemoteKey, &ctx);
+	EXPECT_EQ(ret, 0);
+
+	EXPECT_EQ(efa_test_ope_list_count(resource.ep), 1u);
+}
+
+/**
+ * @brief Asserts that efa_rma_post_write with track_mr posts a direct_ope which persists
+ */
+TEST_F(EfaRmaTest, write_success_keeps_direct_ope_alive)
+{
+	struct fi_context2 ctx = {};
+
+	prev_track_mr = efa_test_set_track_mr(1);
+
+	ASSERT_NO_FATAL_FAILURE(construct(4096));
+
+	auto wr_id_is_not_ctx = Truly([&ctx](uintptr_t wr_id) {
+		return wr_id != 0 && wr_id != (uintptr_t) &ctx;
+	});
+	EXPECT_CALL(mock_efa,
+		    efa_qp_post_write(_, _, 1, _, _, kRemoteKey, kRemoteAddr,
+				      wr_id_is_not_ctx, _, _, _, _, _))
+		.WillOnce(Return(0));
+
+	int ret = fi_write(resource.ep, local_buf, 4096, local_desc, peer_addr,
+			   kRemoteAddr, kRemoteKey, &ctx);
+	EXPECT_EQ(ret, 0);
+
+	EXPECT_EQ(efa_test_ope_list_count(resource.ep), 1u);
+}


### PR DESCRIPTION
if track_mr is on, a direct_ope is allocated on post of 
send, recv, read or write operations, which should persist 
until the corresponding completion handler frees it. 
This is only done correctly by efa_post_recv, whereas 
the other three post functions prematurely and unconditionally 
releases the direct_ope due to a fallthrough in the goto clauses.

This would have caused a potential use-after-free in cq_read_entry.

Four unit tests are added to assert this behavior is now as expected.