### PR TITLE
prov/efa: remove the pps feature flag gate

### DIFF
--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -161,7 +161,7 @@ def test_efa_rma_bw_high_pps(cmdline_args, operation_type, mem_type, rma_fabric)
                                memory_type=mem_type,
                                message_size="all",
                                fabric=rma_fabric,
-                               additional_env="FI_EFA_ENABLE_HIGH_PPS=1 FI_EFA_ENABLE_SHM_TRANSFER=0")
+                               additional_env="FI_EFA_ENABLE_SHM_TRANSFER=0")
 
 
 # Testing the batch mode of fi_efa_rma_bw (--post-list) which batch multiple WQEs with FI_MORE

--- a/prov/efa/src/efa_data_path_direct_entry.h
+++ b/prov/efa/src/efa_data_path_direct_entry.h
@@ -645,7 +645,7 @@ efa_data_path_direct_post_write(
 	}
 
 
-	if (efa_env.enable_high_pps && (flags & FI_EFA_WR_HIGH_PPS))
+	if (flags & FI_EFA_WR_HIGH_PPS)
 		efa_send_wr_set_processing_hint_high_pps(meta_desc);
 
 	/* Set remote memory information */

--- a/prov/efa/src/efa_data_path_ops.h
+++ b/prov/efa/src/efa_data_path_ops.h
@@ -162,7 +162,7 @@ efa_ibv_post_write(
 	ibv_wr_set_ud_addr(qp->ibv_qp_ex, ah->ibv_ah, qpn, qkey);
 
 #if HAVE_EFADV_WR_PROCESSING_HINTS
-	if (efa_env.enable_high_pps && (flags & FI_EFA_WR_HIGH_PPS))
+	if (flags & FI_EFA_WR_HIGH_PPS)
 		efadv_wr_set_processing_hints(efadv_qp_from_ibv_qp_ex(qp->ibv_qp_ex),
 					     EFADV_WR_PROCESSING_HINT_BURST_PPS_SENSITIVE);
 #endif

--- a/prov/efa/src/efa_env.c
+++ b/prov/efa/src/efa_env.c
@@ -42,7 +42,6 @@ struct efa_env efa_env = {
 	.implicit_av_size = 0,
 	.track_mr = 0,
 	.use_hw_cntr = 0,
-	.enable_high_pps = 0,
 };
 
 /**
@@ -58,11 +57,6 @@ static void efa_env_unregistered_param_get(void)
 	tmp = getenv("FI_EFA_USE_HW_CNTR");
 	if (tmp)
 		efa_env.use_hw_cntr = atoi(tmp);
-
-	/* Read enable_high_pps directly from environment variable to avoid showing in fi_info -e */
-	tmp = getenv("FI_EFA_ENABLE_HIGH_PPS");
-	if (tmp)
-		efa_env.enable_high_pps = atoi(tmp);
 }
 
 /* @brief Read and store the FI_EFA_* environment variables.

--- a/prov/efa/src/efa_env.h
+++ b/prov/efa/src/efa_env.h
@@ -80,11 +80,6 @@ struct efa_env {
 	 */
 	int track_mr;
 	int use_hw_cntr;
-	/**
-	 * Enable high PPS (packets per second) optimization hints.
-	 * This feature allows applications to provide hints for burst PPS sensitive workloads.
-	 */
-	int enable_high_pps;
 };
 
 extern struct efa_env efa_env;

--- a/prov/efa/test/efa_unit_test_rma.c
+++ b/prov/efa/test/efa_unit_test_rma.c
@@ -765,9 +765,6 @@ static void test_efa_ibv_post_write_processing_hints_impl(struct efa_resource *r
 	efadv_qp = efadv_qp_from_ibv_qp_ex(ibv_qpx);
 	efadv_qp->wr_set_processing_hints = efa_mock_efadv_wr_set_processing_hints;
 
-	enable_high_pps_orig = efa_env.enable_high_pps;
-	efa_env.enable_high_pps = true;
-
 	if (flags & FI_EFA_WR_HIGH_PPS) {
 		expect_function_call(efa_mock_efadv_wr_set_processing_hints);
 		expect_value(efa_mock_efadv_wr_set_processing_hints, hints,
@@ -782,7 +779,6 @@ static void test_efa_ibv_post_write_processing_hints_impl(struct efa_resource *r
 	efa_ibv_post_write(qp, &sge, 1, 123456, 0x87654321, 0, 0,
 			   flags, &fake_ah, 0, 0);
 
-	efa_env.enable_high_pps = enable_high_pps_orig;
 	efa_unit_test_buff_destruct(&local_buff);
 }
 #endif


### PR DESCRIPTION
pps is already an opt-in feature via flag FI_EFA_WR_HIGH_PPS, remove the libfabric feature gate and leave this gated by applications

This reverts commit 748af20ab3f66251785ef3af8340f06ec9696889.