### PR TITLE
prov/efa: refactor EFA gtest unit test suite

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -86,9 +86,9 @@ _efa_files = \
 	prov/efa/src/rdm/efa_rdm_util.c \
 	prov/efa/src/rdm/efa_rdm_mr.c
 
-if ENABLE_EFA_UNIT_TEST
+if ENABLE_EFA_DATA_PATH_OPS_STUB
 _efa_files += prov/efa/test/efa_unit_test_data_path_ops.c
-endif ENABLE_EFA_UNIT_TEST
+endif ENABLE_EFA_DATA_PATH_OPS_STUB
 
 _efa_headers = \
 	prov/efa/src/efa.h \

--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -368,7 +368,6 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 
 	AS_IF([test x"$enable_efa_unit_test" != xno ],
 	[
-		efa_unit_test=1
 		FI_CHECK_PACKAGE(cmocka,
 			[cmocka.h],
 			[cmocka],
@@ -385,13 +384,9 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 				#include <setjmp.h>
 			])
 		cmocka_rpath+=" -R${cmocka_LDFLAGS:3} "
-	],
-	[
-		efa_unit_test=0
 	])
 
 	AC_SUBST(cmocka_rpath)
-	AC_DEFINE_UNQUOTED([EFA_UNIT_TEST], [$efa_unit_test], [EFA unit testing])
 
 	AM_CONDITIONAL([HAVE_EFADV_CQ_EX], [ test $efadv_support_extended_cq = 1])
 	AM_CONDITIONAL([HAVE_EFADV_QUERY_MR], [ test $have_efadv_query_mr = 1])
@@ -474,6 +469,12 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	AC_SUBST(gtest_LDFLAGS)
 	AC_SUBST(gtest_LIBS)
 	AM_CONDITIONAL([ENABLE_EFA_GTEST], [ test x"$enable_efa_gtest" != xno])
+
+	AS_IF([test x"$enable_efa_unit_test" != xno || test x"$enable_efa_gtest" != xno],
+		[efa_unit_test=1], [efa_unit_test=0])
+	AC_DEFINE_UNQUOTED([EFA_UNIT_TEST], [$efa_unit_test],
+		[Expose EFA data-path static-inline ops as linkable stubs for unit tests])
+	AM_CONDITIONAL([ENABLE_EFA_DATA_PATH_OPS_STUB], [test $efa_unit_test = 1])
 
 	AC_SUBST(efa_CPPFLAGS)
 	AC_SUBST(efa_LDFLAGS)

--- a/prov/efa/test/gtest/AGENTS.md
+++ b/prov/efa/test/gtest/AGENTS.md
@@ -104,9 +104,11 @@ contract or copy a pattern from a nearby test when the docs can settle it.
   `efa_test_resource_destruct`, or `self_ah`'s real destroy routes into the mock
   as an unexpected call (see `EfaConnTest`).
 - **Static-inline functions** (`efa_qp_post_*`, `efa_ibv_cq_*` in
-  `efa_data_path_ops.h`) are only linkable under `#if EFA_UNIT_TEST`. Mocking them
-  requires configuring with **both** `--enable-efa-unit-test` AND
-  `--enable-efa-gtest`; gtest-only silently binds `--wrap` to nothing → false pass.
+  `efa_data_path_ops.h`) are only linkable under `#if EFA_UNIT_TEST`, which turns
+  their `static inline` bodies into extern decls backed by the stub
+  `efa_unit_test_data_path_ops.c`. `EFA_UNIT_TEST` is derived from *either* test
+  suite (`--enable-efa-gtest` OR `--enable-efa-unit-test`), so `--enable-efa-gtest`
+  alone makes them `--wrap`-able — the gtest suite does **not** need cmocka.
 
 ### C/C++ bridge
 

