### PR TITLE
core: Add shared ofi_get_local_rank_info() utility

### DIFF
--- a/include/ofi.h
+++ b/include/ofi.h
@@ -460,6 +460,8 @@ uint64_t ofi_get_realtime_ns(void);
 uint64_t ofi_get_realtime_ms(void);
 uint64_t ofi_get_realtime_us(void);
 
+void ofi_get_local_rank_info(int *local_rank_count, int *local_rank);
+
 static inline uint64_t ofi_timeout_time(int timeout)
 {
 	return (timeout >= 0) ? ofi_gettime_ms() + timeout : 0;

--- a/prov/mrail/src/mrail_init.c
+++ b/prov/mrail/src/mrail_init.c
@@ -126,11 +126,10 @@ static int mrail_parse_env_vars(void)
 	 * Local rank is used to set the default tx rail when fixed mapping
 	 * is used.
 	 */
-	str = getenv("MPI_LOCALRANKID");
-	if (!str)
-		str = getenv("OMPI_COMM_WORLD_LOCAL_RANK");
-	if (str)
-		mrail_local_rank = atoi(str);
+	int local_rank = -1;
+	ofi_get_local_rank_info(NULL, &local_rank);
+	if (local_rank >= 0)
+		mrail_local_rank = local_rank;
 
 	return 0;
 }

--- a/prov/psm2/src/psmx2_util.c
+++ b/prov/psm2/src/psmx2_util.c
@@ -199,27 +199,22 @@ int psmx2_errno(int err)
 
 /*
  * PSM context sharing requires some information from the MPI process manager.
- * Try to get the needed information from the environment.
+ * Try to get the needed information from the environment, normalizing it
+ * into MPI_LOCALNRANKS/MPI_LOCALRANKID if not already set.
  */
 void psmx2_query_mpi(void)
 {
-	char *s;
 	char env[32];
-	int local_size = -1;
-	int local_rank = -1;
+	int local_size, local_rank;
 
-	/* Check Open MPI */
-	if ((s = getenv("OMPI_COMM_WORLD_LOCAL_SIZE"))) {
-		local_size = atoi(s);
-		if ((s = getenv("OMPI_COMM_WORLD_LOCAL_RANK")))
-			local_rank = atoi(s);
+	ofi_get_local_rank_info(&local_size, &local_rank);
+	if (local_size >= 0) {
 		snprintf(env, sizeof(env), "%d", local_size);
 		setenv("MPI_LOCALNRANKS", env, 0);
+	}
+	if (local_rank >= 0) {
 		snprintf(env, sizeof(env), "%d", local_rank);
 		setenv("MPI_LOCALRANKID", env, 0);
-		return;
 	}
-
-	/* TODO: check other MPI */
 }
 

--- a/prov/psm3/psm3/utils/utils_debug.c
+++ b/prov/psm3/psm3/utils/utils_debug.c
@@ -71,6 +71,11 @@
 #include "psm_user.h"
 #include "../psm_log.h"
 
+/* Declared in libfabric core (include/ofi.h); avoid including that header
+   here since it pulls in headers that conflict with this file's free()
+   macro redefinition. */
+void ofi_get_local_rank_info(int *local_rank_count, int *local_rank);
+
 unsigned psm3_dbgmask = __HFI_DEBUG_DEFAULT;
 char psm3_mylabel[1024];
 static int psm3_myrank = -1;
@@ -182,36 +187,13 @@ static void psm3_init_mylabel(void)
 			psm3_myrank_count = val;
 	}
 
