### PR TITLE
  [v2.6.x] fabtests: Remove unused function and fields 

### DIFF
--- a/fabtests/common/hmem_cuda.c
+++ b/fabtests/common/hmem_cuda.c
@@ -515,22 +515,6 @@ int ft_cuda_copy_from_hmem(uint64_t device, void *dst, const void *src,
 	return -FI_EIO;
 }
 
-/* TODO: Make get_base_addr a general hmem ops API */
-static
-int ft_cuda_get_base_addr(const void *ptr, size_t len, void **base, size_t *size)
-{
-	CUresult cu_result;
-
-	cu_result = cuda_ops.cuMemGetAddressRange(
-				(CUdeviceptr *)base,
-				size, (CUdeviceptr) ptr);
-	if (cu_result == CUDA_SUCCESS)
-		return FI_SUCCESS;
-
-	ft_cuda_driver_api_print_error(cu_result, "cuMemGetAddressRange");
-	return -FI_EIO;
-}
-
 /**
  * @brief Get dmabuf fd and offset for a given cuda memory allocation
  *

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -420,14 +420,10 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 		return err;
 	}
 
-	av->used_implicit--;
-
 	err = efa_av_reverse_av_add(av, &av->cur_reverse_av, &av->prv_reverse_av,
 				    explicit_conn);
 	if (err)
 		return err;
-
-	av->used_explicit++;
 
 	/* Handle AH LRU list and refcnt */
 	assert(!dlist_empty(&ah->implicit_conn_list));
@@ -932,8 +928,6 @@ int efa_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 	av->domain = efa_domain;
 	av->type = attr->type;
 	av->implicit_av_size = efa_env.implicit_av_size;
-	av->used_implicit = 0;
-	av->used_explicit = 0;
 	av->shm_used = 0;
 
 	*av_fid = &av->util_av.av_fid;

--- a/prov/efa/src/efa_av.h
+++ b/prov/efa/src/efa_av.h
@@ -61,8 +61,6 @@ struct efa_prv_reverse_av {
 struct efa_av {
 	struct fid_av *shm_rdm_av;
 	struct efa_domain *domain;
-	size_t used_explicit;
-	size_t used_implicit;
 	size_t shm_used;
 	enum fi_av_type type;
 	/* cur_reverse_av is a map from (ahn + qpn) to current (latest) efa_conn.

--- a/prov/efa/src/efa_conn.c
+++ b/prov/efa/src/efa_conn.c
@@ -314,8 +314,6 @@ struct efa_conn *efa_conn_alloc(struct efa_av *av, struct efa_ep_addr *raw_addr,
 		goto err_release;
 	}
 
-	insert_implicit_av ? av->used_implicit++ : av->used_explicit++;
-
 	return conn;
 
 err_release:
@@ -411,8 +409,6 @@ void efa_conn_release(struct efa_av *av, struct efa_conn *conn,
 	efa_ah_release(av->domain, conn->ah, release_from_implicit_av);
 
 	efa_conn_release_util_av(av, conn, release_from_implicit_av);
-
-	release_from_implicit_av ? av->used_implicit-- : av->used_explicit--;
 }
 
 /**
@@ -449,7 +445,6 @@ void efa_conn_release_ah_unsafe(struct efa_av *av, struct efa_conn *conn,
 
 	release_from_implicit_av ? conn->ah->implicit_refcnt-- :
 				   conn->ah->explicit_refcnt--;
-	release_from_implicit_av ? av->used_implicit-- : av->used_explicit--;
 }
 
 void efa_conn_ep_peer_map_insert(struct efa_conn *conn, struct efa_conn_ep_peer_map_entry *map_entry)


### PR DESCRIPTION
backport https://github.com/ofiwg/libfabric/pull/12516 and https://github.com/ofiwg/libfabric/pull/12513