--- a/prov/efa/test/gtest/AGENTS.md
+++ b/prov/efa/test/gtest/AGENTS.md
@@ -1,0 +1,283 @@
+# AGENTS.md — EFA provider work
+
+Companion to [prov/efa/test/gtest/README.md](prov/efa/test/gtest/README.md).
+
+## Ground rules (all skills)
+
+- **For the public API contract, read the man pages ([man/](man/)), don't
+  reverse-engineer it from the code.** The `man/*.md` sources (e.g.
+  [man/fi_cq.3.md](man/fi_cq.3.md), [man/fi_rma.3.md](man/fi_rma.3.md)) are the
+  authoritative spec for what an `fi_*` call promises — return values, flags,
+  which output fields are populated, error semantics. Deducing the contract from
+  the implementation is slow and unsafe: the code may be *buggy*, and a test that
+  encodes the buggy behavior as "correct" is worse than no test. Use the man page
+  to decide what to assert; use the code only to trace which branch runs.
+- **Assume you can't build or run locally.** The EFA provider and its gtest
+  harness are Linux-only (libibverbs/efadv, GNU `ld --wrap`) and need a real EFA
+  device, so a build/run is often unavailable. Self-review instead: re-read the
+  changed code in full, trace the
+  affected paths, and check mock cardinalities against the real call sites.
+- **Don't add comments or documentation to unit tests by default.** It is the
+  user's responsibility to read the code and tests and add comments where they
+  judge them appropriate. After writing a test, prompt the human to review it and
+  add comments where they deem necessary.
+- **Keep this file current.** When a *verified* change to the gtest framework or
+  EFA codebase (one the user confirmed built and passed, per the no-local-build
+  rule) makes an instruction here wrong or misleading, update that instruction in
+  the same change. Fix the stale contract, don't append a changelog — and only
+  after the change is confirmed, never on a speculative or unlanded edit.
+
+---
+
+## Skill 1 — Writing a gtest unit test
+
+File `prov/efa/test/gtest/efa_gtest_<subsystem>.cc`; fixture
+`Efa<Subsystem>Test : testing::Test`; test `TEST_F(Fixture, snake_case_name)`.
+`SetUp` constructs resources + `MockEfa::set(&mock)`; `TearDown`
+`MockEfa::set(nullptr)` + destruct.
+
+**When in doubt about a gtest/gmock API or behavior, consult the GoogleTest
+documentation** (primer + gMock Cookbook, linked in the gtest README) — it is the
+authority, not the existing tests. The current suite exercises only a slice of the
+framework and is not guaranteed to model best practice, so don't infer an API's
+contract or copy a pattern from a nearby test when the docs can settle it.
+
+### Workflow
+
+1. Pick/create the component file; if new, add it to `nodist_..._SOURCES` in
+   [prov/efa/Makefile.include](prov/efa/Makefile.include).
+2. Fixture derives from `::testing::Test`, embeds a `struct efa_resource` and any
+   mocks. Call `efa_test_resource_construct` in SetUp, `efa_test_resource_destruct`
+   in TearDown. Model on `EfaConnTest` in `efa_gtest_conn.cc`.
+3. Route to the intended unit. The resource's fabric name / EP type / CQ format /
+   caps decide which implementation you land in — e.g. `fi_cq_readfrom` reaches
+   `efa_rdm_cq_readfrom` on the RDM fabric but base `efa_cq_readfrom` only on
+   **efa-direct**. Confirm the dispatch before writing assertions.
+4. To run one body over several inputs, parameterize instead of copy-pasting:
+   fixture derives from `testing::TestWithParam<T>`, read the input with
+   `GetParam()` in a `TEST_P(Fixture, name)`, register the set once with
+   `INSTANTIATE_TEST_SUITE_P(, Fixture, <generator>, <name-fn>)` (generator e.g.
+   `testing::Bool()` / `Values(...)`, optional trailing lambda names each
+   instance). Model on `EfaRtmTest` in `efa_gtest_rdm_pke_rtm.cc`. Assert the
+   field that varies with the parameter (Assertion strength below).
+
+### Mocking
+
+- Mock via the `EFA_MOCK_FUNCTIONS` X-macro + `-Wl,--wrap`. To add one: add a row
+  `X(ret, fn, (param decls), (arg names))`, add forward struct decls, add
+  `-Wl,--wrap=<fn>` to the LDFLAGS in Makefile.include. One row generates the
+  `MOCK_METHOD`, the `__real_`/`__wrap_` prototypes, and the `MockEfa::Fn`
+  enumerator that indexes the per-instance armed bitset — no extra step.
+- **Expect via `EFA_EXPECT_CALL(mock, fn, ...)`, not bare `EXPECT_CALL`.** It
+  arms the function *and* opens the expectation; the trampoline routes a wrapped
+  call into the mock **only for armed functions** and otherwise falls through to
+  `__real_<fn>`. Arming is what confines a `--wrap` (a process-wide symbol) to
+  the test that cares. No-arg form matches any args; trailing args are matchers
+  (`EFA_EXPECT_CALL(mock, ibv_destroy_ah, &ah)` → `ibv_destroy_ah(&ah)`).
+- **Any efa provider function (not just libibverbs/efadv) can be wrapped — so
+  choose the seam deliberately.** Arming means an unarmed wrapped symbol stays
+  real, but a seam close to the unit under test still keeps error injection
+  precise: prefer a function whose only relevant caller is the path you are
+  testing (e.g. `ofi_mr_map_insert`, whose single efa caller is unambiguous)
+  over a high-traffic leaf you must enumerate call-by-call once armed. The
+  narrowest seam that fails the exact branch you want is the right one.
+- **`StrictMock<MockEfa>` always.** Once you arm a function you have declared it
+  significant, so every armed call that fires must have a matching expectation —
+  an unexpected one must fail the test. `NiceMock` only as a commented,
+  deliberate exception.
+- **Explicit action on every `EFA_EXPECT_CALL`** — `WillOnce`/`WillRepeatedly`/
+  `Times(0)`. `StrictMock` governs *whether* a call was expected, never *what it
+  returns*; the implicit default (0/NULL) is a trap.
+- **Arm-to-all-real is pointless.** Arming a function only to route *every* call
+  to `__real_<fn>` behaves exactly like leaving it unarmed. Arming pays off when
+  you intercept *some* calls and let the rest run real — sequence per-call
+  `WillOnce`s with a `WillRepeatedly(Invoke(__real_<fn>))` tail, e.g. fail the
+  first `ibv_create_ah` (`WillOnce(Return(nullptr))`) and let later ones succeed
+  for real.
+- **Explicit cardinality.** Trace the path and use `WillOnce` / `Times(N)` /
+  `Times(0)` rather than a bare `WillRepeatedly` when the count is known.
+- **Teardown calls fall through to real unless armed.** Because arming is
+  opt-in, you generally do *not* enumerate the endpoint's destruct calls (e.g.
+  the RDM CQ drain's `efa_ibv_cq_start_poll`) — they reach `__real_`. The
+  exception is a function the test *arms* that also fires in destruct: e.g. a
+  test arming `ibv_destroy_ah` for a peer AH must `MockEfa::set(nullptr)` before
+  `efa_test_resource_destruct`, or `self_ah`'s real destroy routes into the mock
+  as an unexpected call (see `EfaConnTest`).
+- **Static-inline functions** (`efa_qp_post_*`, `efa_ibv_cq_*` in
+  `efa_data_path_ops.h`) are only linkable under `#if EFA_UNIT_TEST`. Mocking them
+  requires configuring with **both** `--enable-efa-unit-test` AND
+  `--enable-efa-gtest`; gtest-only silently binds `--wrap` to nothing → false pass.
+
+### C/C++ bridge
+
+- EFA internal headers won't compile in a `.cc` for two independent reasons, both
+  reached transitively from `efa.h`: (1) `unix/osd.h` includes `<complex.h>` and
+  uses C `_Complex` types, and (2) `ofi.h` → `ofi_atom.h` includes C11
+  `<stdatomic.h>` (`atomic_int`/`_Atomic`/`atomic_*`), which is not C++-compatible
+  — C++ has its own `<atomic>`, and the `extern "C"` guard doesn't help because
+  these are language-level type/keyword incompatibilities, not linkage. Access
+  internals through C helpers in `efa_gtest_common_helpers.c` (`extern "C"`).
+  Prefer forward-declaring a production function over a passthrough wrapper; write
+  a wrapper only to reach opaque struct internals.
+- **Put test-specific C helpers in a per-component `.c/.h` pair, not
+  `common_helpers`.** When a test's own logic must live in C (because it touches
+  EFA internals per above), give that component its own bridge pair — e.g.
+  `efa_gtest_rdm_pke_utils.{c,h}` for `efa_gtest_rdm_pke_rtm.cc`; both files go in
+  `nodist_..._SOURCES` (headers picked up via `-I`). Reserve
+  `efa_gtest_common_helpers.{c,h}` for genuinely common helpers you expect
+  multiple test files to reuse. These per-component helpers are effectively test
+  bodies that had to move into C — keep them next to the test that owns them.
+  When a helper *is* the test body (moved into C only because it touches EFA
+  internals), name it `efa_test_<test_name>` after the `TEST_F`/`TEST_P` in the
+  `.cc` that calls it, so the C body and its owning test are unambiguously paired.
+
+### Assertion strength
+
+- **Assert the produced output, not just the mock's call count.** A satisfied
+  `EFA_EXPECT_CALL` proves a value was *read*, not that it *landed* in the
+  completion/error entry, so don't stop at call count — also check `op_context`,
+  `flags`, `len`, `data`, `prov_errno`, `err`, `src_addr`, etc. Call count is
+  still worth asserting when it *is* the contract (a cardinality like `Times(2)`,
+  or a `Times(0)` proving a branch was skipped); assert both when both matter.
+- **A suppressed output is a claim — assert it** (read back `-FI_EAGAIN` when a
+  branch should stage nothing). A comment is not a test.
+- **Use distinct sentinels to prove which branch ran** (e.g. `op_context == &ctx`
+  where `&ctx != direct_ope`), not a pointer both branches share.
+- **Parameterized tests assert the per-parameter difference** (the field that
+  varies by opcode). Fold opcode-only variants into `TEST_P`.
+- **Read back without re-triggering the path.** `fi_cq_read`/`readfrom` call
+  `progress()` and re-enter the mocked poll loop, breaking `StrictMock`; use
+  `ofi_cq_read_entries` (no progress) or `fi_cq_readerr` (no progress).
+- **Stop before brittle.** Don't assert log strings, exact error text, or values
+  the contract doesn't promise; prefer `EXPECT_NE(x, 0)` when the contract only
+  guarantees "nonzero/derived".
+
+### Host-capability gating (skip, don't fake)
+
+- Paths needing real hardware (efa-direct FI_RMA read/write need Nitro v4+ RDMA)
+  cannot be faked — forcing caps gets past `fi_getinfo` but `fi_enable` still
+  creates a real QP via `efadv_create_qp_ex` and the device rejects it
+  (`-FI_EOPNOTSUPP`). Query the real capability in `SetUp()` (C helper wrapping
+  `efa_device_support_rdma_read()/_write()`) and `GTEST_SKIP()` when absent.
+  Skipping in SetUp means the body never runs (also dodges the fatal-ASSERT-in-
+  helper fall-through trap). Wrap `construct()` in `ASSERT_NO_FATAL_FAILURE`.
+
+### State hygiene
+
+- Save any global mutable state (`efa_env` fields like `track_mr`) in SetUp,
+  restore in TearDown, so tests stay order-independent. Prefer instance-local
+  seams (e.g. swap `rdm_domain->shm_domain` around the call) over mutating globals.
+- Pair every alloc/free; no leaks, no double-frees.
+
+---
+
+## Skill 2 — Reviewing a gtest unit test
+
+Work through these when reviewing a new/modified `efa_gtest_*.cc`. Items 5–7 are
+highest-value — they catch what a passing run does not (wrong function under test,
+mismatched cardinality, a branch never hit).
+
+1. **Conformance** — follows the gtest README and this file (mock style,
+   strictness, C/C++ bridge, static-inline mocking, naming).
+2. **Comments** — terse, contract-focused; flag any that restate code; prefer
+   function-name references over `file.c:812` line refs (they rot).
+3. **No logical overlap; parameterize near-duplicates** — each test should hit a
+   distinct branch. If two `TEST_F`s share the same body and differ only in a set
+   of values (opcode, CQ format, flag combo, expected field) that could be a
+   `GetParam()` field, they're one `TEST_P` over a case table, not copy-paste.
+   The test asserts the per-parameter difference (item 10); if it can't — i.e. the
+   variants really do exercise different logic/branches — keep them separate.
+4. **Naming** — fixture/test names describe the behavior, not overly long.
+5. **Mock expectations match the real path** — re-trace production for every test;
+   confirm each cardinality and action, *including teardown calls*. The *absence*
+   of an expectation is a claim (no `slid`/`src_qp` ⇒ non-`FI_SOURCE` branch) —
+   verify those too.
+6. **Each fixture routes to the intended unit** — confirm fabric name / EP type /
+   CQ format / caps dispatch into the function the test means to cover. A test that
+   passes against the wrong implementation is a trap.
+7. **Strictness and teardown** — `StrictMock` everywhere (no bare/`Nice` without a
+   commented reason), expectations via `EFA_EXPECT_CALL` (never bare
+   `EXPECT_CALL`), `MockEfa::set(nullptr)` in every TearDown. Any function the
+   test arms that also fires during destruct is either uninstalled before
+   destruct or routed to `__real_`.
+8. **Resource/global-state hygiene** — alloc/free pairing; global state saved in
+   SetUp and restored in TearDown.
+9.  **Assertion strength** — asserts the observable contract (output fields set,
+    output suppressed, per-parameter difference), proves *which* branch ran via
+    sentinels, stops short of brittle log/text assertions. Flag any test that
+    checks only the return code or a satisfied `EFA_EXPECT_CALL` while leaving an
+    output field unverified.
+10. **Build wiring** — new mock has a matching `-Wl,--wrap=<fn>` in
+    Makefile.include; new file added to `nodist_..._SOURCES`.
+11. **No pointless arming** — flag any `EFA_EXPECT_CALL` whose every action routes
+    to `__real_<fn>` (a lone `WillRepeatedly(Invoke(__real_...))`): arming only to
+    run fully real behaves exactly like not arming, so either drop the expectation
+    or, if the intent was partial interception, sequence the real `WillOnce`s
+    before the `__real_` tail.
+
+---
+
+## Skill 3 — Reviewing an EFA source file for bugs
+
+Read the file in full and trace each code path by hand (no build here). The
+bug classes below are the ones this codebase has actually shipped and fixed —
+prioritize them.
+
+### High-value bug patterns
+
+- **Error code clobbered by cleanup.** A failure path calls a cleanup function and
+  writes its (successful) return over the real error: `ret = efa_rdm_mr_dereg_impl(...)`
+  turned a failed registration into a success that returned a deregistered MR. Fix
+  is usually to drop the `ret =`. Check every `goto err` / cleanup block: does it
+  preserve the original `ret`?
+- **Buffer bounds skipped on a bypass path.** The util layer bounds a copy with
+  `MIN(user_size, prov_size)`; a provider "bypass" path (e.g. efa-direct
+  `efa_cq_readerr` → `efa_write_error_msg`) can `snprintf` a fixed max into the
+  caller's smaller buffer. For every write into a caller-supplied buffer, confirm
+  the caller's declared capacity actually bounds it — and that the reported size is
+  truncation-aware, not a hardcoded max.
+- **Use-after-free / free-then-use across a boundary.** Completion handlers free
+  the `txe`/`ope` at `bytes_acked == total_len`; anything read after that boundary
+  must come from an object that outlives it (peer/domain counters), not the freed
+  one. Check clone/release paths (cf. the `rdm_pke_release_cloned` UAF fix).
+- **Double-free / missing-free on error paths.** Pair every alloc with exactly one
+  free across all branches; a partially-constructed object freed by both the error
+  path and the destructor is a double-free.
+- **Return-value defaults masking failure.** A function that returns 0 on an
+  untaken path, or an uninitialized `ret`, can report success spuriously.
+- **Refcount asymmetry on error paths.** An `*_open`/`bind` that increments a
+  refcount (util_domain, av, eq, cntr) on success but whose error path returns
+  without the matching decrement leaks the reference — cf. the `rdm_cntr_open`
+  util_domain leak. For every refcount bump, check that *every* exit after it
+  (each `goto err`, early return) either owns the ref or drops it; close/unbind
+  must balance open/bind exactly.
+- **Locking: contention and data races.** Check for lock-ordering and
+  double-locking bugs — a path that re-acquires a lock it already holds (or an
+  error/cleanup branch that unlocks a lock it never took), and two locks taken in
+  opposite orders on different paths (deadlock). When the object is reached
+  concurrently (progress thread vs. app thread, CQ poll vs. completion), confirm
+  every access to shared state is under the intended lock — an unguarded read/write
+  or a field mutated outside the lock that protects its invariant is a race.
+
+### Method
+
+- **Judge public-facing behavior against the man page; judge internal details
+  for self-consistency.** Where a behavior is part of the public API contract,
+  verify it against [man/](man/) (per the ground rule) rather than the code, so
+  you neither flag intended behavior nor bless a buggy implementation. But the
+  man pages don't cover everything — plenty of implementation details have no
+  documented contract; for those, the bar is that the code is internally bug-free
+  and self-consistent (no UAF, no double-free, no path contradicting another).
+- **Identify which fabric/EP the function serves.** Base vs. RDM vs. efa-direct
+  paths differ: a bug may exist only on the bypass path (efa-direct `efa_cq_*`)
+  while the RDM path routes through safe util code. State which path you're
+  analyzing.
+- **Trace each error/early-return branch to its observable effect** — what does the
+  caller see in the return code and in every output field? Mismatches there are the
+  bugs unit tests are meant to pin.
+- **Check capability gating.** Code assuming RDMA read/write, HMEM/CUDA, or shm may
+  be reached on a device that lacks it; confirm the guard exists and is correct.
+- **When you find a bug, describe the failing input → wrong output concretely,** and
+  (if asked to test it) design a *failing* unit test first using the seams in
+  Skill 1 — pick a `--wrap` seam whose only caller is unambiguous so the
+  fault-injection is targeted (e.g. `ofi_mr_map_insert` has exactly one efa caller).

