### PR TITLE
fabtests/scripts: Add -m marker expression option to runfabtests.py

### DIFF
--- a/fabtests/pytest/efa/test_mr_abort.py
+++ b/fabtests/pytest/efa/test_mr_abort.py
@@ -13,7 +13,7 @@ MR_ABORT_NUM_MRS = 2046
 
 # --- Test: abort (RMA) ---
 @pytest.mark.functional
-@pytest.mark.fabric(params=["efa-direct", "efa"])
+@pytest.mark.fabric(params=["efa-direct"])  # TODO add test for efa fabric
 @pytest.mark.parametrize("rma_op", ["write", "read", "writedata"])
 @pytest.mark.parametrize("cancel_order", ["reverse", "random"])
 @pytest.mark.parametrize("close_side", ["initiator", "target"])
@@ -43,7 +43,7 @@ def test_mr_abort(cmdline_args, rma_fabric, rma_op, cancel_order, close_side, op
 
 # --- Test: partial (2 MRs on same buffer) ---
 @pytest.mark.functional
-@pytest.mark.fabric(params=["efa-direct", "efa"])
+@pytest.mark.fabric(params=["efa-direct"]) # TODO add test for efa fabric
 @pytest.mark.parametrize("rma_op", ["write", "read", "writedata"])
 @pytest.mark.parametrize("message_size", [
     4096,
@@ -202,7 +202,7 @@ def abort_owes_rx_completion(protocol):
 
 # --- Test: send ---
 @pytest.mark.functional
-@pytest.mark.fabric(params=["efa-direct", "efa"])
+@pytest.mark.fabric(params=["efa-direct"]) # TODO add test for efa fabric
 @pytest.mark.parametrize("cancel_order", ["reverse", "random"])
 @pytest.mark.parametrize("close_side", ["initiator"]) # TODO add target
 @pytest.mark.parametrize("ops_per_mr", [1, 4])
@@ -241,7 +241,7 @@ def test_mr_abort_send(cmdline_args, fabric, cancel_order, close_side,
 
 # --- Test: tagged ---
 @pytest.mark.functional
-@pytest.mark.fabric(params=["efa-direct", "efa"])
+@pytest.mark.fabric(params=["efa-direct"])  # TODO add test for efa fabric
 @pytest.mark.parametrize("cancel_order", ["reverse", "random"])
 @pytest.mark.parametrize("close_side", ["initiator"]) # TODO add target
 @pytest.mark.parametrize("ops_per_mr", [1, 4])

--- a/fabtests/pytest/efa/test_mr_abort.py
+++ b/fabtests/pytest/efa/test_mr_abort.py
@@ -1,7 +1,9 @@
 import pytest
 from common import ClientServerTest
 
-pytestmark = pytest.mark.skip(reason="Skipping test due to bug")
+
+pytestmark = pytest.mark.pre_release
+
 
 # fi_mr_abort fabtest will allocate MR_ABORT_NUM_MRS and attempt
 # to post N transfers per MR until the provider returns -FI_EAGAIN

--- a/fabtests/pytest/pytest.ini
+++ b/fabtests/pytest/pytest.ini
@@ -18,6 +18,7 @@ markers =
     fabric: decorator declaring the set of libfabric fabric values a test runs on
     hw_cntr: test requires fi_efa_hw_cntr binary (built with efadv_create_comp_cntr)
     gda: test requires fi_efa_gda binary (built with --enable-efagda)
+    pre_release: test requires pre-release firmware, skip unless explicitly requested
 junit_suite_name = fabtests
 junit_logging = all
 junit_log_passing_tests = true

--- a/fabtests/scripts/runfabtests.py
+++ b/fabtests/scripts/runfabtests.py
@@ -168,6 +168,10 @@ def fabtests_args_to_pytest_args(fabtests_args, shared_options, run_mode):
         pytest_args.append("--tb=no")
 
     markers = fabtests_testsets_to_pytest_markers(fabtests_args.testsets, run_mode)
+    if fabtests_args.marker_expression:
+        # AND the user-supplied marker expression onto the expression
+        # derived from the test sets (-t), e.g. -t quick -m 'not pre_release'
+        markers = "(" + markers + ") and (" + fabtests_args.marker_expression + ")"
     pytest_args.append("-m")
     pytest_args.append(markers)
 
@@ -298,6 +302,10 @@ def main():
     parser.add_argument("client_id", type=str, help="client ip or hostname")
     parser.add_argument("-t", dest="testsets", type=str, default="quick",
                         help="test set(s): all,quick,unit,functional,standard,short,ubertest,cuda_memory,neuron_memory (default quick)")
+    parser.add_argument("-m", "--marker-expression", dest="marker_expression", type=str,
+                        help="pytest marker expression ANDed onto the expression "
+                             "derived from -t, e.g. -t quick -m 'not pre_release' "
+                             "runs the quick set excluding pre_release tests.")
     parser.add_argument("-v", dest="verbose", action="count", default=0,
                         help="verbosity level"
                              "-v: print extra info for failed test(s)"

--- a/fabtests/scripts/runfabtests.py
+++ b/fabtests/scripts/runfabtests.py
@@ -13,6 +13,11 @@ import pytest
 from junitparser import JUnitXml
 from pytest import ExitCode
 
+# Marks whose tests only run when explicitly requested via -t or -m.
+# Tests carrying these marks are excluded from every other run, including
+# the default (no arguments) run.
+OPT_IN_MARKS = ["pre_release"]
+
 
 def get_option_longform(option_name, option_params):
     '''
@@ -172,6 +177,16 @@ def fabtests_args_to_pytest_args(fabtests_args, shared_options, run_mode):
         # AND the user-supplied marker expression onto the expression
         # derived from the test sets (-t), e.g. -t quick -m 'not pre_release'
         markers = "(" + markers + ") and (" + fabtests_args.marker_expression + ")"
+
+    # Opt-in marks are excluded from every run unless the user explicitly
+    # names them in -t or -m, e.g. -t pre_release or -m pre_release.
+    for mark in OPT_IN_MARKS:
+        if mark in fabtests_args.testsets.split(","):
+            continue
+        if fabtests_args.marker_expression and mark in fabtests_args.marker_expression:
+            continue
+        markers = "(" + markers + ") and (not " + mark + ")"
+
     pytest_args.append("-m")
     pytest_args.append(markers)
 


### PR DESCRIPTION
Add a -m/--marker-expression option that is ANDed onto the pytest marker expression derived from the test sets (-t). This allows narrowing a run without defining a new test set, e.g.:

    runfabtests.py -t quick -m 'not pre_release' efa server client

runs the quick test set while excluding tests marked pre_release. When -m is omitted, behavior is unchanged.