-	if ((((e = getenv("MPI_LOCALRANKID")) && *e))	// MPICH and IMPI
-	    || (((e = getenv("OMPI_COMM_WORLD_LOCAL_RANK")) && *e)) // OMPI
-	    || (((e = getenv("MPI_LOCALRANKID")) && *e)) // Platform MPI
-	    // N/A | (((e = getenv("MPIRUN_TBD")) && *e)) // older MPICH
-	    || (((e = getenv("PSC_MPI_NODE_RANK")) && *e)) // pathscale MPI
-	    || (((e = getenv("LOCAL_RANK")) && *e)) // pyTorch torchrun
-	    || (((e = getenv("SLURM_LOCALID")) && *e)) // SLURM
-	    || (((e = getenv("CCL_LOCAL_RANK")) && *e)) // oneCCL 1 node w/o launcher
-	) {
-		char *ep;
-		unsigned long val;
-		val = strtoul(e, &ep, 10);
-		if (ep != e) /* valid conversion */
-			psm3_mylocalrank = val;
-	}
-
-	if ((((e = getenv("MPI_LOCALNRANKS")) && *e))	// MPICH and IMPI
-	    || (((e = getenv("OMPI_COMM_WORLD_LOCAL_SIZE")) && *e)) // OMPI
-	    || (((e = getenv("MPI_LOCALNRANKS")) && *e)) // Platform MPI
-	    // N/A || (((e = getenv("MPIRUN_TBD")) && *e)) // older MPICH
-	    || (((e = getenv("PSC_MPI_PPN")) && *e)) // pathscale MPI
-	    || (((e = getenv("LOCAL_WORLD_SIZE")) && *e)) // pyTorch torchrun
-	    || (((e = getenv("SLURM_NTASKS_PER_NODE")) && *e)) // SLURM
-	    || (((e = getenv("CCL_LOCAL_SIZE")) && *e)) // oneCCL 1 node w/o launcher
-	) {
-		char *ep;
-		unsigned long val;
-		val = strtoul(e, &ep, 10);
-		if (ep != e) /* valid conversion */
-			psm3_mylocalrank_count = val;
+	{
+		int rank, count;
+		ofi_get_local_rank_info(&count, &rank);
+		if (rank >= 0)
+			psm3_mylocalrank = rank;
+		if (count >= 0)
+			psm3_mylocalrank_count = count;
 	}
 
 	if ((((e = getenv("PMI_RANK")) && *e))	// MPICH and *_SIZE

--- a/src/common.c
+++ b/src/common.c
@@ -302,6 +302,52 @@ uint32_t ofi_generate_seed(void)
 	return rand_seed;
 }
 
+static bool ofi_parse_env_int(const char *name, int *out)
+{
+	const char *e = getenv(name);
+	if (!e || !*e)
+		return false;
+
+	char *ep;
+	long val = strtol(e, &ep, 10);
+	if (ep == e)
+		return false;
+
+	*out = (int) val;
+	return true;
+}
+
+void ofi_get_local_rank_info(int *local_rank_count, int *local_rank)
+{
+	static const struct {
+		const char *count_var;
+		const char *rank_var;
+	} launchers[] = {
+		{ "MPI_LOCALNRANKS", "MPI_LOCALRANKID" },
+		{ "OMPI_COMM_WORLD_LOCAL_SIZE", "OMPI_COMM_WORLD_LOCAL_RANK" },
+		{ "PSC_MPI_PPN", "PSC_MPI_NODE_RANK" },
+		{ "LOCAL_WORLD_SIZE", "LOCAL_RANK" },
+		{ "SLURM_NTASKS_PER_NODE", "SLURM_LOCALID" },
+		{ "CCL_LOCAL_SIZE", "CCL_LOCAL_RANK" },
+	};
+
+	if (local_rank_count)
+		*local_rank_count = -1;
+	if (local_rank)
+		*local_rank = -1;
+
+	for (size_t i = 0; i < ARRAY_SIZE(launchers); i++) {
+		int count;
+		if (ofi_parse_env_int(launchers[i].count_var, &count) && count > 0) {
+			if (local_rank_count)
+				*local_rank_count = count;
+			if (local_rank)
+				ofi_parse_env_int(launchers[i].rank_var, local_rank);
+			return;
+		}
+	}
+}
+
 uint64_t ofi_get_realtime_ns(void)
 {
 	struct timespec now;


### PR DESCRIPTION
Multiple providers (psm2, psm3, mrail) each implement their own bespoke
getenv()-based scanning of launcher-provided local rank count and
local rank ID environment variables, used for local decisions such as
context sharing, rail/NIC selection, or default transmit rail
assignment.

This adds a shared core utility, `ofi_get_local_rank_info()`, covering
the launcher variable pairs used across these providers (MPICH/IMPI,
Open MPI, pathscale MPI, PyTorch torchrun, SLURM, oneCCL), and converts
psm2, psm3, and mrail to use it instead of their own duplicated scans.

Both outputs are optional (`NULL`-safe) and set to -1 when not found,
matching the sentinel convention already used by prov/psm3's
`psm3_get_mylocalrank()`/`psm3_get_mylocalrank_count()`. Rank and count
are plain `int`, matching MPI's own `MPI_Comm_rank()`/`MPI_Comm_size()`
signature and the existing psm3 precedent.

Commits:
- core: Add ofi_get_local_rank_info() shared local rank/count utility
- prov/mrail: Use ofi_get_local_rank_info() for local rank lookup
- prov/psm2: Use ofi_get_local_rank_info() to normalize MPI env vars
- prov/psm3: Use ofi_get_local_rank_info() for local rank/count lookup

Each provider conversion is a behavior-preserving refactor (same env
vars, same fallback order, same sentinel semantics), verified by
building each provider individually.
