### PR TITLE
prov/efa: fix accidentally nullifying 0-th slot of qp_table

### DIFF
--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -77,6 +77,7 @@ int efa_base_ep_destruct_qp_unsafe(struct efa_base_ep *base_ep)
 {
 	struct efa_domain *domain;
 	struct efa_qp *qp = base_ep->qp;
+	struct efa_qp **qp_table_slot;
 	uint32_t qp_num;
 	struct efa_cq *tx_cq, *rx_cq;
 	int err;
@@ -95,7 +96,9 @@ int efa_base_ep_destruct_qp_unsafe(struct efa_base_ep *base_ep)
 		if (rx_cq != tx_cq)
 			efa_cq_invalidate_cur_wq(rx_cq, qp);
 		efa_qp_destruct(qp);
-		domain->device->qp_table[qp_num & domain->device->qp_table_sz_m1] = NULL;
+		qp_table_slot = &domain->device->qp_table[qp_num & domain->device->qp_table_sz_m1];
+		assert(!*qp_table_slot || *qp_table_slot == qp);
+		*qp_table_slot = NULL;
 		base_ep->qp = NULL;
 	}
 
@@ -333,6 +336,7 @@ int efa_qp_create(struct efa_qp **qp, struct ibv_qp_init_attr_ex *init_attr_ex,
 		return -errno;
 	}
 
+	(*qp)->qp_num = (*qp)->ibv_qp->qp_num;
 	(*qp)->ibv_qp_ex = ibv_qp_to_qp_ex((*qp)->ibv_qp);
 	/* Initialize it explicitly for safety */
 	(*qp)->data_path_direct_enabled = false;
@@ -528,8 +532,6 @@ int efa_base_ep_enable_qp(struct efa_base_ep *base_ep, struct efa_qp *qp)
 	err = efa_base_ep_modify_qp_rst2rts(base_ep, qp);
 	if (err)
 		return err;
-
-	qp->qp_num = qp->ibv_qp->qp_num;
 
 #if HAVE_EFA_DATA_PATH_DIRECT
 	if (qp->data_path_direct_enabled) {


### PR DESCRIPTION
efa_base_ep_destruct_qp_unsafe can be called after efa_base_ep_enable_qp
errors out. Some error returns happen before qp_num is assigned, meaning
qp->qp_num == 0. The destruct function is then called and nullifies
qp_table[0 & qp_table_sz_m1], which can accidentally nullify another live
qp whose qpn is an integer multiple of qp_table_sz_m1. This commit fixes
this edge case by moving the assignment of qp->qp_num up, immediately
after ibv_qp is created. An assert is added in the unsafe qp destruct.