--- a/prov/efa/test/gtest/README.md
+++ b/prov/efa/test/gtest/README.md
@@ -10,12 +10,12 @@
 To run efa unit tests, you will need to have [GoogleTest 1.17](https://github.com/google/googletest/releases/tag/v1.17.0) installed.
 See installation instructions [here](https://google.github.io/googletest/quickstart-cmake.html).
 
-You will need to configure libfabric with `--enable-efa-gtest=<path_to_gtest_install>`.
+Note that the GTest suite **does not** depend on the cmocka suite (`--enable-efa-unit-test`).
 
 An example build and run command would look like:
 
 ```bash
-./autogen.sh && ./configure --enable-efa-gtest=/home/ec2-user/googletest/install
+./autogen.sh && ./configure --your-flags --enable-efa --enable-efa-gtest=/path/to/googletest/install
 make /prov/efa/test/gtest/efa_gtest -j
 ```
 
@@ -24,12 +24,18 @@ You can then directly execute the test executable:
 ./prov/efa/test/gtest/efa_gtest
 ```
 
+To run a subset of the test suite, you can do
+```
+./prov/efa/test/gtest/efa_gtest --gtest_filter='EfaCqTest*'
+```
+
 ## File Structure
 * `efa_gtest_main.cc`: Test entry point. Its `main` calls `InitGoogleMock` and `RUN_ALL_TESTS()`. Tests register themselves through the `TEST`/`TEST_F` macros, so — unlike cmocka — there is nothing to declare or add to `main` by hand.
 * `efa_gtest_common_resource.{cc,h}`: Defines `struct efa_resource` and `efa_test_resource_construct`/`efa_test_resource_destruct`, which build and tear down a full set of OFI objects (fabric, domain, endpoint, EQ, AV, CQ).
-* `efa_gtest_common_mocks.{cc,h}`: The `MockEfa` gmock class for libibverbs/efadv calls (e.g. `ibv_create_ah`), plus the `__wrap_*` trampolines that route those calls to the installed mock.
+* `efa_gtest_common_mocks.{cc,h}`: All mock-related infrastructure. This is the single place you add a mock definition (a row in the `EFA_MOCK_FUNCTIONS` X macro), from which the related X-macro machinery generates the `MockEfa` class's `MOCK_METHOD` declarations, the `__real_`/`__wrap_` prototypes and trampolines, and the per-function arm enumerator. 
 * `efa_gtest_common_helpers.{c,h}`: C-linkage helpers. EFA internal headers (`efa.h`, `efa_av.h`, ...) transitively pull in `unix/osd.h`, which uses C `_Complex` types that don't compile under C++. Anything a test needs from EFA internals is wrapped by a C function here and declared `extern "C"` in the header.
-* `efa_gtest_{component}.cc`: The tests themselves, one file per component (e.g. `efa_gtest_conn.cc`).
+* `efa_gtest_{component}.cc`: The tests themselves, one file per component.
+* `efa_gtest_{component}_utils.{c,h}`: Optional, test-specific C-bridge utilities for a single component — the per-component counterpart to `efa_gtest_common_helpers.{c,h}`. Use these when a component's tests need C-linkage access to EFA internals that is too specialized to belong in the shared helpers.
 
 ## What Should be Tested
 1. We make a conscious trade-off to test larger rather than smaller units. Hitting small but trivial units can increase coverage but don't test anything interesting.
@@ -38,9 +44,10 @@ You can then directly execute the test executable:
 ## How to write
 1. Read the [GoogleTest documentation](https://google.github.io/googletest/), particularly the [primer](https://google.github.io/googletest/primer.html), and the [gMock Cookbook](https://google.github.io/googletest/gmock_cook_book.html).
 2. Pick the component file `efa_gtest_{component}.cc` (create one if needed and add it to `nodist_..._SOURCES` in `prov/efa/Makefile.include`).
-3. Write a fixture class deriving from `::testing::Test`. Embed a `struct efa_resource` and any mocks (e.g. `MockEfa`); call `efa_test_resource_construct` to set up and `efa_test_resource_destruct` + `MockEfa::set(nullptr)` to tear down. See `EfaConnTest` in `efa_gtest_conn.cc`.
+3. Write a fixture class deriving from `::testing::Test`. Typically you need a `struct efa_resource` and an instance of `MockEfa` as members; call `efa_test_resource_construct` to set up and `efa_test_resource_destruct` + `MockEfa::set(nullptr)` to tear down.
 4. Write tests with `TEST_F(Fixture, name)`. There is no header to update and no group to register — gtest discovers tests automatically.
-5. If a test needs EFA internals, expose them through a helper in `efa_gtest_common_helpers.c` rather than including the EFA headers from C++.
+5. To run the *same* test body over several inputs (e.g. an opcode or a bool flag), write a parameterized test instead of copy-pasting `TEST_F`s. Derive the fixture from `testing::TestWithParam<T>` (rather than `testing::Test`), read the current input with `GetParam()` inside a `TEST_P(Fixture, name)`, and register the value set once with `INSTANTIATE_TEST_SUITE_P(, Fixture, <generator>, <name-fn>)` — where `<generator>` is e.g. `testing::Bool()` or `testing::Values(...)`, and the optional trailing lambda names each instance for readable output. See `EfaRtmTest` in `efa_gtest_rdm_pke_rtm.cc`.
+6. If a test needs EFA internals, expose them through a C-linkage helper rather than including the EFA headers from C++ — in `efa_gtest_common_helpers.c` if it is broadly reusable, or in a component-specific `efa_gtest_{component}_utils.c` (with its `.h` declaring the `extern "C"` interface) if it is specialized to one component's tests. Remember to add any new `.c` file to `nodist_..._SOURCES` in `prov/efa/Makefile.include`.
 
 ## Mocking
 We intercept functions with the GNU linker's `--wrap` and back them with gmock for expressive expectations. The `EFA_MOCK_FUNCTIONS` X macro in `efa_gtest_common_mocks.h` is the single source of truth — it generates `MOCK_METHOD` declarations, `__real_` extern declarations, `__wrap_` trampolines, and a `MockEfa::Fn` enumerator per function automatically.
@@ -53,9 +60,10 @@ A `--wrap=<fn>` is global: it rewires *every* call to `<fn>` across the whole te
 2. Add any needed forward struct declarations at the top of the header.
 3. Add `-Wl,--wrap=<fn>` to `prov_efa_test_gtest_efa_gtest_LDFLAGS` in `prov/efa/Makefile.include`.
 
-Because the trampoline only intercepts *armed* functions, adding a new mock does not silently reroute an existing test's real calls into gMock's defaults — an unarmed function stays real. If a wrapped function does need real behavior *within* a test that also mocks it (e.g. you arm it but want some calls to run for real), route it explicitly:
+Because the trampoline only intercepts *armed* functions, adding a new mock does not silently reroute an existing test's real calls into gMock's defaults — an unarmed function stays real. Arming a function only to send *every* call straight to `__real_<fn>` is pointless — it behaves exactly like leaving it unarmed. Arming earns its keep when you want to intercept *some* calls but let the rest run for real; sequence the actions with per-call `WillOnce`s and a `WillRepeatedly` tail. For example, to fail the first AH creation but let all later ones succeed for real:
 ```
 EFA_EXPECT_CALL(mock_efa, ibv_create_ah)
+        .WillOnce(Return(nullptr))
         .WillRepeatedly(Invoke(__real_ibv_create_ah));
 ```
 
@@ -63,7 +71,7 @@ EFA_EXPECT_CALL(mock_efa, ibv_create_ah)
 
 Install the mock with `MockEfa::set(&mock)` and set up expectations with **`EFA_EXPECT_CALL(mock, ...)`** — not the bare `EXPECT_CALL` — e.g. `.WillOnce(testing::Return(...))`. `EFA_EXPECT_CALL` arms the function and opens the expectation in one step; the chained action builders (`.WillOnce`/`.Times`/etc.) work exactly as on `EXPECT_CALL`. A function you never `EFA_EXPECT_CALL` stays unarmed, so its wrapped calls fall through to `__real_<fn>`.
 
-`EFA_EXPECT_CALL(mock, fn)` matches any arguments; to match on arguments pass them as trailing macro args — `EFA_EXPECT_CALL(mock_efa, ibv_destroy_ah, &dummy_ah)` expands to `EXPECT_CALL(mock_efa, ibv_destroy_ah(&dummy_ah))`. (Matchers cannot be written as `fn(...)` inside the macro because the arming step pastes `FN_##fn`, which requires `fn` to be a bare identifier; the macro uses `__VA_OPT__` to add the matcher parentheses only when trailing args are present.)
+`EFA_EXPECT_CALL(mock, fn)` matches any arguments; to match on arguments pass them as trailing args — `EFA_EXPECT_CALL(mock_efa, fn, arg1, arg2, ...)` expands to `EXPECT_CALL(mock_efa, fn(arg1, arg2, ...))`.
 
 Always clear the mock in the fixture's `TearDown` with `MockEfa::set(nullptr)` so it doesn't leak between tests. Note the arming bitset lives on the per-test `MockEfa` instance, so it resets automatically each test — but the `--wrap` symbol and the installed-mock pointer are process-global, hence the explicit clear.
 

--- a/prov/efa/test/gtest/README.md
+++ b/prov/efa/test/gtest/README.md
@@ -38,34 +38,34 @@ You can then directly execute the test executable:
 5. If a test needs EFA internals, expose them through a helper in `efa_gtest_common_helpers.c` rather than including the EFA headers from C++.
 
 ## Mocking
-We intercept functions with the GNU linker's `--wrap` and back them with gmock for expressive expectations. The `EFA_MOCK_FUNCTIONS` X macro in `efa_gtest_common_mocks.h` is the single source of truth — it generates `MOCK_METHOD` declarations, `__real_` extern declarations, and `__wrap_` trampolines automatically.
+We intercept functions with the GNU linker's `--wrap` and back them with gmock for expressive expectations. The `EFA_MOCK_FUNCTIONS` X macro in `efa_gtest_common_mocks.h` is the single source of truth — it generates `MOCK_METHOD` declarations, `__real_` extern declarations, `__wrap_` trampolines, and a `MockEfa::Fn` enumerator per function automatically.
+
+A `--wrap=<fn>` is global: it rewires *every* call to `<fn>` across the whole test binary. So the moment one test file adds a symbol to the wrap set, an installed mock would intercept that symbol everywhere — including in tests that never cared about it. To contain this, each `MockEfa` instance carries an *armed* bitset and the trampoline forwards to the mock **only for armed functions**, falling through to `__real_<fn>` otherwise. A function is automatically armed through `EFA_EXPECT_CALL` (below).
 
 ### Adding a new mock
 
-1. Add a row `X(return_type, fn, (param decls), (arg names))` to the `EFA_MOCK_FUNCTIONS` list in `efa_gtest_common_mocks.h`. The parenthesized param/arg groups are single macro arguments (the parens shield their commas); the generators drop them into `MOCK_METHOD` and the `__real_`/`__wrap_` prototypes.
+1. Add a row `X(return_type, fn, (param decls), (arg names))` to the `EFA_MOCK_FUNCTIONS` list in `efa_gtest_common_mocks.h`. The parenthesized param/arg groups are single macro arguments (the parens shield their commas); the generators drop them into `MOCK_METHOD`, the `__real_`/`__wrap_` prototypes, and the arm enumerator.
 2. Add any needed forward struct declarations at the top of the header.
 3. Add `-Wl,--wrap=<fn>` to `prov_efa_test_gtest_efa_gtest_LDFLAGS` in `prov/efa/Makefile.include`.
 
-If adding a mock breaks other tests, it's likely due to the new mock is being unintentionally called in a test where a real function call is expected. By default, mocked functions will return 0/false/NULL/default construct, and this may not be the expected behavior of the real functions. There are two solutions to this:
-
-1. Define multiple mock classes analogous to `MockEfa`, to isolate the mocks, and only install the mocks you need by `MockEfa::set(&mock_efa);`
-2. Set up the correct expectation to route all calls to a specific wrapped function to the real function, like
+Because the trampoline only intercepts *armed* functions, adding a new mock does not silently reroute an existing test's real calls into gMock's defaults — an unarmed function stays real. If a wrapped function does need real behavior *within* a test that also mocks it (e.g. you arm it but want some calls to run for real), route it explicitly:
 ```
-ON_CALL(*this, ibv_create_ah(_,:_))
-        .WillByDefault(Invoke(__real_ibv_create_ah));
+EFA_EXPECT_CALL(mock_efa, ibv_create_ah)
+        .WillRepeatedly(Invoke(__real_ibv_create_ah));
 ```
-A mixture of both strategy can be used, to minimize the changes required.
 
 ### Using mocks in tests
 
-Install the mock with `MockEfa::set(&mock)` and set up `EXPECT_CALL(mock, ...)` expectations (e.g. `.WillOnce(testing::Return(...))`). When no mock is installed, the trampoline falls through to the real `__real_<fn>` implementation.
+Install the mock with `MockEfa::set(&mock)` and set up expectations with **`EFA_EXPECT_CALL(mock, ...)`** — not the bare `EXPECT_CALL` — e.g. `.WillOnce(testing::Return(...))`. `EFA_EXPECT_CALL` arms the function and opens the expectation in one step; the chained action builders (`.WillOnce`/`.Times`/etc.) work exactly as on `EXPECT_CALL`. A function you never `EFA_EXPECT_CALL` stays unarmed, so its wrapped calls fall through to `__real_<fn>`.
 
-Because `--wrap` rewires every call to the function across the whole test binary, always restore the default in the fixture's `TearDown` — clear the mock with `MockEfa::set(nullptr)` — so mocks don't leak between tests.
+`EFA_EXPECT_CALL(mock, fn)` matches any arguments; to match on arguments pass them as trailing macro args — `EFA_EXPECT_CALL(mock_efa, ibv_destroy_ah, &dummy_ah)` expands to `EXPECT_CALL(mock_efa, ibv_destroy_ah(&dummy_ah))`. (Matchers cannot be written as `fn(...)` inside the macro because the arming step pastes `FN_##fn`, which requires `fn` to be a bare identifier; the macro uses `__VA_OPT__` to add the matcher parentheses only when trailing args are present.)
+
+Always clear the mock in the fixture's `TearDown` with `MockEfa::set(nullptr)` so it doesn't leak between tests. Note the arming bitset lives on the per-test `MockEfa` instance, so it resets automatically each test — but the `--wrap` symbol and the installed-mock pointer are process-global, hence the explicit clear.
 
 ### Strictness and explicit actions
 
-Declare the mock member as `testing::StrictMock<MockEfa>`, not bare `MockEfa`. A bare mock only prints a warning when a wrapped function fires with no matching `EXPECT_CALL`; `StrictMock` makes it a hard failure. That is the behavior we want here: `--wrap` intercepts the function process-wide, so every wrapped call that fires during a test is significant and should be accounted for. Reserve `testing::NiceMock<MockEfa>` for the rare, commented case where a helper fires a high-volume call you deliberately don't want to enumerate.
+Declare the mock member as `testing::StrictMock<MockEfa>`, not bare `MockEfa`. A bare mock only prints a warning when an *armed* function fires with no matching expectation; `StrictMock` makes it a hard failure. That is the behavior we want here: once you arm a function you have declared it significant, so every armed call that fires should be accounted for. Reserve `testing::NiceMock<MockEfa>` for the rare, commented case where a helper fires a high-volume call you deliberately don't want to enumerate.
 
-Strictness is a separate concern from the *return value* of an expected call: `StrictMock` only governs whether a call was expected, never what it returns. A `StrictMock` whose `EXPECT_CALL` omits an action still returns the gMock default (0/false/NULL/default-constructed). So always give every `EXPECT_CALL` an explicit action (`WillOnce`/`WillRepeatedly`/`Times(0)`) rather than relying on that implicit default.
+Strictness is a separate concern from the *return value* of an expected call: `StrictMock` only governs whether a call was expected, never what it returns. A `StrictMock` whose expectation omits an action still returns the gMock default (0/false/NULL/default-constructed). So always give every `EFA_EXPECT_CALL` an explicit action (`WillOnce`/`WillRepeatedly`/`Times(0)`) rather than relying on that implicit default.
 
-Note that the mock is typically installed *after* `efa_test_resource_construct` and cleared in `TearDown`, so any wrapped call made while tearing the resources down (e.g. destroying the endpoint's `self_ah` via `ibv_destroy_ah`) is also subject to strict checking — expect those calls too.
+Because arming is opt-in, a wrapped call made during teardown falls through to `__real_<fn>` **unless the test armed that function** — so you generally do *not* need to expect the endpoint's teardown calls (e.g. the RDM CQ drain's `efa_ibv_cq_start_poll`). The exception is a function the test *does* arm that also fires during teardown: e.g. a test that arms `ibv_destroy_ah` for a peer AH must clear the mock (`MockEfa::set(nullptr)`) *before* `efa_test_resource_destruct`, or the real destroy of `self_ah` will route into the mock as an unexpected call. See `EfaConnTest`.

--- a/prov/efa/test/gtest/README.md
+++ b/prov/efa/test/gtest/README.md
@@ -1,5 +1,10 @@
 # GoogleTest-based EFA unit tests
 
+> **Using an AI coding agent?** Read [AGENTS.md](AGENTS.md) — it distills the
+> conventions in this README into task-oriented skills for writing tests,
+> reviewing tests, and finding bugs in EFA source. This applies whether you are an
+> agent yourself or a human planning to drive one.
+
 ## How to run
 
 To run efa unit tests, you will need to have [GoogleTest 1.17](https://github.com/google/googletest/releases/tag/v1.17.0) installed.

--- a/prov/efa/test/gtest/README.md
+++ b/prov/efa/test/gtest/README.md
@@ -27,9 +27,8 @@ You can then directly execute the test executable:
 * `efa_gtest_{component}.cc`: The tests themselves, one file per component (e.g. `efa_gtest_conn.cc`).
 
 ## What Should be Tested
-1. Unit tests should test `efa_*` functions as opposed to `fi_*` functions - the latter should be left to integration tests as much as possible.
-2. We make a conscious trade-off to test larger rather than smaller units. Hitting small but trivial units can increase coverage but don't test anything interesting.
-3. We are biased toward testing edge cases over "happy cases", especially if the code path under test cannot be covered by integration tests.
+1. We make a conscious trade-off to test larger rather than smaller units. Hitting small but trivial units can increase coverage but don't test anything interesting.
+2. We are biased toward testing edge cases over "happy cases", especially if the code path under test cannot be covered by integration tests.
 
 ## How to write
 1. Read the [GoogleTest documentation](https://google.github.io/googletest/), particularly the [primer](https://google.github.io/googletest/primer.html), and the [gMock Cookbook](https://google.github.io/googletest/gmock_cook_book.html).
@@ -43,10 +42,9 @@ We intercept functions with the GNU linker's `--wrap` and back them with gmock f
 
 ### Adding a new mock
 
-1. Define `EFA_MOCK_PARAMS_<fn>` (full parameter declarations) and `EFA_MOCK_ARGS_<fn>` (argument names only) in `efa_gtest_common_mocks.h`.
-2. Add `X(return_type, fn)` to the `EFA_MOCK_FUNCTIONS` list.
-3. Add any needed forward struct declarations at the top of the header.
-4. Add `-Wl,--wrap=<fn>` to `prov_efa_test_gtest_efa_gtest_LDFLAGS` in `prov/efa/Makefile.include`.
+1. Add a row `X(return_type, fn, (param decls), (arg names))` to the `EFA_MOCK_FUNCTIONS` list in `efa_gtest_common_mocks.h`. The parenthesized param/arg groups are single macro arguments (the parens shield their commas); the generators drop them into `MOCK_METHOD` and the `__real_`/`__wrap_` prototypes.
+2. Add any needed forward struct declarations at the top of the header.
+3. Add `-Wl,--wrap=<fn>` to `prov_efa_test_gtest_efa_gtest_LDFLAGS` in `prov/efa/Makefile.include`.
 
 If adding a mock breaks other tests, it's likely due to the new mock is being unintentionally called in a test where a real function call is expected. By default, mocked functions will return 0/false/NULL/default construct, and this may not be the expected behavior of the real functions. There are two solutions to this:
 

--- a/prov/efa/test/gtest/efa_gtest_ah.cc
+++ b/prov/efa/test/gtest/efa_gtest_ah.cc
@@ -12,15 +12,6 @@ using testing::Return;
 using testing::Invoke;
 using testing::StrictMock;
 
-/**
- * @brief Exercises the ENOMEM recovery branch of efa_ah_alloc.
- *
- * When ibv_create_ah fails with FI_ENOMEM during an implicit AV insertion,
- * efa_ah_alloc attempts to evict an AH entry that has no explicit AV references
- * and retries ibv_create_ah. These tests drive both outcomes of that branch:
- * the retry succeeding after a successful eviction, and the branch bailing out
- * because there is no AH available to evict.
- */
 class EfaAhTest : public Test
 {
 	protected:
@@ -41,19 +32,13 @@ class EfaAhTest : public Test
 
 	void TearDown() override
 	{
-		/* ep_close calls this wrapped function */
-		EXPECT_CALL(mock_efa, efa_ibv_cq_start_poll)
-			.WillRepeatedly(Return(ENOENT));
-
 		efa_test_resource_destruct(&resource);
 		MockEfa::set(nullptr);
 	}
 };
 
 /**
- * @brief efa_ah_alloc's ENOMEM eviction branch where the retry succeeds: a
- * second insert hits ENOMEM, efa_ah_implicit_av_evict_ah releases the first
- * (implicit-only) AH, and the retried ibv_create_ah succeeds.
+ * @brief Exerise efa_ah_alloc's ENOMEM eviction branch where the retry succeeds
  */
 TEST_F(EfaAhTest, alloc_enomem_evict_and_retry_succeeds)
 {
@@ -66,7 +51,7 @@ TEST_F(EfaAhTest, alloc_enomem_evict_and_retry_succeeds)
 	 *   2. second GID -> ENOMEM (drives the errno == FI_ENOMEM branch)
 	 *   3. second GID retry after eviction of dummy_ah_a -> success
 	 */
-	EXPECT_CALL(mock_efa, ibv_create_ah)
+	EFA_EXPECT_CALL(mock_efa, ibv_create_ah)
 		.WillOnce(Return(&dummy_ah_a))
 		.WillOnce(Invoke([](struct ibv_pd *,
 				    struct ibv_ah_attr *) -> struct ibv_ah * {
@@ -75,7 +60,7 @@ TEST_F(EfaAhTest, alloc_enomem_evict_and_retry_succeeds)
 		}))
 		.WillOnce(Return(&dummy_ah_b));
 
-	EXPECT_CALL(mock_efa, efadv_query_ah)
+	EFA_EXPECT_CALL(mock_efa, efadv_query_ah)
 		.Times(2)
 		.WillRepeatedly(Return(0));
 
@@ -83,7 +68,7 @@ TEST_F(EfaAhTest, alloc_enomem_evict_and_retry_succeeds)
 	 * ibv_destroy_ah is called for three AH's: we need to fake
 	 * dummy_ah_a/b's destroy calls, but actually call destroy on self_ah.
 	 */
-	EXPECT_CALL(mock_efa, ibv_destroy_ah)
+	EFA_EXPECT_CALL(mock_efa, ibv_destroy_ah)
 		.Times(3)
 		.WillRepeatedly(Invoke([](struct ibv_ah *ah) -> int {
 			if (ah == &dummy_ah_a || ah == &dummy_ah_b)
@@ -91,21 +76,14 @@ TEST_F(EfaAhTest, alloc_enomem_evict_and_retry_succeeds)
 			return __real_ibv_destroy_ah(ah);
 		}));
 
-	// run the real reverse_av_add to populate the reverse av hash
-	EXPECT_CALL(mock_efa, efa_av_reverse_av_add)
-		.WillRepeatedly(Invoke(__real_efa_av_reverse_av_add));
 
 	addr_a = efa_test_insert_peer_new_gid(resource.ep, resource.av);
 	EXPECT_NE(addr_a, (fi_addr_t) FI_ADDR_NOTAVAIL);
 
-	// we have configured this insertion to fail-retry-succeed
 	addr_b = efa_test_insert_peer_new_gid(resource.ep, resource.av);
 	EXPECT_NE(addr_b, (fi_addr_t) FI_ADDR_NOTAVAIL);
 
-	/*
-	 * A's conn was released during B's insert, so addr_a no longer
-	 * resolves. This proves A specifically was the evicted entry.
-	 */
+	/* This proves A specifically was the evicted entry */
 	EXPECT_EQ(efa_test_implicit_addr_to_ibv_ah(resource.av, addr_a),
 		  nullptr);
 	/*
@@ -118,28 +96,20 @@ TEST_F(EfaAhTest, alloc_enomem_evict_and_retry_succeeds)
 }
 
 /**
- * @brief efa_ah_alloc's ENOMEM eviction branch where the retry never happens:
- * with an empty AH map efa_ah_implicit_av_evict_ah returns -FI_ENOMEM, so
- * efa_ah_alloc bails via err_free_efa_ah and the insert fails.
+ * @brief Exercise efa_ah_alloc's ENOMEM eviction branch where there is nothing
+ * to evict, so the retry never happens and the insert fails
  */
 TEST_F(EfaAhTest, alloc_enomem_no_evictable_ah_fails)
 {
 	fi_addr_t addr;
 
-	/* The only AH creation attempt fails with ENOMEM; with an empty LRU
-	 * list the eviction helper cannot free anything, so no retry occurs. */
-	EXPECT_CALL(mock_efa, ibv_create_ah)
+	/* one failed AH creation: empty LRU = no retry */
+	EFA_EXPECT_CALL(mock_efa, ibv_create_ah)
 		.WillOnce(Invoke([](struct ibv_pd *,
 				    struct ibv_ah_attr *) -> struct ibv_ah * {
 			errno = ENOMEM;
 			return nullptr;
 		}));
-
-	/* The failed insert creates no AH, so ibv_destroy_ah is only expected
-	 * to be called once on the real AH. */
-	EXPECT_CALL(mock_efa, ibv_destroy_ah)
-		.Times(1)
-		.WillOnce(Invoke(__real_ibv_destroy_ah));
 
 	addr = efa_test_insert_peer_new_gid(resource.ep, resource.av);
 	EXPECT_EQ(addr, (fi_addr_t) FI_ADDR_NOTAVAIL);

--- a/prov/efa/test/gtest/efa_gtest_common_mocks.cc
+++ b/prov/efa/test/gtest/efa_gtest_common_mocks.cc
@@ -15,14 +15,17 @@ void MockEfa::set(MockEfa *instance)
 	g_mock_efa = instance;
 }
 
-// Generate the definitions of the __wrap_* functions
-#define EFA_MOCK_GEN_WRAP(ret, name, params, args)               \
-	ret __wrap_##name params                                 \
-	{                                                        \
-		auto *mock = MockEfa::get();                     \
-		if (mock)                                        \
-			return mock->name args;                  \
-		return __real_##name args;                       \
+/*
+ * Route a wrapped call into the mock only when the installed mock has armed
+ * this function (via EFA_EXPECT_CALL); otherwise fall through to __real_.
+ */
+#define EFA_MOCK_GEN_WRAP(ret, name, params, args)                      \
+	ret __wrap_##name params                                        \
+	{                                                               \
+		auto *mock = MockEfa::get();                            \
+		if (mock && mock->is_armed(MockEfa::FN_##name))         \
+			return mock->name args;                         \
+		return __real_##name args;                              \
 	}
 
 extern "C" {

--- a/prov/efa/test/gtest/efa_gtest_common_mocks.cc
+++ b/prov/efa/test/gtest/efa_gtest_common_mocks.cc
@@ -16,13 +16,13 @@ void MockEfa::set(MockEfa *instance)
 }
 
 // Generate the definitions of the __wrap_* functions
-#define EFA_MOCK_GEN_WRAP(ret, name)                             \
-	ret __wrap_##name(EFA_MOCK_PARAMS_##name)                \
+#define EFA_MOCK_GEN_WRAP(ret, name, params, args)               \
+	ret __wrap_##name params                                 \
 	{                                                        \
 		auto *mock = MockEfa::get();                     \
 		if (mock)                                        \
-			return mock->name(EFA_MOCK_ARGS_##name); \
-		return __real_##name(EFA_MOCK_ARGS_##name);      \
+			return mock->name args;                  \
+		return __real_##name args;                       \
 	}
 
 extern "C" {

--- a/prov/efa/test/gtest/efa_gtest_common_mocks.h
+++ b/prov/efa/test/gtest/efa_gtest_common_mocks.h
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
-/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All
+ * rights reserved. */
 
 #ifndef EFA_GTEST_COMMON_MOCKS_H
 #define EFA_GTEST_COMMON_MOCKS_H
@@ -21,126 +22,85 @@ struct efa_qp;
 struct efa_ah;
 
 /*
- * X macro infrastructure for mock generation.
+ * X-macro list of every mocked function. Each row is
+ *   X(ret, name, (param decls), (arg names))
  *
  * To add a new mocked function:
- *   1. Define EFA_MOCK_PARAMS_<name> and EFA_MOCK_ARGS_<name> below
- *   2. Add X(ret, name) to EFA_MOCK_FUNCTIONS
- *   3. Add any needed forward struct declarations above
- *   4. Add -Wl,--wrap=<name> to prov_efa_test_gtest_efa_gtest_LDFLAGS
+ *   1. Add a row to EFA_MOCK_FUNCTIONS
+ *   2. Add any needed forward struct declarations above
+ *   3. Add -Wl,--wrap=<name> to prov_efa_test_gtest_efa_gtest_LDFLAGS
  *      in prov/efa/Makefile.include
  */
-
-/* --- Per-function parameter definitions --- */
-
-#define EFA_MOCK_PARAMS_ibv_create_ah \
-	struct ibv_pd *pd, struct ibv_ah_attr *attr
-#define EFA_MOCK_ARGS_ibv_create_ah pd, attr
-
-#define EFA_MOCK_PARAMS_ibv_destroy_ah struct ibv_ah *ibv_ah
-#define EFA_MOCK_ARGS_ibv_destroy_ah   ibv_ah
-
-#define EFA_MOCK_PARAMS_efadv_query_ah \
-	struct ibv_ah *ibv_ah, struct efadv_ah_attr *attr, uint32_t inlen
-#define EFA_MOCK_ARGS_efadv_query_ah ibv_ah, attr, inlen
-
-#define EFA_MOCK_PARAMS_efa_av_reverse_av_add                          \
-	struct efa_av *av, struct efa_cur_reverse_av **cur_reverse_av, \
-		struct efa_prv_reverse_av **prv_reverse_av,            \
-		struct efa_conn *conn
-#define EFA_MOCK_ARGS_efa_av_reverse_av_add \
-	av, cur_reverse_av, prv_reverse_av, conn
-
-#define EFA_MOCK_PARAMS_ofi_mr_map_insert                                  \
-	struct ofi_mr_map *map, const struct fi_mr_attr *attr,             \
-		uint64_t *key, void *context, uint64_t flags
-#define EFA_MOCK_ARGS_ofi_mr_map_insert map, attr, key, context, flags
-#define EFA_MOCK_PARAMS_efa_rdm_pke_clone                              \
-	struct efa_rdm_pke *src, struct ofi_bufpool *pkt_pool, int alloc_type
-#define EFA_MOCK_ARGS_efa_rdm_pke_clone src, pkt_pool, alloc_type
-
-#define EFA_MOCK_PARAMS_efa_qp_post_recv \
-	struct efa_qp *qp, struct ibv_recv_wr *wr, struct ibv_recv_wr **bad
-#define EFA_MOCK_ARGS_efa_qp_post_recv qp, wr, bad
-
-#define EFA_MOCK_PARAMS_efa_qp_post_send                                        \
-	struct efa_qp *qp, const struct ibv_sge *sge_list,                     \
-		const struct ibv_data_buf *inline_data_list, size_t iov_count, \
-		bool use_inline, uintptr_t wr_id, uint64_t data,               \
-		uint64_t flags, struct efa_ah *ah, uint32_t qpn, uint32_t qkey
-#define EFA_MOCK_ARGS_efa_qp_post_send                                        \
-	qp, sge_list, inline_data_list, iov_count, use_inline, wr_id, data,   \
-		flags, ah, qpn, qkey
-
-#define EFA_MOCK_PARAMS_efa_qp_post_read                                       \
-	struct efa_qp *qp, const struct ibv_sge *sge_list, size_t sge_count,  \
-		uint32_t remote_key, uint64_t remote_addr, uintptr_t wr_id,   \
-		uint64_t flags, struct efa_ah *ah, uint32_t qpn, uint32_t qkey
-#define EFA_MOCK_ARGS_efa_qp_post_read \
-	qp, sge_list, sge_count, remote_key, remote_addr, wr_id, flags, ah, qpn, qkey
-
-#define EFA_MOCK_PARAMS_efa_qp_post_write                                      \
-	struct efa_qp *qp, const struct ibv_sge *sge_list, size_t sge_count,  \
-		const struct ibv_data_buf *inline_data_list, bool use_inline, \
-		uint32_t remote_key, uint64_t remote_addr, uintptr_t wr_id,   \
-		uint64_t data, uint64_t flags, struct efa_ah *ah,             \
-		uint32_t qpn, uint32_t qkey
-#define EFA_MOCK_ARGS_efa_qp_post_write                                  \
-	qp, sge_list, sge_count, inline_data_list, use_inline, remote_key, \
-		remote_addr, wr_id, data, flags, ah, qpn, qkey
-
-#define EFA_MOCK_PARAMS_efa_ibv_cq_start_poll \
-	struct efa_ibv_cq *ibv_cq, struct ibv_poll_cq_attr *attr
-#define EFA_MOCK_ARGS_efa_ibv_cq_start_poll ibv_cq, attr
-
-#define EFA_MOCK_PARAMS_efa_ibv_cq_end_poll struct efa_ibv_cq *ibv_cq
-#define EFA_MOCK_ARGS_efa_ibv_cq_end_poll   ibv_cq
-
-#define EFA_MOCK_PARAMS_efa_ibv_cq_wc_read_opcode struct efa_ibv_cq *ibv_cq
-#define EFA_MOCK_ARGS_efa_ibv_cq_wc_read_opcode	  ibv_cq
-
-#define EFA_MOCK_PARAMS_efa_ibv_cq_wc_read_vendor_err struct efa_ibv_cq *ibv_cq
-#define EFA_MOCK_ARGS_efa_ibv_cq_wc_read_vendor_err   ibv_cq
-
-#define EFA_MOCK_PARAMS_efa_ibv_cq_wc_read_qp_num struct efa_ibv_cq *ibv_cq
-#define EFA_MOCK_ARGS_efa_ibv_cq_wc_read_qp_num	  ibv_cq
-
-#define EFA_MOCK_PARAMS_efa_ibv_cq_wc_read_wc_flags struct efa_ibv_cq *ibv_cq
-#define EFA_MOCK_ARGS_efa_ibv_cq_wc_read_wc_flags   ibv_cq
-
-#define EFA_MOCK_PARAMS_efa_ibv_cq_wc_read_byte_len struct efa_ibv_cq *ibv_cq
-#define EFA_MOCK_ARGS_efa_ibv_cq_wc_read_byte_len   ibv_cq
-
-/* --- Function list --- */
-
-#define EFA_MOCK_FUNCTIONS(X)             \
-	X(struct ibv_ah *, ibv_create_ah) \
-	X(int, ibv_destroy_ah)            \
-	X(int, efadv_query_ah)            \
-	X(int, efa_av_reverse_av_add)     \
-	X(int, efa_qp_post_recv)          \
-	X(int, efa_qp_post_send)          \
-	X(int, efa_qp_post_read)          \
-	X(int, efa_qp_post_write)		\
-	X(int, efa_ibv_cq_start_poll)                    \
-	X(void, efa_ibv_cq_end_poll)                     \
-	X(enum ibv_wc_opcode, efa_ibv_cq_wc_read_opcode) \
-	X(uint32_t, efa_ibv_cq_wc_read_vendor_err)       \
-	X(uint32_t, efa_ibv_cq_wc_read_qp_num)           \
-	X(unsigned int, efa_ibv_cq_wc_read_wc_flags)     \
-	X(uint32_t, efa_ibv_cq_wc_read_byte_len)		\
-	X(int, ofi_mr_map_insert)						\
-	X(struct efa_rdm_pke *, efa_rdm_pke_clone)
+#define EFA_MOCK_FUNCTIONS(X)                                                  \
+	X(struct ibv_ah *, ibv_create_ah,                                      \
+	  (struct ibv_pd * pd, struct ibv_ah_attr * attr), (pd, attr))         \
+	X(int, ibv_destroy_ah, (struct ibv_ah * ibv_ah), (ibv_ah))             \
+	X(int, efadv_query_ah,                                                 \
+	  (struct ibv_ah * ibv_ah, struct efadv_ah_attr * attr,                \
+	   uint32_t inlen),                                                    \
+	  (ibv_ah, attr, inlen))                                               \
+	X(int, efa_av_reverse_av_add,                                          \
+	  (struct efa_av * av, struct efa_cur_reverse_av * *cur_reverse_av,    \
+	   struct efa_prv_reverse_av * *prv_reverse_av,                        \
+	   struct efa_conn * conn),                                            \
+	  (av, cur_reverse_av, prv_reverse_av, conn))                          \
+	X(int, efa_ibv_cq_start_poll,                                          \
+	  (struct efa_ibv_cq * ibv_cq, struct ibv_poll_cq_attr * attr),        \
+	  (ibv_cq, attr))                                                      \
+	X(void, efa_ibv_cq_end_poll, (struct efa_ibv_cq * ibv_cq), (ibv_cq))   \
+	X(enum ibv_wc_opcode, efa_ibv_cq_wc_read_opcode,                       \
+	  (struct efa_ibv_cq * ibv_cq), (ibv_cq))                              \
+	X(uint32_t, efa_ibv_cq_wc_read_vendor_err,                             \
+	  (struct efa_ibv_cq * ibv_cq), (ibv_cq))                              \
+	X(uint32_t, efa_ibv_cq_wc_read_qp_num, (struct efa_ibv_cq * ibv_cq),   \
+	  (ibv_cq))                                                            \
+	X(unsigned int, efa_ibv_cq_wc_read_wc_flags,                           \
+	  (struct efa_ibv_cq * ibv_cq), (ibv_cq))                              \
+	X(uint32_t, efa_ibv_cq_wc_read_byte_len, (struct efa_ibv_cq * ibv_cq), \
+	  (ibv_cq))                                                            \
+	X(int, ofi_mr_map_insert,                                              \
+	  (struct ofi_mr_map * map, const struct fi_mr_attr *attr,             \
+	   uint64_t *key, void *context, uint64_t flags),                      \
+	  (map, attr, key, context, flags))                                    \
+	X(struct efa_rdm_pke *, efa_rdm_pke_clone,                             \
+	  (struct efa_rdm_pke * src, struct ofi_bufpool * pkt_pool,            \
+	   int alloc_type),                                                    \
+	  (src, pkt_pool, alloc_type))                                         \
+	X(int, efa_qp_post_recv,                                               \
+	  (struct efa_qp * qp, struct ibv_recv_wr * wr,                        \
+	   struct ibv_recv_wr * *bad),                                         \
+	  (qp, wr, bad))                                                       \
+	X(int, efa_qp_post_send,                                               \
+	  (struct efa_qp * qp, const struct ibv_sge *sge_list,                 \
+	   const struct ibv_data_buf *inline_data_list, size_t iov_count,      \
+	   bool use_inline, uintptr_t wr_id, uint64_t data, uint64_t flags,    \
+	   struct efa_ah *ah, uint32_t qpn, uint32_t qkey),                    \
+	  (qp, sge_list, inline_data_list, iov_count, use_inline, wr_id, data, \
+	   flags, ah, qpn, qkey))                                              \
+	X(int, efa_qp_post_read,                                               \
+	  (struct efa_qp * qp, const struct ibv_sge *sge_list,                 \
+	   size_t sge_count, uint32_t remote_key, uint64_t remote_addr,        \
+	   uintptr_t wr_id, uint64_t flags, struct efa_ah *ah, uint32_t qpn,   \
+	   uint32_t qkey),                                                     \
+	  (qp, sge_list, sge_count, remote_key, remote_addr, wr_id, flags, ah, \
+	   qpn, qkey))                                                         \
+	X(int, efa_qp_post_write,                                              \
+	  (struct efa_qp * qp, const struct ibv_sge *sge_list,                 \
+	   size_t sge_count, const struct ibv_data_buf *inline_data_list,      \
+	   bool use_inline, uint32_t remote_key, uint64_t remote_addr,         \
+	   uintptr_t wr_id, uint64_t data, uint64_t flags, struct efa_ah *ah,  \
+	   uint32_t qpn, uint32_t qkey),                                       \
+	  (qp, sge_list, sge_count, inline_data_list, use_inline, remote_key,  \
+	   remote_addr, wr_id, data, flags, ah, qpn, qkey))
 
 /* --- Generator macros --- */
 
-#define EFA_MOCK_GEN_METHOD(ret, name) \
-	MOCK_METHOD(ret, name, (EFA_MOCK_PARAMS_##name));
+#define EFA_MOCK_GEN_METHOD(ret, name, params, args) \
+	MOCK_METHOD(ret, name, params);
 
-#define EFA_MOCK_GEN_REAL_DECL(ret, name) \
-	ret __real_##name(EFA_MOCK_PARAMS_##name);
+#define EFA_MOCK_GEN_REAL_DECL(ret, name, params, args) \
+	ret __real_##name params;
 
-// Generate the definitions of the MOCK_METHOD's in the MockEfa class
 class MockEfa
 {
 	public:

--- a/prov/efa/test/gtest/efa_gtest_common_mocks.h
+++ b/prov/efa/test/gtest/efa_gtest_common_mocks.h
@@ -5,6 +5,7 @@
 #ifndef EFA_GTEST_COMMON_MOCKS_H
 #define EFA_GTEST_COMMON_MOCKS_H
 
+#include <bitset>
 #include <gmock/gmock.h>
 #include <infiniband/efadv.h>
 #include <infiniband/verbs.h>
@@ -24,7 +25,7 @@ struct efa_ah;
 /*
  * X-macro list of every mocked function. Each row is
  *   X(ret, name, (param decls), (arg names))
- *
+ * 
  * To add a new mocked function:
  *   1. Add a row to EFA_MOCK_FUNCTIONS
  *   2. Add any needed forward struct declarations above
@@ -101,14 +102,30 @@ struct efa_ah;
 #define EFA_MOCK_GEN_REAL_DECL(ret, name, params, args) \
 	ret __real_##name params;
 
+#define EFA_MOCK_GEN_ENUM(ret, name, params, args) FN_##name,
+
 class MockEfa
 {
 	public:
 	EFA_MOCK_FUNCTIONS(EFA_MOCK_GEN_METHOD)
 
+	/* FN_COUNT is the last member of the enum, hence the number of wrapped fns */
+	enum Fn { EFA_MOCK_FUNCTIONS(EFA_MOCK_GEN_ENUM) FN_COUNT };
+
+	void arm(Fn fn) { armed_.set(fn); }
+	/* test whether a wrapped function should be mocked in the current test */
+	bool is_armed(Fn fn) const { return armed_.test(fn); }
+
 	static MockEfa *get();
 	static void set(MockEfa *instance);
+
+	private:
+	std::bitset<FN_COUNT> armed_;
 };
+
+#define EFA_EXPECT_CALL(obj, name, ...)          \
+	((obj).arm(MockEfa::FN_##name),          \
+	 EXPECT_CALL(obj, name __VA_OPT__((__VA_ARGS__))))
 
 // Generate the declarations of the real function prototypes
 extern "C" {

--- a/prov/efa/test/gtest/efa_gtest_conn.cc
+++ b/prov/efa/test/gtest/efa_gtest_conn.cc
@@ -24,9 +24,6 @@ class EfaConnTest : public Test
 
 	void TearDown() override
 	{
-		/* Uninstall the mock before destruct: ep close drains the RDM
-		 * CQ, whose efa_ibv_cq_* calls are globally wrapped and would
-		 * otherwise route into the (now-irrelevant) mock. */
 		MockEfa::set(nullptr);
 		efa_test_resource_destruct(&resource);
 	}
@@ -47,14 +44,15 @@ TEST_F(EfaConnTest, alloc_reverse_av_add_failure_rdm_cleanup)
 	ASSERT_NE(resource.ep, nullptr);
 
 	MockEfa::set(&mock_efa);
-	EXPECT_CALL(mock_efa, ibv_create_ah)
+	EFA_EXPECT_CALL(mock_efa, ibv_create_ah)
 		.WillOnce(Return(&dummy_ibv_ah));
 	/* The unwind releases only the peer's dummy AH; self_ah is destroyed
 	 * in teardown after the mock is uninstalled (real destroy). */
-	EXPECT_CALL(mock_efa, ibv_destroy_ah(&dummy_ibv_ah)).WillOnce(Return(0));
-	EXPECT_CALL(mock_efa, efadv_query_ah)
+	EFA_EXPECT_CALL(mock_efa, ibv_destroy_ah, &dummy_ibv_ah)
+		.WillOnce(Return(0));
+	EFA_EXPECT_CALL(mock_efa, efadv_query_ah)
 		.WillRepeatedly(Return(0));
-	EXPECT_CALL(mock_efa, efa_av_reverse_av_add)
+	EFA_EXPECT_CALL(mock_efa, efa_av_reverse_av_add)
 		.WillOnce(Return(-FI_ENOMEM));
 
 	addr = efa_test_insert_peer_new_gid(resource.ep, resource.av);
@@ -79,14 +77,15 @@ TEST_F(EfaConnTest, alloc_reverse_av_add_failure_explicit_insert)
 	ASSERT_NE(resource.ep, nullptr);
 
 	MockEfa::set(&mock_efa);
-	EXPECT_CALL(mock_efa, ibv_create_ah(_, _))
+	EFA_EXPECT_CALL(mock_efa, ibv_create_ah, _, _)
 		.WillOnce(Return(&dummy_ibv_ah));
 	/* The unwind releases only the peer's dummy AH; self_ah is destroyed
 	 * in teardown after the mock is uninstalled (real destroy). */
-	EXPECT_CALL(mock_efa, ibv_destroy_ah(&dummy_ibv_ah)).WillOnce(Return(0));
-	EXPECT_CALL(mock_efa, efadv_query_ah)
+	EFA_EXPECT_CALL(mock_efa, ibv_destroy_ah, &dummy_ibv_ah)
+		.WillOnce(Return(0));
+	EFA_EXPECT_CALL(mock_efa, efadv_query_ah)
 		.WillRepeatedly(Return(0));
-	EXPECT_CALL(mock_efa, efa_av_reverse_av_add)
+	EFA_EXPECT_CALL(mock_efa, efa_av_reverse_av_add)
 		.WillOnce(Return(-FI_ENOMEM));
 
 	num_addr = efa_test_explicit_av_insert(resource.ep, resource.av, &addr);

--- a/prov/efa/test/gtest/efa_gtest_cq.cc
+++ b/prov/efa/test/gtest/efa_gtest_cq.cc
@@ -46,18 +46,18 @@ class EfaCqTest : public Test
 	/* Set up expectations to get an error cqe */
 	void set_expectations_for_cq_err()
 	{
-		EXPECT_CALL(mock_efa, efa_ibv_cq_start_poll).WillOnce(Return(0));
-		EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_qp_num)
+		EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_start_poll).WillOnce(Return(0));
+		EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_qp_num)
 			.WillOnce(Return(qp_num));
-		EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_opcode)
+		EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_opcode)
 			.WillOnce(Return(IBV_WC_SEND));
-		EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_vendor_err)
+		EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_vendor_err)
 			.WillOnce(Return(kProvErrno));
-		EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_byte_len)
+		EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_byte_len)
 			.WillOnce(Return(64));
-		EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_wc_flags)
+		EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_wc_flags)
 			.WillOnce(Return(0));
-		EXPECT_CALL(mock_efa, efa_ibv_cq_end_poll).Times(1);
+		EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_end_poll).Times(1);
 	}
 
 	void drive_error_cqe(struct efa_context *ctx,

--- a/prov/efa/test/gtest/efa_gtest_msg.cc
+++ b/prov/efa/test/gtest/efa_gtest_msg.cc
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
-/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All
+ * rights reserved. */
 
 #include "efa_gtest_common_helpers.h"
 #include "efa_gtest_common_mocks.h"
@@ -40,8 +41,8 @@ class EfaMsgTest : public Test
 		ASSERT_EQ(ret, 0) << "fi_mr_reg failed: " << fi_strerror(-ret);
 		local_desc = fi_mr_desc(local_mr);
 
-		peer_addr = efa_test_insert_self_gid_peer(resource.ep,
-							  resource.av);
+		peer_addr =
+			efa_test_insert_self_gid_peer(resource.ep, resource.av);
 		ASSERT_NE(peer_addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
 
 		MockEfa::set(&mock_efa);
@@ -69,7 +70,8 @@ class EfaMsgTest : public Test
 };
 
 /**
- * @brief Asserts that efa_post_send with track_mr posts a direct_ope which persists
+ * @brief Asserts that efa_post_send with track_mr posts a direct_ope which
+ * persists
  */
 TEST_F(EfaMsgTest, send_success_keeps_direct_ope_alive)
 {
@@ -82,9 +84,8 @@ TEST_F(EfaMsgTest, send_success_keeps_direct_ope_alive)
 	auto wr_id_is_not_ctx = Truly([&ctx](uintptr_t wr_id) {
 		return wr_id != 0 && wr_id != (uintptr_t) &ctx;
 	});
-	EXPECT_CALL(mock_efa,
-		    efa_qp_post_send(_, _, _, 1, _, wr_id_is_not_ctx, _, _,
-				     _, _, _))
+	EFA_EXPECT_CALL(mock_efa, efa_qp_post_send, _, _, _, 1, _,
+			wr_id_is_not_ctx, _, _, _, _, _)
 		.WillOnce(Return(0));
 
 	int ret = fi_send(resource.ep, local_buf, 4096, local_desc, peer_addr,
@@ -95,7 +96,8 @@ TEST_F(EfaMsgTest, send_success_keeps_direct_ope_alive)
 }
 
 /**
- * @brief Asserts that efa_post_recv with track_mr posts a direct_ope which persists
+ * @brief Asserts that efa_post_recv with track_mr posts a direct_ope which
+ * persists
  */
 TEST_F(EfaMsgTest, recv_success_keeps_direct_ope_alive)
 {
@@ -108,7 +110,7 @@ TEST_F(EfaMsgTest, recv_success_keeps_direct_ope_alive)
 	auto wr_id_is_not_ctx = Truly([&ctx](const struct ibv_recv_wr *wr) {
 		return wr->wr_id != 0 && wr->wr_id != (uintptr_t) &ctx;
 	});
-	EXPECT_CALL(mock_efa, efa_qp_post_recv(_, wr_id_is_not_ctx, _))
+	EFA_EXPECT_CALL(mock_efa, efa_qp_post_recv, _, wr_id_is_not_ctx, _)
 		.WillOnce(Return(0));
 
 	int ret = fi_recv(resource.ep, local_buf, 4096, local_desc, peer_addr,

--- a/prov/efa/test/gtest/efa_gtest_rdm_mr.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_mr.cc
@@ -54,7 +54,7 @@ TEST_F(EfaRdmMrTest, reg_map_insert_failure_propagates_error)
 	attr.access = FI_SEND | FI_RECV;
 	attr.iface = FI_HMEM_SYSTEM;
 
-	EXPECT_CALL(mock_efa, ofi_mr_map_insert)
+	EFA_EXPECT_CALL(mock_efa, ofi_mr_map_insert)
 		.Times(1)
 		.WillOnce(Return(-FI_ENOMEM));
 

--- a/prov/efa/test/gtest/efa_gtest_rdm_peer.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_peer.cc
@@ -47,8 +47,7 @@ TEST_F(EfaRdmPeerTest, failed_reorder_msg_releases_rx_pkt)
 {
 	size_t to_post_before = 0, to_post_after = 0;
 
-	EXPECT_CALL(mock_efa, ofi_mr_map_insert).WillRepeatedly(Invoke(__real_ofi_mr_map_insert));
-	EXPECT_CALL(mock_efa, efa_rdm_pke_clone).WillOnce(Return(nullptr));
+	EFA_EXPECT_CALL(mock_efa, efa_rdm_pke_clone).WillOnce(Return(nullptr));
 
 	ASSERT_EQ(efa_test_failed_reorder_msg_releases_rx_pkt(
 			  resource.ep, peer_addr, &to_post_before,
@@ -67,8 +66,7 @@ TEST_F(EfaRdmPeerTest, failed_reorder_msg_overflow_releases_rx_pkt_and_entry)
 	size_t to_post_before = 0, to_post_after = 0;
 	size_t overflow_free_before = 0, overflow_free_after = 0;
 
-	EXPECT_CALL(mock_efa, ofi_mr_map_insert).WillRepeatedly(Invoke(__real_ofi_mr_map_insert));
-	EXPECT_CALL(mock_efa, efa_rdm_pke_clone).WillOnce(Return(nullptr));
+	EFA_EXPECT_CALL(mock_efa, efa_rdm_pke_clone).WillOnce(Return(nullptr));
 
 	ASSERT_EQ(efa_test_failed_reorder_msg_overflow_releases_rx_pkt_and_entry(
 			  resource.ep, peer_addr, &to_post_before,

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc
@@ -49,9 +49,6 @@ TEST_P(EfaRtmTest, read_nack_missing_rxe_no_null_deref)
 {
 	ssize_t ret = 0;
 
-	EXPECT_CALL(mock_efa, ofi_mr_map_insert)
-		.WillOnce(Invoke(__real_ofi_mr_map_insert));
-
 	ASSERT_EQ(efa_test_rtm_read_nack_missing_rxe(resource.ep, peer_addr,
 						     GetParam(), &ret),
 		  1);

--- a/prov/efa/test/gtest/efa_gtest_rma.cc
+++ b/prov/efa/test/gtest/efa_gtest_rma.cc
@@ -1,5 +1,6 @@
 /* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
-/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All
+ * rights reserved. */
 
 #include "efa_gtest_common_helpers.h"
 #include "efa_gtest_common_mocks.h"
@@ -47,8 +48,8 @@ class EfaRmaTest : public Test
 		ASSERT_EQ(ret, 0) << "fi_mr_reg failed: " << fi_strerror(-ret);
 		local_desc = fi_mr_desc(local_mr);
 
-		peer_addr = efa_test_insert_self_gid_peer(resource.ep,
-							  resource.av);
+		peer_addr =
+			efa_test_insert_self_gid_peer(resource.ep, resource.av);
 		ASSERT_NE(peer_addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
 
 		MockEfa::set(&mock_efa);
@@ -80,7 +81,8 @@ class EfaRmaTest : public Test
 };
 
 /**
- * @brief Asserts that efa_rma_post_read with track_mr posts a direct_ope which persists
+ * @brief Asserts that efa_rma_post_read with track_mr posts a direct_ope which
+ * persists
  */
 TEST_F(EfaRmaTest, read_success_keeps_direct_ope_alive)
 {
@@ -93,9 +95,8 @@ TEST_F(EfaRmaTest, read_success_keeps_direct_ope_alive)
 	auto wr_id_is_not_ctx = Truly([&ctx](uintptr_t wr_id) {
 		return wr_id != 0 && wr_id != (uintptr_t) &ctx;
 	});
-	EXPECT_CALL(mock_efa,
-		    efa_qp_post_read(_, _, 1, kRemoteKey, kRemoteAddr,
-				     wr_id_is_not_ctx, _, _, _, _))
+	EFA_EXPECT_CALL(mock_efa, efa_qp_post_read, _, _, 1, kRemoteKey,
+			kRemoteAddr, wr_id_is_not_ctx, _, _, _, _)
 		.WillOnce(Return(0));
 
 	int ret = fi_read(resource.ep, local_buf, 4096, local_desc, peer_addr,
@@ -106,7 +107,8 @@ TEST_F(EfaRmaTest, read_success_keeps_direct_ope_alive)
 }
 
 /**
- * @brief Asserts that efa_rma_post_write with track_mr posts a direct_ope which persists
+ * @brief Asserts that efa_rma_post_write with track_mr posts a direct_ope which
+ * persists
  */
 TEST_F(EfaRmaTest, write_success_keeps_direct_ope_alive)
 {
@@ -119,9 +121,8 @@ TEST_F(EfaRmaTest, write_success_keeps_direct_ope_alive)
 	auto wr_id_is_not_ctx = Truly([&ctx](uintptr_t wr_id) {
 		return wr_id != 0 && wr_id != (uintptr_t) &ctx;
 	});
-	EXPECT_CALL(mock_efa,
-		    efa_qp_post_write(_, _, 1, _, _, kRemoteKey, kRemoteAddr,
-				      wr_id_is_not_ctx, _, _, _, _, _))
+	EFA_EXPECT_CALL(mock_efa, efa_qp_post_write, _, _, 1, _, _, kRemoteKey,
+			kRemoteAddr, wr_id_is_not_ctx, _, _, _, _, _)
 		.WillOnce(Return(0));
 
 	int ret = fi_write(resource.ep, local_buf, 4096, local_desc, peer_addr,


### PR DESCRIPTION
This PR does the following
1. reorganize the X-macro so that each new mocked function is added in exactly one place.
2. add an 'arming' mechanism that automatically detects which functions a test needs to mock and only route those calls to the mocked function, leaving the rest of the wrapped functions to the real implementations.
3. update the README.md in the gtest suite to reflect the above
4. add AGENTS.md for writing new gtest unit tests
5. Decouple the gTest and CMocka suites (either flags alone now compile and run)
6. Bump the C++ standard to 20