### PR TITLE
[v2.6.x] fabtests/efa: add short iteration type for test_rdm_bw_mt_thread_completion

### DIFF
--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -331,8 +331,11 @@ def test_rmd_tagged_pingpong_truncate_error(cmdline_args, completion_semantic):
 @pytest.mark.functional
 @pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.parametrize("num_eps", [8, 16, 32])
-def test_rdm_bw_mt_thread_completion(cmdline_args, num_eps, fabric):
+@pytest.mark.parametrize("iteration_type",
+                         [pytest.param("short", marks=pytest.mark.short),
+                          pytest.param("standard", marks=pytest.mark.standard)])
+def test_rdm_bw_mt_thread_completion(cmdline_args, iteration_type, num_eps, fabric):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, f"fi_rdm_bw_mt -g -n {num_eps} --threading completion",
-                            "standard", "transmit_complete", fabric=fabric)
+                            iteration_type, "transmit_complete", fabric=fabric)
     test.run()

--- a/fabtests/scripts/runfabtests.py
+++ b/fabtests/scripts/runfabtests.py
@@ -41,6 +41,7 @@ def fabtests_testsets_to_pytest_markers(fabtests_testsets, run_mode=None):
 
     test_set = set()
     test_list = fabtests_testsets.split(",")
+    exclude_standard = False
 
     # use set() to remove duplicate test set
     for test in test_list:
@@ -49,6 +50,7 @@ def fabtests_testsets_to_pytest_markers(fabtests_testsets, run_mode=None):
             test_set.add("functional")
             test_set.add("short")
             test_set.add("ubertest_quick")
+            exclude_standard = True
         elif test =="ubertest":
             test_set.add("ubertest_quick")
         elif test == "all":
@@ -68,6 +70,9 @@ def fabtests_testsets_to_pytest_markers(fabtests_testsets, run_mode=None):
             markers = test[:]
         else:
             markers += " or " + test
+
+    if exclude_standard:
+        markers = "(" + markers + ") and (not standard)"
 
     if run_mode:
         if run_mode == "serial":


### PR DESCRIPTION
backport https://github.com/ofiwg/libfabric/pull/12534 and https://github.com/ofiwg/libfabric/pull/12543