### PR TITLE
prov/efa: make the peer map a per-endpoint fi_addr-indexed array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 *.vc.db
 *.vc.opendb
 *.log
+*.trs
 *.exe
 *.lib
 *.dll
@@ -103,3 +104,7 @@ prov/efa/docs/doxygen/latex
 # Rust
 /target
 /Cargo.lock
+
+# EFA test binaries (build outputs)
+prov/efa/test/gtest/efa_gtest
+prov/efa/test/efa_unit_test

--- a/prov/efa/src/efa_ah.c
+++ b/prov/efa/src/efa_ah.c
@@ -15,7 +15,7 @@ void efa_ah_destroy_ah(struct efa_domain *domain, struct efa_ah *ah);
  * @brief Move the AH to the end of the LRU list to indicate that it is the
  * most recently used entry
  *
- * This function is not called in the efa_rdm_ep_get_peer so that we don't add
+ * This function is not called in efa_rdm_ep_get_peer_explicit so that we don't add
  * extra latency to the critical path with explicit AV insertion. We use the LRU
  * list to remove AH entries with only implicit AV entries, so it is OK to do
  * that.

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -351,7 +351,7 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 	struct efa_rdm_ep *ep;
 	struct dlist_entry *entry;
 	struct util_av_entry *implicit_util_av_entry, *explicit_util_av_entry;
-	struct efa_conn_ep_peer_map_entry *map_entry, *tmp;
+	struct efa_rdm_peer *peer;
 	struct efa_av_entry *implicit_av_entry, *explicit_av_entry;
 	struct fid_peer_srx *peer_srx;
 
@@ -404,12 +404,6 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 	explicit_conn->fi_addr = *fi_addr;
 	explicit_conn->shm_fi_addr = implicit_conn->shm_fi_addr;
 	explicit_conn->implicit_fi_addr = FI_ADDR_NOTAVAIL;
-	HASH_ITER(hh, implicit_conn->ep_peer_map, map_entry, tmp) {
-		HASH_DELETE(hh, implicit_conn->ep_peer_map, map_entry);
-		HASH_ADD_PTR(explicit_conn->ep_peer_map, ep_ptr, map_entry);
-		map_entry->peer.conn = explicit_conn;
-	}
-	assert(HASH_CNT(hh, implicit_conn->ep_peer_map) == 0);
 
 	/* Handle reverse AV and AV ref counts */
 	efa_av_reverse_av_remove(&av->cur_reverse_av_implicit,
@@ -451,6 +445,14 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 	ofi_genlock_lock(&av->util_av.ep_list_lock);
 	dlist_foreach(&av->util_av.ep_list, entry) {
 		ep = container_of(entry, struct efa_rdm_ep, base_ep.util_ep.av_entry);
+		/* move from implicit to explicit peer map, using new fi_addr */
+		peer = efa_rdm_peer_map_remove(&ep->fi_addr_to_peer_map_implicit,
+					       implicit_fi_addr);
+		if (peer) {
+			peer->conn = explicit_conn;
+			efa_rdm_peer_map_insert(&ep->fi_addr_to_peer_map,
+						*fi_addr, peer);
+		}
 		peer_srx = util_get_peer_srx(ep->peer_srx_ep);
 		peer_srx->owner_ops->foreach_unspec_addr(peer_srx, &efa_av_get_addr_from_peer_rx_entry);
 	}

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -450,13 +450,18 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 	dlist_foreach(&av->util_av.ep_list, entry) {
 		ep = container_of(entry, struct efa_rdm_ep, base_ep.util_ep.av_entry);
 		/* move from implicit to explicit peer map, using new fi_addr */
+		EFA_GENLOCK_LOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
 		peer = efa_rdm_ep_peer_map_remove(ep->fi_addr_to_peer_map_implicit,
 					       implicit_fi_addr);
 		if (peer) {
 			peer->conn = explicit_conn;
-			efa_rdm_ep_peer_map_insert(ep->fi_addr_to_peer_map,
-						*fi_addr, peer);
+			if (efa_rdm_ep_peer_map_insert(ep->fi_addr_to_peer_map,
+						       *fi_addr, peer))
+				EFA_WARN(FI_LOG_AV,
+					 "Failed to insert peer into explicit map for addr %lu\n",
+					 *fi_addr);
 		}
+		EFA_GENLOCK_UNLOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
 		peer_srx = util_get_peer_srx(ep->peer_srx_ep);
 		peer_srx->owner_ops->foreach_unspec_addr(peer_srx, &efa_av_get_addr_from_peer_rx_entry);
 	}

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -355,7 +355,7 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 	struct efa_rdm_ep *ep;
 	struct dlist_entry *entry;
 	struct util_av_entry *implicit_util_av_entry, *explicit_util_av_entry;
-	struct efa_conn_ep_peer_map_entry *map_entry, *tmp;
+	struct efa_rdm_peer *peer;
 	struct efa_av_entry *implicit_av_entry, *explicit_av_entry;
 	struct fid_peer_srx *peer_srx;
 
@@ -408,12 +408,6 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 	explicit_conn->fi_addr = *fi_addr;
 	explicit_conn->shm_fi_addr = implicit_conn->shm_fi_addr;
 	explicit_conn->implicit_fi_addr = FI_ADDR_NOTAVAIL;
-	HASH_ITER(hh, implicit_conn->ep_peer_map, map_entry, tmp) {
-		HASH_DELETE(hh, implicit_conn->ep_peer_map, map_entry);
-		HASH_ADD_PTR(explicit_conn->ep_peer_map, ep_ptr, map_entry);
-		map_entry->peer.conn = explicit_conn;
-	}
-	assert(HASH_CNT(hh, implicit_conn->ep_peer_map) == 0);
 
 	/* Handle reverse AV and AV ref counts */
 	efa_av_reverse_av_remove(&av->cur_reverse_av_implicit,
@@ -455,6 +449,14 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 	ofi_genlock_lock(&av->util_av.ep_list_lock);
 	dlist_foreach(&av->util_av.ep_list, entry) {
 		ep = container_of(entry, struct efa_rdm_ep, base_ep.util_ep.av_entry);
+		/* move from implicit to explicit peer map, using new fi_addr */
+		peer = efa_rdm_ep_peer_map_remove(ep->fi_addr_to_peer_map_implicit,
+					       implicit_fi_addr);
+		if (peer) {
+			peer->conn = explicit_conn;
+			efa_rdm_ep_peer_map_insert(ep->fi_addr_to_peer_map,
+						*fi_addr, peer);
+		}
 		peer_srx = util_get_peer_srx(ep->peer_srx_ep);
 		peer_srx->owner_ops->foreach_unspec_addr(peer_srx, &efa_av_get_addr_from_peer_rx_entry);
 	}

--- a/prov/efa/src/efa_conn.c
+++ b/prov/efa/src/efa_conn.c
@@ -7,6 +7,7 @@
 #include <infiniband/efadv.h>
 
 #include "efa.h"
+#include "rdm/efa_rdm_ep.h"
 
 /*
  * Local/remote peer detection by comparing peer GID with stored local GIDs
@@ -174,7 +175,11 @@ int efa_conn_rdm_insert_shm_av(struct efa_av *av, struct efa_conn *conn)
 void efa_conn_rdm_deinit(struct efa_av *av, struct efa_conn *conn)
 {
 	int err;
-	struct efa_conn_ep_peer_map_entry *peer_map_entry, *tmp;
+	struct dlist_entry *entry, *tmp;
+	struct efa_rdm_ep *ep;
+	struct ofi_dyn_arr *peer_map;
+	struct efa_rdm_peer *peer;
+	fi_addr_t fi_addr;
 
 	assert(av->domain->info_type == EFA_INFO_RDM);
 
@@ -196,13 +201,26 @@ void efa_conn_rdm_deinit(struct efa_av *av, struct efa_conn *conn)
 	}
 
 	assert(ofi_genlock_held(&((struct efa_rdm_domain *) av->domain)->srx_lock));
-	HASH_ITER(hh, conn->ep_peer_map, peer_map_entry, tmp) {
-		dlist_remove(&peer_map_entry->peer.ep_peer_list_entry);
-		efa_rdm_peer_destruct(&peer_map_entry->peer, peer_map_entry->ep_ptr);
-		HASH_DEL(conn->ep_peer_map, peer_map_entry);
-		ofi_buf_free(peer_map_entry);
+
+	/* since an efa_conn is all connections to a specific remote ep,
+	 * we must walk all local ep peer maps and remove the connection
+	 * to the remote ep */
+	dlist_foreach_safe(&av->util_av.ep_list, entry, tmp) {
+		ep = container_of(entry, struct efa_rdm_ep,
+				  base_ep.util_ep.av_entry);
+		if (conn->fi_addr != FI_ADDR_NOTAVAIL) {
+			peer_map = &ep->fi_addr_to_peer_map;
+			fi_addr = conn->fi_addr;
+		} else {
+			peer_map = &ep->fi_addr_to_peer_map_implicit;
+			fi_addr = conn->implicit_fi_addr;
+		}
+		peer = efa_rdm_peer_map_remove(peer_map, fi_addr);
+		if (peer) {
+			efa_rdm_peer_destruct(peer, ep);
+			ofi_buf_free(peer);
+		}
 	}
-	assert(HASH_CNT(hh, conn->ep_peer_map) == 0);
 }
 
 /**
@@ -443,31 +461,4 @@ void efa_conn_release_ah_unsafe(struct efa_av *av, struct efa_conn *conn,
 
 	release_from_implicit_av ? conn->ah->implicit_refcnt-- :
 				   conn->ah->explicit_refcnt--;
-}
-
-void efa_conn_ep_peer_map_insert(struct efa_conn *conn, struct efa_conn_ep_peer_map_entry *map_entry)
-{
-	HASH_ADD_PTR(conn->ep_peer_map, ep_ptr, map_entry);
-}
-
-struct efa_rdm_peer *efa_conn_ep_peer_map_lookup(struct efa_conn *conn,
-						 struct efa_rdm_ep *ep)
-{
-	struct efa_conn_ep_peer_map_entry *map_entry;
-
-	/* coverity[suspicious_sizeof : FALSE] - key is a pointer; HASH_FIND_PTR compares sizeof(void *) */
-	HASH_FIND_PTR(conn->ep_peer_map, &ep, map_entry);
-
-	return map_entry ? &map_entry->peer : NULL;
-}
-
-void efa_conn_ep_peer_map_remove(struct efa_conn *conn, struct efa_rdm_ep *ep)
-{
-	struct efa_conn_ep_peer_map_entry *map_entry;
-
-	/* coverity[suspicious_sizeof : FALSE] - key is a pointer; HASH_FIND_PTR compares sizeof(void *) */
-	HASH_FIND_PTR(conn->ep_peer_map, &ep, map_entry);
-	assert(map_entry);
-	HASH_DELETE(hh, conn->ep_peer_map, map_entry);
-	ofi_buf_free(map_entry);
 }

--- a/prov/efa/src/efa_conn.c
+++ b/prov/efa/src/efa_conn.c
@@ -7,6 +7,7 @@
 #include <infiniband/efadv.h>
 
 #include "efa.h"
+#include "rdm/efa_rdm_ep.h"
 
 /*
  * Local/remote peer detection by comparing peer GID with stored local GIDs
@@ -174,7 +175,11 @@ int efa_conn_rdm_insert_shm_av(struct efa_av *av, struct efa_conn *conn)
 void efa_conn_rdm_deinit(struct efa_av *av, struct efa_conn *conn)
 {
 	int err;
-	struct efa_conn_ep_peer_map_entry *peer_map_entry, *tmp;
+	struct dlist_entry *entry, *tmp;
+	struct efa_rdm_ep *ep;
+	struct efa_av_array *peer_map;
+	struct efa_rdm_peer *peer;
+	fi_addr_t fi_addr;
 
 	assert(av->domain->info_type == EFA_INFO_RDM);
 
@@ -196,13 +201,26 @@ void efa_conn_rdm_deinit(struct efa_av *av, struct efa_conn *conn)
 	}
 
 	assert(ofi_genlock_held(&((struct efa_rdm_domain *) av->domain)->srx_lock));
-	HASH_ITER(hh, conn->ep_peer_map, peer_map_entry, tmp) {
-		dlist_remove(&peer_map_entry->peer.ep_peer_list_entry);
-		efa_rdm_peer_destruct(&peer_map_entry->peer, peer_map_entry->ep_ptr);
-		HASH_DEL(conn->ep_peer_map, peer_map_entry);
-		ofi_buf_free(peer_map_entry);
+
+	/* since an efa_conn is all connections to a specific remote ep,
+	 * we must walk all local ep peer maps and remove the connection
+	 * to the remote ep */
+	dlist_foreach_safe(&av->util_av.ep_list, entry, tmp) {
+		ep = container_of(entry, struct efa_rdm_ep,
+				  base_ep.util_ep.av_entry);
+		if (conn->fi_addr != FI_ADDR_NOTAVAIL) {
+			peer_map = ep->fi_addr_to_peer_map;
+			fi_addr = conn->fi_addr;
+		} else {
+			peer_map = ep->fi_addr_to_peer_map_implicit;
+			fi_addr = conn->implicit_fi_addr;
+		}
+		peer = efa_rdm_ep_peer_map_remove(peer_map, fi_addr);
+		if (peer) {
+			efa_rdm_peer_destruct(peer, ep);
+			ofi_buf_free(peer);
+		}
 	}
-	assert(HASH_CNT(hh, conn->ep_peer_map) == 0);
 }
 
 /**
@@ -499,31 +517,4 @@ void efa_conn_release_implicit_ah_unsafe(struct efa_av *av, struct efa_conn *con
 	dlist_remove(&conn->ah_implicit_conn_list_entry);
 	efa_conn_release_util_av(av, conn, true);
 	conn->ah->implicit_refcnt--;
-}
-
-void efa_conn_ep_peer_map_insert(struct efa_conn *conn, struct efa_conn_ep_peer_map_entry *map_entry)
-{
-	HASH_ADD_PTR(conn->ep_peer_map, ep_ptr, map_entry);
-}
-
-struct efa_rdm_peer *efa_conn_ep_peer_map_lookup(struct efa_conn *conn,
-						 struct efa_rdm_ep *ep)
-{
-	struct efa_conn_ep_peer_map_entry *map_entry;
-
-	/* coverity[suspicious_sizeof : FALSE] - key is a pointer; HASH_FIND_PTR compares sizeof(void *) */
-	HASH_FIND_PTR(conn->ep_peer_map, &ep, map_entry);
-
-	return map_entry ? &map_entry->peer : NULL;
-}
-
-void efa_conn_ep_peer_map_remove(struct efa_conn *conn, struct efa_rdm_ep *ep)
-{
-	struct efa_conn_ep_peer_map_entry *map_entry;
-
-	/* coverity[suspicious_sizeof : FALSE] - key is a pointer; HASH_FIND_PTR compares sizeof(void *) */
-	HASH_FIND_PTR(conn->ep_peer_map, &ep, map_entry);
-	assert(map_entry);
-	HASH_DELETE(hh, conn->ep_peer_map, map_entry);
-	ofi_buf_free(map_entry);
 }

--- a/prov/efa/src/efa_conn.c
+++ b/prov/efa/src/efa_conn.c
@@ -200,11 +200,10 @@ void efa_conn_rdm_deinit(struct efa_av *av, struct efa_conn *conn)
 		}
 	}
 
-	assert(ofi_genlock_held(&((struct efa_rdm_domain *) av->domain)->srx_lock));
-
 	/* since an efa_conn is all connections to a specific remote ep,
 	 * we must walk all local ep peer maps and remove the connection
 	 * to the remote ep */
+	ofi_genlock_lock(&av->util_av.ep_list_lock);
 	dlist_foreach_safe(&av->util_av.ep_list, entry, tmp) {
 		ep = container_of(entry, struct efa_rdm_ep,
 				  base_ep.util_ep.av_entry);
@@ -215,12 +214,15 @@ void efa_conn_rdm_deinit(struct efa_av *av, struct efa_conn *conn)
 			peer_map = ep->fi_addr_to_peer_map_implicit;
 			fi_addr = conn->implicit_fi_addr;
 		}
+		EFA_GENLOCK_LOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
 		peer = efa_rdm_ep_peer_map_remove(peer_map, fi_addr);
 		if (peer) {
 			efa_rdm_peer_destruct(peer, ep);
 			ofi_buf_free(peer);
 		}
+		EFA_GENLOCK_UNLOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
 	}
+	ofi_genlock_unlock(&av->util_av.ep_list_lock);
 }
 
 /**

--- a/prov/efa/src/efa_conn.h
+++ b/prov/efa/src/efa_conn.h
@@ -16,22 +16,7 @@ struct efa_conn {
 	fi_addr_t		shm_fi_addr;
 	struct dlist_entry	implicit_av_lru_entry;
 	struct dlist_entry ah_implicit_conn_list_entry;
-	struct efa_conn_ep_peer_map_entry *ep_peer_map;
 };
-
-struct efa_conn_ep_peer_map_entry {
-	struct efa_rdm_ep *ep_ptr;
-	struct efa_rdm_peer peer;
-	UT_hash_handle hh;
-};
-
-void efa_conn_ep_peer_map_insert(struct efa_conn *conn,
-				struct efa_conn_ep_peer_map_entry *map_entry);
-
-struct efa_rdm_peer *efa_conn_ep_peer_map_lookup(struct efa_conn *conn,
-						 struct efa_rdm_ep *ep);
-
-void efa_conn_ep_peer_map_remove(struct efa_conn *conn, struct efa_rdm_ep *ep);
 
 int efa_conn_rdm_insert_shm_av(struct efa_av *av, struct efa_conn *conn);
 

--- a/prov/efa/src/efa_conn.h
+++ b/prov/efa/src/efa_conn.h
@@ -17,22 +17,7 @@ struct efa_conn {
 	fi_addr_t		shm_fi_addr;
 	struct dlist_entry	implicit_av_lru_entry;
 	struct dlist_entry ah_implicit_conn_list_entry;
-	struct efa_conn_ep_peer_map_entry *ep_peer_map;
 };
-
-struct efa_conn_ep_peer_map_entry {
-	struct efa_rdm_ep *ep_ptr;
-	struct efa_rdm_peer peer;
-	UT_hash_handle hh;
-};
-
-void efa_conn_ep_peer_map_insert(struct efa_conn *conn,
-				struct efa_conn_ep_peer_map_entry *map_entry);
-
-struct efa_rdm_peer *efa_conn_ep_peer_map_lookup(struct efa_conn *conn,
-						 struct efa_rdm_ep *ep);
-
-void efa_conn_ep_peer_map_remove(struct efa_conn *conn, struct efa_rdm_ep *ep);
 
 int efa_conn_rdm_insert_shm_av(struct efa_av *av, struct efa_conn *conn);
 

--- a/prov/efa/src/efa_thread_annotations.c
+++ b/prov/efa/src/efa_thread_annotations.c
@@ -5,3 +5,4 @@
 
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_qp_table_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_implicit_av_lock_sym);
+OFI_TSA_LOCK_SYMBOL_DEFINE(efa_util_ep_lock_sym);

--- a/prov/efa/src/efa_thread_annotations.h
+++ b/prov/efa/src/efa_thread_annotations.h
@@ -94,5 +94,6 @@ efa_genlock_held(struct ofi_genlock *lock, struct ofi_tsa_lock_symbol *sym)
 /* EFA lock symbols (one per lock role). */
 OFI_TSA_LOCK_SYMBOL_DECLARE(efa_qp_table_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DECLARE(efa_implicit_av_lock_sym);
+OFI_TSA_LOCK_SYMBOL_DECLARE(efa_util_ep_lock_sym);
 
 #endif /* EFA_THREAD_ANNOTATIONS_H */

--- a/prov/efa/src/rdm/efa_rdm_cntr.c
+++ b/prov/efa/src/rdm/efa_rdm_cntr.c
@@ -28,8 +28,8 @@ static uint64_t efa_rdm_cntr_read(struct fid_cntr *cntr_fid)
 	/*
 	 * keep srx_lock for ofi_cntr_read because the registered
 	 * progress callback (efa_rdm_cntr_progress) drives ibv_cq polling,
-	 * and the CQ poll path calls efa_rdm_ep_get_peer_explicit which
-	 * asserts srx_lock is held.
+	 * and the CQ poll path looks up peers and the implicit AV, which the
+	 * datapath serializes under srx_lock.
 	 */
 	ret = ofi_cntr_read(cntr_fid);
 	ofi_genlock_unlock(&((struct efa_rdm_domain *) domain)->srx_lock);
@@ -53,8 +53,8 @@ static uint64_t efa_rdm_cntr_readerr(struct fid_cntr *cntr_fid)
 	/*
 	 * keep srx_lock for ofi_cntr_readerr because the registered
 	 * progress callback (efa_rdm_cntr_progress) drives ibv_cq polling,
-	 * and the CQ poll path calls efa_rdm_ep_get_peer_explicit which
-	 * asserts srx_lock is held.
+	 * and the CQ poll path looks up peers and the implicit AV, which the
+	 * datapath serializes under srx_lock.
 	 */
 	ret = ofi_cntr_readerr(cntr_fid);
 	ofi_genlock_unlock(&((struct efa_rdm_domain *) domain)->srx_lock);

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -12,6 +12,7 @@
 #include "efa_rdm_rxe_map.h"
 #include "efa_rdm_mr.h"
 #include "efa_rdm_domain.h"
+#include "ofi_indexer.h"
 
 
 /** @brief Information of a queued copy.
@@ -132,11 +133,12 @@ struct efa_rdm_ep {
 	/* list of pre-posted recv buffers */
 	struct dlist_entry rx_posted_buf_list;
 
-	/* bufpool to hold the fi_addr->peer hashmap entries */
-	struct ofi_bufpool *peer_map_entry_pool;
-
-	/**< List of peers associated with this endpoint */
-	struct dlist_entry ep_peer_list;
+	/* fi_addr-indexed maps from this endpoint to its peers,
+	 * one for the explicit AV and one for the implicit AV. Peers are
+	 * allocated from efa_rdm_peer_pool and the maps hold pointers to them. */
+	struct ofi_dyn_arr fi_addr_to_peer_map;
+	struct ofi_dyn_arr fi_addr_to_peer_map_implicit;
+	struct ofi_bufpool *efa_rdm_peer_pool;
 
 	/* buffer pool for peer reorder circular buffer */
 	struct ofi_bufpool *peer_robuf_pool;
@@ -230,6 +232,14 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer_explicit(struct efa_rdm_ep *ep, fi_addr
 
 int32_t efa_rdm_ep_get_peer_ahn(struct efa_rdm_ep *ep, fi_addr_t addr);
 struct efa_rdm_peer *efa_rdm_ep_get_peer_implicit(struct efa_rdm_ep *ep, fi_addr_t addr);
+
+void efa_rdm_peer_map_init(struct ofi_dyn_arr *arr);
+
+struct efa_rdm_peer *efa_rdm_peer_map_lookup(struct ofi_dyn_arr *arr, fi_addr_t addr);
+
+int efa_rdm_peer_map_insert(struct ofi_dyn_arr *arr, fi_addr_t addr, struct efa_rdm_peer *peer);
+
+struct efa_rdm_peer *efa_rdm_peer_map_remove(struct ofi_dyn_arr *arr, fi_addr_t addr);
 
 struct efa_rdm_ope *efa_rdm_ep_alloc_rxe(struct efa_rdm_ep *ep,
 					   struct efa_rdm_peer *peer, uint32_t op);

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -12,6 +12,8 @@
 #include "efa_rdm_rxe_map.h"
 #include "efa_rdm_mr.h"
 #include "efa_rdm_domain.h"
+#include "ofi_indexer.h"
+#include "efa_av_array.h"
 
 
 /** @brief Information of a queued copy.
@@ -132,11 +134,12 @@ struct efa_rdm_ep {
 	/* list of pre-posted recv buffers */
 	struct dlist_entry rx_posted_buf_list;
 
-	/* bufpool to hold the fi_addr->peer hashmap entries */
-	struct ofi_bufpool *peer_map_entry_pool;
-
-	/**< List of peers associated with this endpoint */
-	struct dlist_entry ep_peer_list;
+	/* fi_addr-indexed maps from this endpoint to its peers,
+	 * one for the explicit AV and one for the implicit AV. Peers are
+	 * allocated from efa_rdm_peer_pool and the maps hold pointers to them. */
+	struct efa_av_array *fi_addr_to_peer_map;
+	struct efa_av_array *fi_addr_to_peer_map_implicit;
+	struct ofi_bufpool *efa_rdm_peer_pool;
 
 	/* buffer pool for peer reorder circular buffer */
 	struct ofi_bufpool *peer_robuf_pool;
@@ -230,6 +233,14 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer_explicit(struct efa_rdm_ep *ep, fi_addr
 
 int32_t efa_rdm_ep_get_peer_ahn(struct efa_rdm_ep *ep, fi_addr_t addr);
 struct efa_rdm_peer *efa_rdm_ep_get_peer_implicit(struct efa_rdm_ep *ep, fi_addr_t addr);
+
+int efa_rdm_ep_peer_map_init(struct efa_av_array **arr);
+
+struct efa_rdm_peer *efa_rdm_ep_peer_map_lookup(struct efa_av_array *arr, fi_addr_t addr);
+
+int efa_rdm_ep_peer_map_insert(struct efa_av_array *arr, fi_addr_t addr, struct efa_rdm_peer *peer);
+
+struct efa_rdm_peer *efa_rdm_ep_peer_map_remove(struct efa_av_array *arr, fi_addr_t addr);
 
 struct efa_rdm_ope *efa_rdm_ep_alloc_rxe(struct efa_rdm_ep *ep,
 					   struct efa_rdm_peer *peer, uint32_t op);

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -228,8 +228,6 @@ int efa_rdm_ep_flush_queued_blocking_copy_to_hmem(struct efa_rdm_ep *ep);
 
 struct efa_ep_addr *efa_rdm_ep_raw_addr(struct efa_rdm_ep *ep);
 
-struct efa_rdm_peer *efa_rdm_ep_get_peer(struct efa_rdm_ep *ep, fi_addr_t addr);
-
 struct efa_rdm_peer *efa_rdm_ep_get_peer_explicit(struct efa_rdm_ep *ep, fi_addr_t addr);
 
 int32_t efa_rdm_ep_get_peer_ahn(struct efa_rdm_ep *ep, fi_addr_t addr);

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -14,6 +14,7 @@
 #include "efa_rdm_domain.h"
 #include "ofi_indexer.h"
 #include "efa_av_array.h"
+#include "efa_thread_annotations.h"
 
 
 /** @brief Information of a queued copy.
@@ -238,9 +239,11 @@ int efa_rdm_ep_peer_map_init(struct efa_av_array **arr);
 
 struct efa_rdm_peer *efa_rdm_ep_peer_map_lookup(struct efa_av_array *arr, fi_addr_t addr);
 
-int efa_rdm_ep_peer_map_insert(struct efa_av_array *arr, fi_addr_t addr, struct efa_rdm_peer *peer);
+int efa_rdm_ep_peer_map_insert(struct efa_av_array *arr, fi_addr_t addr, struct efa_rdm_peer *peer)
+	OFI_TSA_REQUIRES(efa_util_ep_lock_sym);
 
-struct efa_rdm_peer *efa_rdm_ep_peer_map_remove(struct efa_av_array *arr, fi_addr_t addr);
+struct efa_rdm_peer *efa_rdm_ep_peer_map_remove(struct efa_av_array *arr, fi_addr_t addr)
+	OFI_TSA_REQUIRES(efa_util_ep_lock_sym);
 
 struct efa_rdm_ope *efa_rdm_ep_alloc_rxe(struct efa_rdm_ep *ep,
 					   struct efa_rdm_peer *peer, uint32_t op);

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -266,8 +266,8 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 	if (ret)
 		goto err_free;
 
-	ret = ofi_bufpool_create(&ep->peer_map_entry_pool,
-				 sizeof(struct efa_conn_ep_peer_map_entry),
+	ret = ofi_bufpool_create(&ep->efa_rdm_peer_pool,
+				 sizeof(struct efa_rdm_peer),
 				 EFA_RDM_BUFPOOL_ALIGNMENT,
 				 0, /* no limit to max_cnt */
 				 EFA_RDM_EP_MIN_PEER_POOL_SIZE,
@@ -275,9 +275,12 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 	if (ret)
 		goto err_free;
 
-	ret = ofi_bufpool_grow(ep->peer_map_entry_pool);
+	ret = ofi_bufpool_grow(ep->efa_rdm_peer_pool);
 	if (ret)
 		goto err_free;
+
+	efa_rdm_peer_map_init(&ep->fi_addr_to_peer_map);
+	efa_rdm_peer_map_init(&ep->fi_addr_to_peer_map_implicit);
 
 	ret = ofi_bufpool_create(&ep->peer_robuf_pool,
 				(sizeof(struct efa_rdm_pke*) * (roundup_power_of_two(efa_env.recvwin_size)) +
@@ -335,8 +338,8 @@ err_free:
 	if (ep->efa_tx_pkt_pool)
 		ofi_bufpool_destroy(ep->efa_tx_pkt_pool);
 
-	if (ep->peer_map_entry_pool)
-		ofi_bufpool_destroy(ep->peer_map_entry_pool);
+	if (ep->efa_rdm_peer_pool)
+		ofi_bufpool_destroy(ep->efa_rdm_peer_pool);
 
 	if (ep->peer_robuf_pool)
 		ofi_bufpool_destroy(ep->peer_robuf_pool);
@@ -607,10 +610,6 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 		goto err_free_send_pkt_entry_vec;
 	}
 
-	dlist_init(&efa_rdm_ep->ep_peer_list);
-
-	dlist_init(&efa_rdm_ep->ep_peer_list);
-
 	*ep = &efa_rdm_ep->base_ep.util_ep.ep_fid;
 	(*ep)->msg = &efa_rdm_msg_ops;
 	(*ep)->rma = &efa_rdm_rma_ops;
@@ -728,30 +727,52 @@ static int efa_rdm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
  * @param[in,out] efa_rdm_ep  EFA RDM endpoint
  * @related #efa_rdm_ep
  */
+static int efa_rdm_ep_release_peer_overflow_pke(struct ofi_dyn_arr *arr,
+						void *item, void *context)
+{
+	struct efa_rdm_peer *peer = *(struct efa_rdm_peer **) item;
+	struct efa_rdm_peer_overflow_pke_list_entry *overflow_pke_list_entry;
+	struct dlist_entry *tmp;
+
+	if (!peer)
+		return 0;
+
+	dlist_foreach_container_safe(&peer->overflow_pke_list,
+				     struct efa_rdm_peer_overflow_pke_list_entry,
+				     overflow_pke_list_entry, entry, tmp) {
+		dlist_remove(&overflow_pke_list_entry->entry);
+		efa_rdm_pke_release_rx_list(overflow_pke_list_entry->pkt_entry);
+		ofi_buf_free(overflow_pke_list_entry);
+	}
+	return 0;
+}
+
+static int efa_rdm_ep_destroy_peer(struct ofi_dyn_arr *arr, void *item,
+				   void *context)
+{
+	struct efa_rdm_ep *ep = context;
+	struct efa_rdm_peer **slot = item;
+
+	if (*slot) {
+		efa_rdm_peer_destruct(*slot, ep);
+		ofi_buf_free(*slot);
+		*slot = NULL;
+	}
+	return 0;
+}
+
 static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 {
 	struct dlist_entry *entry, *tmp;
-	struct efa_rdm_peer *peer;
-	struct efa_rdm_peer_overflow_pke_list_entry *overflow_pke_list_entry;
-	struct util_av_entry *util_av_entry;
-	struct efa_av_entry *av_entry;
-	struct efa_conn_ep_peer_map_entry *peer_map_entry;
 
 	/*
 	 * Overflow pkes sit on both peer->overflow_pke_list and (in debug mode) rx_pkt_list.
 	 * Release them before: rx_pkt_list debug sweep & efa_rdm_peer_destruct to avoid a double-free.
 	 */
-	dlist_foreach_container(&efa_rdm_ep->ep_peer_list,
-				struct efa_rdm_peer, peer,
-				ep_peer_list_entry) {
-		dlist_foreach_container_safe(&peer->overflow_pke_list,
-					     struct efa_rdm_peer_overflow_pke_list_entry,
-					     overflow_pke_list_entry, entry, tmp) {
-			dlist_remove(&overflow_pke_list_entry->entry);
-			efa_rdm_pke_release_rx_list(overflow_pke_list_entry->pkt_entry);
-			ofi_buf_free(overflow_pke_list_entry);
-		}
-	}
+	ofi_array_iter(&efa_rdm_ep->fi_addr_to_peer_map, efa_rdm_ep,
+		       efa_rdm_ep_release_peer_overflow_pke);
+	ofi_array_iter(&efa_rdm_ep->fi_addr_to_peer_map_implicit, efa_rdm_ep,
+		       efa_rdm_ep_release_peer_overflow_pke);
 
 #if ENABLE_DEBUG
 	struct efa_rdm_pke *pkt_entry;
@@ -795,34 +816,13 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 		}
 	}
 
-	/* Clean up any remaining peers before destroying buffer pools */
-	dlist_foreach_container_safe (&efa_rdm_ep->ep_peer_list,
-				      struct efa_rdm_peer, peer,
-				      ep_peer_list_entry, tmp) {
-
-		if (peer->conn->fi_addr != FI_ADDR_UNSPEC) {
-			util_av_entry = ofi_bufpool_get_ibuf(
-				efa_rdm_ep->base_ep.av->util_av.av_entry_pool,
-				peer->conn->fi_addr);
-		} else {
-			assert(peer->conn->implicit_fi_addr != FI_ADDR_UNSPEC);
-
-			util_av_entry = ofi_bufpool_get_ibuf(
-				efa_rdm_ep->base_ep.av->util_av_implicit.av_entry_pool,
-				peer->conn->implicit_fi_addr);
-		}
-
-		dlist_remove(&peer->ep_peer_list_entry);
-
-		efa_rdm_peer_destruct(peer, efa_rdm_ep);
-
-		peer_map_entry = container_of(
-			peer, struct efa_conn_ep_peer_map_entry, peer);
-
-		av_entry = (struct efa_av_entry *) util_av_entry->data;
-		HASH_DEL(av_entry->conn.ep_peer_map, peer_map_entry);
-		ofi_buf_free(peer_map_entry);
-	}
+	/* free every peer this endpoint created, then release the maps and pools */
+	ofi_array_iter(&efa_rdm_ep->fi_addr_to_peer_map, efa_rdm_ep,
+		       efa_rdm_ep_destroy_peer);
+	ofi_array_iter(&efa_rdm_ep->fi_addr_to_peer_map_implicit, efa_rdm_ep,
+		       efa_rdm_ep_destroy_peer);
+	ofi_array_destroy(&efa_rdm_ep->fi_addr_to_peer_map);
+	ofi_array_destroy(&efa_rdm_ep->fi_addr_to_peer_map_implicit);
 
 	if (efa_rdm_ep->base_ep.ope_pool)
 		ofi_bufpool_destroy(efa_rdm_ep->base_ep.ope_pool);
@@ -857,8 +857,8 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 	if (efa_rdm_ep->rx_atomrsp_pool)
 		ofi_bufpool_destroy(efa_rdm_ep->rx_atomrsp_pool);
 
-	if (efa_rdm_ep->peer_map_entry_pool)
-		ofi_bufpool_destroy(efa_rdm_ep->peer_map_entry_pool);
+	if (efa_rdm_ep->efa_rdm_peer_pool)
+		ofi_bufpool_destroy(efa_rdm_ep->efa_rdm_peer_pool);
 
 	if (efa_rdm_ep->peer_robuf_pool)
 		ofi_bufpool_destroy(efa_rdm_ep->peer_robuf_pool);

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -266,8 +266,8 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 	if (ret)
 		goto err_free;
 
-	ret = ofi_bufpool_create(&ep->peer_map_entry_pool,
-				 sizeof(struct efa_conn_ep_peer_map_entry),
+	ret = ofi_bufpool_create(&ep->efa_rdm_peer_pool,
+				 sizeof(struct efa_rdm_peer),
 				 EFA_RDM_BUFPOOL_ALIGNMENT,
 				 0, /* no limit to max_cnt */
 				 EFA_RDM_EP_MIN_PEER_POOL_SIZE,
@@ -275,7 +275,15 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 	if (ret)
 		goto err_free;
 
-	ret = ofi_bufpool_grow(ep->peer_map_entry_pool);
+	ret = ofi_bufpool_grow(ep->efa_rdm_peer_pool);
+	if (ret)
+		goto err_free;
+
+	ret = efa_rdm_ep_peer_map_init(&ep->fi_addr_to_peer_map);
+	if (ret)
+		goto err_free;
+
+	ret = efa_rdm_ep_peer_map_init(&ep->fi_addr_to_peer_map_implicit);
 	if (ret)
 		goto err_free;
 
@@ -308,6 +316,8 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 	return 0;
 
 err_free:
+	efa_av_array_destroy(ep->fi_addr_to_peer_map);
+	efa_av_array_destroy(ep->fi_addr_to_peer_map_implicit);
 	if (ep->rx_atomrsp_pool)
 		ofi_bufpool_destroy(ep->rx_atomrsp_pool);
 
@@ -335,8 +345,8 @@ err_free:
 	if (ep->efa_tx_pkt_pool)
 		ofi_bufpool_destroy(ep->efa_tx_pkt_pool);
 
-	if (ep->peer_map_entry_pool)
-		ofi_bufpool_destroy(ep->peer_map_entry_pool);
+	if (ep->efa_rdm_peer_pool)
+		ofi_bufpool_destroy(ep->efa_rdm_peer_pool);
 
 	if (ep->peer_robuf_pool)
 		ofi_bufpool_destroy(ep->peer_robuf_pool);
@@ -607,10 +617,6 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 		goto err_free_send_pkt_entry_vec;
 	}
 
-	dlist_init(&efa_rdm_ep->ep_peer_list);
-
-	dlist_init(&efa_rdm_ep->ep_peer_list);
-
 	*ep = &efa_rdm_ep->base_ep.util_ep.ep_fid;
 	(*ep)->msg = &efa_rdm_msg_ops;
 	(*ep)->rma = &efa_rdm_rma_ops;
@@ -728,30 +734,49 @@ static int efa_rdm_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
  * @param[in,out] efa_rdm_ep  EFA RDM endpoint
  * @related #efa_rdm_ep
  */
+static int efa_rdm_ep_release_peer_overflow_pke(struct efa_av_array *arr,
+						void *entry, void *context)
+{
+	struct efa_rdm_peer *peer = entry;
+	struct efa_rdm_peer_overflow_pke_list_entry *overflow_pke_list_entry;
+	struct dlist_entry *tmp;
+
+	if (!peer)
+		return 0;
+
+	dlist_foreach_container_safe(&peer->overflow_pke_list,
+				     struct efa_rdm_peer_overflow_pke_list_entry,
+				     overflow_pke_list_entry, entry, tmp) {
+		dlist_remove(&overflow_pke_list_entry->entry);
+		efa_rdm_pke_release_rx_list(overflow_pke_list_entry->pkt_entry);
+		ofi_buf_free(overflow_pke_list_entry);
+	}
+	return 0;
+}
+
+static int efa_rdm_ep_destroy_peer(struct efa_av_array *arr, void *entry,
+				   void *context)
+{
+	struct efa_rdm_ep *ep = context;
+	struct efa_rdm_peer *peer = entry;
+
+	efa_rdm_peer_destruct(peer, ep);
+	ofi_buf_free(peer);
+	return 0;
+}
+
 static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 {
 	struct dlist_entry *entry, *tmp;
-	struct efa_rdm_peer *peer;
-	struct efa_rdm_peer_overflow_pke_list_entry *overflow_pke_list_entry;
-	struct util_av_entry *util_av_entry;
-	struct efa_av_entry *av_entry;
-	struct efa_conn_ep_peer_map_entry *peer_map_entry;
 
 	/*
 	 * Overflow pkes sit on both peer->overflow_pke_list and (in debug mode) rx_pkt_list.
 	 * Release them before: rx_pkt_list debug sweep & efa_rdm_peer_destruct to avoid a double-free.
 	 */
-	dlist_foreach_container(&efa_rdm_ep->ep_peer_list,
-				struct efa_rdm_peer, peer,
-				ep_peer_list_entry) {
-		dlist_foreach_container_safe(&peer->overflow_pke_list,
-					     struct efa_rdm_peer_overflow_pke_list_entry,
-					     overflow_pke_list_entry, entry, tmp) {
-			dlist_remove(&overflow_pke_list_entry->entry);
-			efa_rdm_pke_release_rx_list(overflow_pke_list_entry->pkt_entry);
-			ofi_buf_free(overflow_pke_list_entry);
-		}
-	}
+	efa_av_array_iter(efa_rdm_ep->fi_addr_to_peer_map, efa_rdm_ep,
+		       efa_rdm_ep_release_peer_overflow_pke);
+	efa_av_array_iter(efa_rdm_ep->fi_addr_to_peer_map_implicit, efa_rdm_ep,
+		       efa_rdm_ep_release_peer_overflow_pke);
 
 #if ENABLE_DEBUG
 	struct efa_rdm_pke *pkt_entry;
@@ -795,34 +820,13 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 		}
 	}
 
-	/* Clean up any remaining peers before destroying buffer pools */
-	dlist_foreach_container_safe (&efa_rdm_ep->ep_peer_list,
-				      struct efa_rdm_peer, peer,
-				      ep_peer_list_entry, tmp) {
-
-		if (peer->conn->fi_addr != FI_ADDR_UNSPEC) {
-			util_av_entry = ofi_bufpool_get_ibuf(
-				efa_rdm_ep->base_ep.av->util_av.av_entry_pool,
-				peer->conn->fi_addr);
-		} else {
-			assert(peer->conn->implicit_fi_addr != FI_ADDR_UNSPEC);
-
-			util_av_entry = ofi_bufpool_get_ibuf(
-				efa_rdm_ep->base_ep.av->util_av_implicit.av_entry_pool,
-				peer->conn->implicit_fi_addr);
-		}
-
-		dlist_remove(&peer->ep_peer_list_entry);
-
-		efa_rdm_peer_destruct(peer, efa_rdm_ep);
-
-		peer_map_entry = container_of(
-			peer, struct efa_conn_ep_peer_map_entry, peer);
-
-		av_entry = (struct efa_av_entry *) util_av_entry->data;
-		HASH_DEL(av_entry->conn.ep_peer_map, peer_map_entry);
-		ofi_buf_free(peer_map_entry);
-	}
+	/* free every peer this endpoint created, then release the maps and pools */
+	efa_av_array_iter(efa_rdm_ep->fi_addr_to_peer_map, efa_rdm_ep,
+		       efa_rdm_ep_destroy_peer);
+	efa_av_array_iter(efa_rdm_ep->fi_addr_to_peer_map_implicit, efa_rdm_ep,
+		       efa_rdm_ep_destroy_peer);
+	efa_av_array_destroy(efa_rdm_ep->fi_addr_to_peer_map);
+	efa_av_array_destroy(efa_rdm_ep->fi_addr_to_peer_map_implicit);
 
 	if (efa_rdm_ep->base_ep.ope_pool)
 		ofi_bufpool_destroy(efa_rdm_ep->base_ep.ope_pool);
@@ -857,8 +861,8 @@ static void efa_rdm_ep_destroy_buffer_pools(struct efa_rdm_ep *efa_rdm_ep)
 	if (efa_rdm_ep->rx_atomrsp_pool)
 		ofi_bufpool_destroy(efa_rdm_ep->rx_atomrsp_pool);
 
-	if (efa_rdm_ep->peer_map_entry_pool)
-		ofi_bufpool_destroy(efa_rdm_ep->peer_map_entry_pool);
+	if (efa_rdm_ep->efa_rdm_peer_pool)
+		ofi_bufpool_destroy(efa_rdm_ep->efa_rdm_peer_pool);
 
 	if (efa_rdm_ep->peer_robuf_pool)
 		ofi_bufpool_destroy(efa_rdm_ep->peer_robuf_pool);

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "ofi.h"
+#include "ofi_indexer.h"
 #include <ofi_util.h>
 #include <ofi_iov.h>
 #include "efa.h"
@@ -46,6 +47,55 @@ int32_t efa_rdm_ep_get_peer_ahn(struct efa_rdm_ep *ep, fi_addr_t addr)
 }
 
 
+void efa_rdm_peer_map_init(struct ofi_dyn_arr *arr)
+{
+	ofi_array_init(arr, sizeof(struct efa_rdm_peer *), NULL);
+}
+
+struct efa_rdm_peer *efa_rdm_peer_map_lookup(struct ofi_dyn_arr *arr, fi_addr_t addr)
+{
+	struct efa_rdm_peer **slot;
+
+	if (addr > OFI_IDX_MAX_INDEX)
+		return NULL;
+
+	slot = ofi_array_at_max(arr, (int) addr, OFI_IDX_MAX_INDEX + 1);
+	return slot ? *slot : NULL;
+}
+
+int efa_rdm_peer_map_insert(struct ofi_dyn_arr *arr, fi_addr_t addr, struct efa_rdm_peer *peer)
+{
+	struct efa_rdm_peer **slot;
+
+	if (addr > OFI_IDX_MAX_INDEX)
+		return -FI_ENOMEM;
+
+	slot = ofi_array_at(arr, (int) addr);
+	if (!slot)
+		return -FI_ENOMEM;
+
+	assert(!*slot);
+	*slot = peer;
+	return 0;
+}
+
+struct efa_rdm_peer *efa_rdm_peer_map_remove(struct ofi_dyn_arr *arr, fi_addr_t addr)
+{
+	struct efa_rdm_peer **slot;
+	struct efa_rdm_peer *peer;
+
+	if (addr > OFI_IDX_MAX_INDEX)
+		return NULL;
+
+	slot = ofi_array_at_max(arr, (int) addr, OFI_IDX_MAX_INDEX + 1);
+	if (!slot || !*slot)
+		return NULL;
+
+	peer = *slot;
+	*slot = NULL;
+	return peer;
+}
+
 /**
  * @brief get pointer to efa_rdm_peer structure for a given libfabric address in
  * the explicit AV, this function is a thread-safe version of efa_rdm_ep_get_peer_explicit
@@ -75,41 +125,40 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer(struct efa_rdm_ep *ep, fi_addr_t addr)
 struct efa_rdm_peer *efa_rdm_ep_get_peer_explicit(struct efa_rdm_ep *ep, fi_addr_t addr)
 {
 	struct efa_conn *conn;
-	struct efa_conn_ep_peer_map_entry *map_entry;
 	struct efa_rdm_peer *peer;
 
 	assert(ofi_genlock_held(&efa_rdm_ep_rdm_domain(ep)->srx_lock));
 
-	conn = efa_av_addr_to_conn(ep->base_ep.av, addr);
-
 	if (OFI_UNLIKELY(addr == FI_ADDR_NOTAVAIL))
 		return NULL;
 
-	peer = efa_conn_ep_peer_map_lookup(conn, ep);
+	peer = efa_rdm_peer_map_lookup(&ep->fi_addr_to_peer_map, addr);
 	if (peer)
 		return peer;
 
+	conn = efa_av_addr_to_conn(ep->base_ep.av, addr);
+	if (OFI_UNLIKELY(!conn))
+		return NULL;
+
 	EFA_INFO(FI_LOG_EP_DATA, "Creating peer for addr %lu\n", addr);
-	map_entry = ofi_buf_alloc(ep->peer_map_entry_pool);
-	if (OFI_UNLIKELY(!map_entry)) {
-		EFA_WARN(FI_LOG_EP_DATA,
-			"Map entries for fi_addr to peer mapping exhausted.\n");
+	peer = ofi_buf_alloc(ep->efa_rdm_peer_pool);
+	if (OFI_UNLIKELY(!peer)) {
+		EFA_WARN(FI_LOG_EP_DATA, "Cannot allocate peer\n");
 		return NULL;
 	}
 
-	memset(map_entry, 0, sizeof(*map_entry));
-	map_entry->ep_ptr = ep;
-
-	if (efa_rdm_peer_construct(&map_entry->peer, ep, conn)) {
-		ofi_buf_free(map_entry);
+	if (efa_rdm_peer_construct(peer, ep, conn)) {
+		ofi_buf_free(peer);
 		return NULL;
 	}
 
-	efa_conn_ep_peer_map_insert(conn, map_entry);
+	if (efa_rdm_peer_map_insert(&ep->fi_addr_to_peer_map, addr, peer)) {
+		efa_rdm_peer_destruct(peer, ep);
+		ofi_buf_free(peer);
+		return NULL;
+	}
 
-	dlist_insert_tail(&map_entry->peer.ep_peer_list_entry, &ep->ep_peer_list);
-
-	return &map_entry->peer;
+	return peer;
 }
 
 /**
@@ -124,42 +173,39 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer_implicit(struct efa_rdm_ep *ep, fi_addr
 {
 	struct efa_conn *conn;
 	struct efa_rdm_peer *peer;
-	struct efa_conn_ep_peer_map_entry *map_entry;
 
 	assert(ofi_genlock_held(&efa_rdm_ep_rdm_domain(ep)->srx_lock));
-
-	conn = efa_av_addr_to_conn_implicit(ep->base_ep.av, addr);
 
 	if (OFI_UNLIKELY(addr == FI_ADDR_NOTAVAIL))
 		return NULL;
 
-	peer = efa_conn_ep_peer_map_lookup(conn, ep);
+	peer = efa_rdm_peer_map_lookup(&ep->fi_addr_to_peer_map_implicit, addr);
 	if (peer)
 		goto out;
 
+	conn = efa_av_addr_to_conn_implicit(ep->base_ep.av, addr);
+	if (OFI_UNLIKELY(!conn))
+		return NULL;
+
 	EFA_INFO(FI_LOG_EP_DATA, "Creating peer for addr %lu\n", addr);
-	map_entry = ofi_buf_alloc(ep->peer_map_entry_pool);
-	if (OFI_UNLIKELY(!map_entry)) {
-		EFA_WARN(FI_LOG_EP_DATA,
-			"Map entries for fi_addr to peer mapping exhausted.\n");
+	peer = ofi_buf_alloc(ep->efa_rdm_peer_pool);
+	if (OFI_UNLIKELY(!peer)) {
+		EFA_WARN(FI_LOG_EP_DATA, "Cannot allocate peer\n");
 		return NULL;
 	}
 
-	memset(map_entry, 0, sizeof(*map_entry));
-	map_entry->ep_ptr = ep;
-
-	if (efa_rdm_peer_construct(&map_entry->peer, ep, conn)) {
-		ofi_buf_free(map_entry);
+	if (efa_rdm_peer_construct(peer, ep, conn)) {
+		ofi_buf_free(peer);
 		return NULL;
 	}
-	peer = &map_entry->peer;
 
-	efa_conn_ep_peer_map_insert(conn, map_entry);
-
-	dlist_insert_tail(&map_entry->peer.ep_peer_list_entry, &ep->ep_peer_list);
+	if (efa_rdm_peer_map_insert(&ep->fi_addr_to_peer_map_implicit, addr, peer)) {
+		efa_rdm_peer_destruct(peer, ep);
+		ofi_buf_free(peer);
+		return NULL;
+	}
 
 out:
-	assert(peer);
 	/* Move to the front of the LRU list */
 	efa_av_implicit_av_lru_conn_move(ep->base_ep.av, peer->conn);
 	return peer;

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -73,20 +73,6 @@ struct efa_rdm_peer *efa_rdm_ep_peer_map_remove(struct efa_av_array *arr, fi_add
 
 /**
  * @brief get pointer to efa_rdm_peer structure for a given libfabric address in
- * the explicit AV
- *
- * @param[in]		ep		endpoint
- * @param[in]		addr 		libfabric address
- * @returns pointer to #efa_rdm_peer
- */
-struct efa_rdm_peer *efa_rdm_ep_get_peer(struct efa_rdm_ep *ep, fi_addr_t addr)
-{
-	return efa_rdm_ep_get_peer_explicit(ep, addr);
-}
-
-
-/**
- * @brief get pointer to efa_rdm_peer structure for a given libfabric address in
  * the explicit AV. The map is read without a lock; a peer is created on a miss
  * under the endpoint lock.
  *

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -46,7 +46,6 @@ int32_t efa_rdm_ep_get_peer_ahn(struct efa_rdm_ep *ep, fi_addr_t addr)
 	return efa_conn ? efa_conn->ah->ahn : -1;
 }
 
-
 int efa_rdm_ep_peer_map_init(struct efa_av_array **arr)
 {
 	return efa_av_array_init(arr);
@@ -74,7 +73,7 @@ struct efa_rdm_peer *efa_rdm_ep_peer_map_remove(struct efa_av_array *arr, fi_add
 
 /**
  * @brief get pointer to efa_rdm_peer structure for a given libfabric address in
- * the explicit AV, this function is a thread-safe version of efa_rdm_ep_get_peer_explicit
+ * the explicit AV
  *
  * @param[in]		ep		endpoint
  * @param[in]		addr 		libfabric address
@@ -82,17 +81,14 @@ struct efa_rdm_peer *efa_rdm_ep_peer_map_remove(struct efa_av_array *arr, fi_add
  */
 struct efa_rdm_peer *efa_rdm_ep_get_peer(struct efa_rdm_ep *ep, fi_addr_t addr)
 {
-	struct efa_rdm_peer *peer;
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(ep)->srx_lock);
-	peer = efa_rdm_ep_get_peer_explicit(ep, addr);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(ep)->srx_lock);
-	return peer;
+	return efa_rdm_ep_get_peer_explicit(ep, addr);
 }
 
 
 /**
  * @brief get pointer to efa_rdm_peer structure for a given libfabric address in
- * the explicit AV, this function must be called inside an SRX lock
+ * the explicit AV. The map is read without a lock; a peer is created on a miss
+ * under the endpoint lock.
  *
  * @param[in]		ep		endpoint
  * @param[in]		addr 		libfabric address
@@ -103,11 +99,11 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer_explicit(struct efa_rdm_ep *ep, fi_addr
 	struct efa_conn *conn;
 	struct efa_rdm_peer *peer;
 
-	assert(ofi_genlock_held(&efa_rdm_ep_rdm_domain(ep)->srx_lock));
-
 	if (OFI_UNLIKELY(addr == FI_ADDR_NOTAVAIL))
 		return NULL;
 
+	/* Path 1 (common case): the peer is already in the map. Keep this
+	 * lookup lock-free -- if we find the peer, just return it. */
 	peer = efa_rdm_ep_peer_map_lookup(ep->fi_addr_to_peer_map, addr);
 	if (peer)
 		return peer;
@@ -116,16 +112,30 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer_explicit(struct efa_rdm_ep *ep, fi_addr
 	if (OFI_UNLIKELY(!conn))
 		return NULL;
 
+	/* Path 2: the peer is not in the map. Take the lock, then create the
+	 * peer and insert it. */
+	EFA_GENLOCK_LOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
+
+	/* Path 2.1: two writers can race here -- both looked up, neither found
+	 * the peer, so both would try to insert. Re-check under the lock; if
+	 * another writer already inserted it, use theirs rather than insert a
+	 * duplicate. */
+	peer = efa_rdm_ep_peer_map_lookup(ep->fi_addr_to_peer_map, addr);
+	if (peer)
+		goto unlock;
+
 	EFA_INFO(FI_LOG_EP_DATA, "Creating peer for addr %lu\n", addr);
 	peer = ofi_buf_alloc(ep->efa_rdm_peer_pool);
 	if (OFI_UNLIKELY(!peer)) {
 		EFA_WARN(FI_LOG_EP_DATA, "Cannot allocate peer for addr %lu\n", addr);
-		return NULL;
+		goto unlock;
 	}
+	assert(peer);
 
 	if (efa_rdm_peer_construct(peer, ep, conn)) {
 		ofi_buf_free(peer);
-		return NULL;
+		peer = NULL;
+		goto unlock;
 	}
 
 	if (efa_rdm_ep_peer_map_insert(ep->fi_addr_to_peer_map, addr, peer)) {
@@ -133,9 +143,11 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer_explicit(struct efa_rdm_ep *ep, fi_addr
 			 "Failed to insert peer into map for addr %lu\n", addr);
 		efa_rdm_peer_destruct(peer, ep);
 		ofi_buf_free(peer);
-		return NULL;
+		peer = NULL;
 	}
 
+unlock:
+	EFA_GENLOCK_UNLOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
 	return peer;
 }
 
@@ -152,29 +164,44 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer_implicit(struct efa_rdm_ep *ep, fi_addr
 	struct efa_conn *conn;
 	struct efa_rdm_peer *peer;
 
-	assert(ofi_genlock_held(&efa_rdm_ep_rdm_domain(ep)->srx_lock));
-
 	if (OFI_UNLIKELY(addr == FI_ADDR_NOTAVAIL))
 		return NULL;
 
+	/*
+	 * The endpoint lock protects the peer map; the implicit-AV lock
+	 * protects peer->conn and its implicit-LRU entry (touched by the LRU
+	 * move below).
+	 *
+	 * We hold the implicit-AV lock across the whole function to prevent a
+	 * concurrent fi_av_insert from promoting an implicit to explicit peer at
+	 * the same time. Otherwise, the promotion could free the implicit conn
+	 * and cause the LRU move to operate on a now-bad pointer.
+	 *
+	 * Follows locking order: implicit-AV -> endpoint.
+	 */
+	EFA_GENLOCK_LOCK(&ep->base_ep.av->util_av_implicit.lock, efa_implicit_av_lock_sym);
+	EFA_GENLOCK_LOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
+
 	peer = efa_rdm_ep_peer_map_lookup(ep->fi_addr_to_peer_map_implicit, addr);
 	if (peer)
-		goto out;
+		goto unlock_ep;
 
 	conn = efa_av_addr_to_conn_implicit(ep->base_ep.av, addr);
 	if (OFI_UNLIKELY(!conn))
-		return NULL;
+		goto unlock_ep;
 
 	EFA_INFO(FI_LOG_EP_DATA, "Creating peer for addr %lu\n", addr);
 	peer = ofi_buf_alloc(ep->efa_rdm_peer_pool);
 	if (OFI_UNLIKELY(!peer)) {
 		EFA_WARN(FI_LOG_EP_DATA, "Cannot allocate peer for addr %lu\n", addr);
-		return NULL;
+		goto unlock_ep;
 	}
+	assert(peer);
 
 	if (efa_rdm_peer_construct(peer, ep, conn)) {
 		ofi_buf_free(peer);
-		return NULL;
+		peer = NULL;
+		goto unlock_ep;
 	}
 
 	if (efa_rdm_ep_peer_map_insert(ep->fi_addr_to_peer_map_implicit, addr, peer)) {
@@ -182,14 +209,17 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer_implicit(struct efa_rdm_ep *ep, fi_addr
 			 "Failed to insert peer into map for addr %lu\n", addr);
 		efa_rdm_peer_destruct(peer, ep);
 		ofi_buf_free(peer);
-		return NULL;
+		peer = NULL;
 	}
 
-out:
-	assert(peer);
-	/* Move to the front of the LRU list */
-	EFA_GENLOCK_LOCK(&ep->base_ep.av->util_av_implicit.lock, efa_implicit_av_lock_sym);
-	efa_av_implicit_av_lru_conn_move(ep->base_ep.av, peer->conn);
+unlock_ep:
+	EFA_GENLOCK_UNLOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
+
+	/* Move to the front of the LRU list; peer->conn stays valid under the
+	 * implicit-AV lock held here. */
+	if (peer)
+		efa_av_implicit_av_lru_conn_move(ep->base_ep.av, peer->conn);
+
 	EFA_GENLOCK_UNLOCK(&ep->base_ep.av->util_av_implicit.lock, efa_implicit_av_lock_sym);
 	return peer;
 }

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -5,6 +5,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "ofi.h"
+#include "ofi_indexer.h"
 #include <ofi_util.h>
 #include <ofi_iov.h>
 #include "efa.h"
@@ -46,6 +47,31 @@ int32_t efa_rdm_ep_get_peer_ahn(struct efa_rdm_ep *ep, fi_addr_t addr)
 }
 
 
+int efa_rdm_ep_peer_map_init(struct efa_av_array **arr)
+{
+	return efa_av_array_init(arr);
+}
+
+struct efa_rdm_peer *efa_rdm_ep_peer_map_lookup(struct efa_av_array *arr, fi_addr_t addr)
+{
+	return efa_av_array_at(arr, addr);
+}
+
+int efa_rdm_ep_peer_map_insert(struct efa_av_array *arr, fi_addr_t addr, struct efa_rdm_peer *peer)
+{
+	assert(!efa_av_array_at(arr, addr));
+	return efa_av_array_insert(arr, addr, peer);
+}
+
+struct efa_rdm_peer *efa_rdm_ep_peer_map_remove(struct efa_av_array *arr, fi_addr_t addr)
+{
+	struct efa_rdm_peer *peer = efa_av_array_at(arr, addr);
+
+	if (peer)
+		efa_av_array_insert(arr, addr, NULL);
+	return peer;
+}
+
 /**
  * @brief get pointer to efa_rdm_peer structure for a given libfabric address in
  * the explicit AV, this function is a thread-safe version of efa_rdm_ep_get_peer_explicit
@@ -75,41 +101,42 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer(struct efa_rdm_ep *ep, fi_addr_t addr)
 struct efa_rdm_peer *efa_rdm_ep_get_peer_explicit(struct efa_rdm_ep *ep, fi_addr_t addr)
 {
 	struct efa_conn *conn;
-	struct efa_conn_ep_peer_map_entry *map_entry;
 	struct efa_rdm_peer *peer;
 
 	assert(ofi_genlock_held(&efa_rdm_ep_rdm_domain(ep)->srx_lock));
 
-	conn = efa_av_addr_to_conn(ep->base_ep.av, addr);
-
 	if (OFI_UNLIKELY(addr == FI_ADDR_NOTAVAIL))
 		return NULL;
 
-	peer = efa_conn_ep_peer_map_lookup(conn, ep);
+	peer = efa_rdm_ep_peer_map_lookup(ep->fi_addr_to_peer_map, addr);
 	if (peer)
 		return peer;
 
+	conn = efa_av_addr_to_conn(ep->base_ep.av, addr);
+	if (OFI_UNLIKELY(!conn))
+		return NULL;
+
 	EFA_INFO(FI_LOG_EP_DATA, "Creating peer for addr %lu\n", addr);
-	map_entry = ofi_buf_alloc(ep->peer_map_entry_pool);
-	if (OFI_UNLIKELY(!map_entry)) {
+	peer = ofi_buf_alloc(ep->efa_rdm_peer_pool);
+	if (OFI_UNLIKELY(!peer)) {
+		EFA_WARN(FI_LOG_EP_DATA, "Cannot allocate peer for addr %lu\n", addr);
+		return NULL;
+	}
+
+	if (efa_rdm_peer_construct(peer, ep, conn)) {
+		ofi_buf_free(peer);
+		return NULL;
+	}
+
+	if (efa_rdm_ep_peer_map_insert(ep->fi_addr_to_peer_map, addr, peer)) {
 		EFA_WARN(FI_LOG_EP_DATA,
-			"Map entries for fi_addr to peer mapping exhausted.\n");
+			 "Failed to insert peer into map for addr %lu\n", addr);
+		efa_rdm_peer_destruct(peer, ep);
+		ofi_buf_free(peer);
 		return NULL;
 	}
 
-	memset(map_entry, 0, sizeof(*map_entry));
-	map_entry->ep_ptr = ep;
-
-	if (efa_rdm_peer_construct(&map_entry->peer, ep, conn)) {
-		ofi_buf_free(map_entry);
-		return NULL;
-	}
-
-	efa_conn_ep_peer_map_insert(conn, map_entry);
-
-	dlist_insert_tail(&map_entry->peer.ep_peer_list_entry, &ep->ep_peer_list);
-
-	return &map_entry->peer;
+	return peer;
 }
 
 /**
@@ -124,39 +151,39 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer_implicit(struct efa_rdm_ep *ep, fi_addr
 {
 	struct efa_conn *conn;
 	struct efa_rdm_peer *peer;
-	struct efa_conn_ep_peer_map_entry *map_entry;
 
 	assert(ofi_genlock_held(&efa_rdm_ep_rdm_domain(ep)->srx_lock));
-
-	conn = efa_av_addr_to_conn_implicit(ep->base_ep.av, addr);
 
 	if (OFI_UNLIKELY(addr == FI_ADDR_NOTAVAIL))
 		return NULL;
 
-	peer = efa_conn_ep_peer_map_lookup(conn, ep);
+	peer = efa_rdm_ep_peer_map_lookup(ep->fi_addr_to_peer_map_implicit, addr);
 	if (peer)
 		goto out;
 
+	conn = efa_av_addr_to_conn_implicit(ep->base_ep.av, addr);
+	if (OFI_UNLIKELY(!conn))
+		return NULL;
+
 	EFA_INFO(FI_LOG_EP_DATA, "Creating peer for addr %lu\n", addr);
-	map_entry = ofi_buf_alloc(ep->peer_map_entry_pool);
-	if (OFI_UNLIKELY(!map_entry)) {
+	peer = ofi_buf_alloc(ep->efa_rdm_peer_pool);
+	if (OFI_UNLIKELY(!peer)) {
+		EFA_WARN(FI_LOG_EP_DATA, "Cannot allocate peer for addr %lu\n", addr);
+		return NULL;
+	}
+
+	if (efa_rdm_peer_construct(peer, ep, conn)) {
+		ofi_buf_free(peer);
+		return NULL;
+	}
+
+	if (efa_rdm_ep_peer_map_insert(ep->fi_addr_to_peer_map_implicit, addr, peer)) {
 		EFA_WARN(FI_LOG_EP_DATA,
-			"Map entries for fi_addr to peer mapping exhausted.\n");
+			 "Failed to insert peer into map for addr %lu\n", addr);
+		efa_rdm_peer_destruct(peer, ep);
+		ofi_buf_free(peer);
 		return NULL;
 	}
-
-	memset(map_entry, 0, sizeof(*map_entry));
-	map_entry->ep_ptr = ep;
-
-	if (efa_rdm_peer_construct(&map_entry->peer, ep, conn)) {
-		ofi_buf_free(map_entry);
-		return NULL;
-	}
-	peer = &map_entry->peer;
-
-	efa_conn_ep_peer_map_insert(conn, map_entry);
-
-	dlist_insert_tail(&map_entry->peer.ep_peer_list_entry, &ep->ep_peer_list);
 
 out:
 	assert(peer);

--- a/prov/efa/src/rdm/efa_rdm_peer.h
+++ b/prov/efa/src/rdm/efa_rdm_peer.h
@@ -112,7 +112,6 @@ struct efa_rdm_peer {
 	struct dlist_entry txe_list; /**< a list of txe related to this peer */
 	struct dlist_entry rxe_list; /**< a list of rxe related to this peer */
 	struct dlist_entry overflow_pke_list; /**< a list of out-of-order pke that overflow the current recvwin */
-	struct dlist_entry ep_peer_list_entry; /**< linked to efa_rdm_ep->ep_peer_list */
 	/**
 	 * @brief number of bytes that has been sent as part of runting protocols
 	 * @details this value is capped by efa_env.efa_runt_size

--- a/prov/efa/src/rdm/efa_rdm_peer.h
+++ b/prov/efa/src/rdm/efa_rdm_peer.h
@@ -123,7 +123,6 @@ struct efa_rdm_peer {
 	struct dlist_entry txe_list; /**< a list of txe related to this peer */
 	struct dlist_entry rxe_list; /**< a list of rxe related to this peer */
 	struct dlist_entry overflow_pke_list; /**< a list of out-of-order pke that overflow the current recvwin */
-	struct dlist_entry ep_peer_list_entry; /**< linked to efa_rdm_ep->ep_peer_list */
 	/**
 	 * @brief number of bytes that has been sent as part of runting protocols
 	 * @details this value is capped by efa_env.efa_runt_size

--- a/prov/efa/test/efa_unit_test_av.c
+++ b/prov/efa/test/efa_unit_test_av.c
@@ -302,7 +302,7 @@ void test_av_reinsertion(void **state)
 	assert_int_equal(err, 0);
 	assert_int_equal(efa_is_same_addr(&raw_addr, &raw_addr_2), 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, fi_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, fi_addr);
 	assert_int_equal(peer->conn->fi_addr, fi_addr);
 	assert_int_equal(efa_is_same_addr(&raw_addr, peer->conn->ep_addr), 1);
 
@@ -319,7 +319,7 @@ void test_av_reinsertion(void **state)
 	assert_int_equal(err, 0);
 	assert_int_equal(efa_is_same_addr(&raw_addr, &raw_addr_2), 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, fi_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, fi_addr);
 	assert_int_equal(peer->conn->fi_addr, fi_addr);
 	assert_int_equal(efa_is_same_addr(&raw_addr, peer->conn->ep_addr), 1);
 
@@ -508,7 +508,7 @@ void test_av_implicit_to_explicit(void **state)
 	assert_int_equal(err, 0);
 	assert_int_equal(efa_is_same_addr(&raw_addr, &raw_addr_2), 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, explicit_fi_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, explicit_fi_addr);
 	assert_int_equal(peer->conn->fi_addr, explicit_fi_addr);
 	assert_int_equal(peer->conn->implicit_fi_addr, FI_ADDR_NOTAVAIL);
 	assert_int_equal(efa_is_same_addr(&raw_addr, peer->conn->ep_addr), 1);
@@ -907,7 +907,7 @@ void test_ah_lru_eviction_impl(bool explicit)
 	if (explicit) {
 		err = fi_av_insert(av_fid[0], &raw_addr[1], 1, &fi_addr, 0, NULL);
 		assert_int_equal(err, 1);
-		peer = efa_rdm_ep_get_peer(efa_rdm_ep[0], fi_addr);
+		peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep[0], fi_addr);
 	} else {
 		ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep[0])->srx_lock);
 		err = efa_av_insert_one_implicit(efa_av[0], &raw_addr[1], &fi_addr, 0, NULL);

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -432,7 +432,7 @@ struct efa_rdm_ope *efa_unit_test_alloc_txe(struct efa_resource *resource, uint3
 
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL), 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 
 	txe = ofi_buf_alloc(efa_rdm_ep->base_ep.ope_pool);
 	if (!txe)
@@ -458,7 +458,7 @@ struct efa_rdm_ope *efa_unit_test_alloc_rxe(struct efa_resource *resource, uint3
 
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL), 1);
 
-	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer(efa_rdm_ep, 0);
+	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, 0);
 
 	/* TODO - peer struct might need more info */
 	return efa_rdm_ep_alloc_rxe(efa_rdm_ep, peer, op);
@@ -485,7 +485,7 @@ void efa_unit_test_rdm_0byte_prep(struct efa_resource *resource, fi_addr_t *addr
 
 	/* Mark peer as handshake received and enable RDMA write/read */
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, *addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, *addr);
 	peer->flags |= EFA_RDM_PEER_HANDSHAKE_RECEIVED;
 	peer->extra_info[0] |= EFA_RDM_EXTRA_FEATURE_RDMA_WRITE | EFA_RDM_EXTRA_FEATURE_RDMA_READ | EFA_RDM_EXTRA_FEATURE_UNSOLICITED_WRITE_RECV;
 }

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -104,7 +104,7 @@ static void test_rdm_cq_read_bad_send_status(struct efa_resource *resource,
 	ret = fi_av_insert(resource->av, &raw_addr, 1, &addr, 0 /* flags */, NULL /* context */);
 	assert_int_equal(ret, 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	assert_non_null(peer);
 	peer->host_id = peer_host_id;
 
@@ -303,7 +303,7 @@ void test_rdm_cq_handshake_bad_send_status_impl(void **state, int prov_errno, bo
 
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL), 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	assert_non_null(peer);
 	/* Peer host id is uninitialized before handshake */
 	assert_int_equal(peer->host_id, 0);
@@ -892,7 +892,7 @@ static void test_impl_ibv_cq_ex_read_unknow_peer_ah(struct efa_resource *resourc
 	assert_int_equal(ret, 1);
 
 	/* Skip handshake */
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	assert_non_null(peer);
 	peer->flags |= EFA_RDM_PEER_HANDSHAKE_SENT;
 

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -134,7 +134,7 @@ void test_efa_rdm_ep_handshake_exchange_host_id(void **state, uint64_t local_hos
 
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL), 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	assert_non_null(peer);
 	/* Peer host id is uninitialized before handshake */
 	assert_int_equal(peer->host_id, 0);
@@ -477,7 +477,7 @@ void test_efa_rdm_ep_rma_queue_before_handshake(void **state, int op)
 	 * a REQ packet has been sent to the peer (so no need to send again)
 	 * handshake has not been received, so we do not know whether the peer support DC
 	 */
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	peer->flags = EFA_RDM_PEER_REQ_SENT;
 	/* Do not use shm in this unit test because we are testing efa rma path */
 	peer->conn->shm_fi_addr = FI_ADDR_NOTAVAIL;
@@ -547,7 +547,7 @@ void test_efa_rdm_ep_trigger_handshake(void **state)
 
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL), 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	assert_non_null(peer);
 
 	/* No txe should have been allocated yet */
@@ -615,7 +615,7 @@ void test_efa_rdm_txe_construct_splits_internal_flags(void **state)
 	raw_addr.qkey = 0x1234;
 	ret = fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL);
 	assert_int_equal(ret, 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 
 	msg.msg_iov = &iov;
 	msg.iov_count = 1;
@@ -1087,7 +1087,7 @@ void test_efa_rdm_ep_handshake_receive_peer_user_recv_qp(void **state)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL), 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	assert_non_null(peer);
 
 	/* Construct a handshake packet that mimics an old peer with zcpy enabled */
@@ -1168,7 +1168,7 @@ void test_efa_rdm_ep_handshake_receive_peer_no_user_recv_qp(void **state)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL), 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	assert_non_null(peer);
 
 	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
@@ -1213,7 +1213,7 @@ void test_efa_rdm_ep_handshake_receive_hmem_p2p_supported(void **state)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL), 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	assert_non_null(peer);
 
 	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
@@ -1257,7 +1257,7 @@ void test_efa_rdm_ep_handshake_receive_hmem_p2p_not_supported(void **state)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL), 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	assert_non_null(peer);
 
 	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
@@ -1301,7 +1301,7 @@ void test_efa_rdm_ep_handshake_receive_hmem_legacy_peer(void **state)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL), 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	assert_non_null(peer);
 
 	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool, EFA_RDM_PKE_FROM_EFA_RX_POOL);
@@ -1425,7 +1425,7 @@ void test_efa_rdm_ep_post_handshake_error_handling_pke_exhaustion(void **state)
 	 * a REQ packet has been sent to the peer (so no need to send again)
 	 * handshake has not been received, so we do not know whether the peer support DC
 	 */
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	peer->flags = EFA_RDM_PEER_REQ_SENT;
 	peer->is_local = false;
 
@@ -2157,7 +2157,7 @@ void test_efa_rdm_ep_outstanding_tx_ops_decremented_with_error_completion(void *
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL), 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	assert_non_null(peer);
 
 	/* Allocate a packet entry for the test */

--- a/prov/efa/test/efa_unit_test_mr.c
+++ b/prov/efa/test/efa_unit_test_mr.c
@@ -2034,7 +2034,7 @@ void test_efa_rdm_mr_gen_check_cancels_rnr_queued_ope(void **state)
 	assert_int_equal(ret, 1);
 
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	peer->flags |= EFA_RDM_PEER_HANDSHAKE_RECEIVED;
 
 	/* Mock a successful send, the packet is tracked as submitted */
@@ -2119,7 +2119,7 @@ void test_efa_rdm_mr_gen_check_cancels_longcts_ope(void **state)
 	assert_int_equal(ret, 1);
 
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	peer->flags |= EFA_RDM_PEER_HANDSHAKE_RECEIVED;
 
 	/* Mock a successful send, the initial RTM goes out */

--- a/prov/efa/test/efa_unit_test_ope.c
+++ b/prov/efa/test/efa_unit_test_ope.c
@@ -87,7 +87,7 @@ void test_efa_rdm_ope_prepare_to_post_send_impl(struct efa_resource *resource,
 	mock_mr.efa_mr.iface = iface;
 
 	struct efa_rdm_ep *efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
-	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer(efa_rdm_ep, 0);
+	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, 0);
 
 	memset(&mock_txe, 0, sizeof(mock_txe));
 	mock_txe.total_len = total_len;
@@ -315,7 +315,7 @@ void test_efa_rdm_ope_post_write_0_byte(void **state)
 	assert_int_equal(ret, 1);
 
 	struct efa_rdm_ep *efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
-	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer(efa_rdm_ep, 0);
+	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, 0);
 
 	efa_unit_test_buff_construct(&local_buff, resource, 4096 /* buff_size */);
 	memset(&mock_txe, 0, sizeof(mock_txe));
@@ -791,7 +791,7 @@ void test_efa_rdm_rxe_map(void **state)
 	/* efa_unit_test_alloc_rxe only inserts one address.
 	 * So fi_addr is guaranteed to be 0
 	 */
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, 0);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, 0);
 
 	efa_rdm_rxe_map_insert(&peer->rxe_map, rxe->msg_id, rxe);
 	assert_true(rxe->rxe_map == &peer->rxe_map);
@@ -1395,7 +1395,7 @@ void test_efa_rdm_atomic_compare_desc_persistence(void **state)
 	assert_int_equal(ret, 1);
 
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	peer->flags = EFA_RDM_PEER_REQ_SENT;
 	peer->is_local = false;
 
@@ -2254,7 +2254,7 @@ void test_efa_rdm_rxe_peer_abort_writes_error_completion_at_drain(void **state)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL),
 			 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	assert_non_null(peer);
 
 	/* Post a recv and match it. */
@@ -2406,7 +2406,7 @@ void test_efa_rdm_rxe_mark_peer_aborted_multi_recv_writes_err(
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr,
 				      0, NULL),
 			 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	assert_non_null(peer);
 
 	/* 1. Post a multi-recv. */
@@ -2637,7 +2637,7 @@ static struct efa_rdm_ope *build_matched_rxe(struct efa_resource *resource)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL),
 			 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 
 	iov = calloc(1, sizeof(*iov));
@@ -2809,7 +2809,7 @@ void test_efa_rdm_pke_handle_tx_error_longread_tagged_peer_aborts(void **state)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL),
 			 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 
 	/* Post a tagged recv. */
@@ -2891,7 +2891,7 @@ void test_efa_rdm_rxe_emit_peer_error_emits_pkt(void **state)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL),
 			 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 
 	/* Mark the peer as supporting PEER_ERROR_PKT. */
@@ -3011,7 +3011,7 @@ void test_efa_rdm_rxe_emit_peer_error_multi_recv_emits_pkt(
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr,
 				      0, NULL),
 			 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 
 	/* Mark peer as supporting PEER_ERROR_PKT. */
@@ -3142,7 +3142,7 @@ void test_efa_rdm_rxe_emit_peer_error_skips_on_peer_ep_closed(void **state)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL),
 			 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 
 	/* Even though the peer advertises support, an ABORT prov_errno
@@ -3233,7 +3233,7 @@ void test_efa_rdm_rxe_emit_peer_error_with_homogeneous_peers(void **state)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL),
 			 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 	/* No HANDSHAKE_RECEIVED, no extra_info bit set. */
 	assert_false(peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED);
@@ -3316,7 +3316,7 @@ void test_efa_rdm_rxe_emit_peer_error_skips_when_no_handshake(void **state)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL),
 			 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 	assert_false(peer->flags & EFA_RDM_PEER_HANDSHAKE_RECEIVED);
 
@@ -3388,7 +3388,7 @@ void test_efa_rdm_pke_handle_send_completion_peer_error_releases_rxe(void **stat
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL),
 			 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 
 	rxe = efa_rdm_ep_alloc_rxe(ep, peer, ofi_op_msg);
@@ -3463,7 +3463,7 @@ void test_efa_rdm_pke_handle_tx_error_peer_error_pkt_releases_rxe(void **state)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL),
 			 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 
 	/* Build an rxe in the post-mark, awaiting-PEER_ERROR_PKT-completion
@@ -3562,7 +3562,7 @@ void test_efa_rdm_rxe_emit_peer_error_reentry_safe(void **state)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL),
 			 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 	peer->flags |= EFA_RDM_PEER_HANDSHAKE_RECEIVED;
 	peer->extra_info[0] |= EFA_RDM_EXTRA_FEATURE_PEER_ERROR;
@@ -3651,7 +3651,7 @@ void test_efa_rdm_pke_handle_tx_error_sibling_read_wr_does_not_release_rxe(
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr,
 				      0, NULL),
 			 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 
 	rxe = efa_rdm_ep_alloc_rxe(ep, peer, ofi_op_msg);
@@ -3835,7 +3835,7 @@ void test_efa_rdm_pke_handle_peer_error_recv_longcts_reaps_rxe(void **state)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL),
 			 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 
 	/* Post + match a recv to build the rxe. */
@@ -3930,7 +3930,7 @@ void test_efa_rdm_pke_handle_peer_error_recv_longcts_tagged(void **state)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL),
 			 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 
 	/* Post + match a tagged recv. */
@@ -4647,7 +4647,7 @@ void test_efa_rdm_pke_handle_rma_read_completion_drains_recovered_rxe(
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr,
 				      0, NULL), 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 
 	iov.iov_base = buf;
@@ -4771,7 +4771,7 @@ void test_efa_rdm_pke_handle_peer_error_recv_longcts_cts_outstanding(
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL),
 			 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 
 	iov.iov_base = buf;
@@ -4920,7 +4920,7 @@ static void run_medium_inbound_peer_abort(struct efa_resource *resource,
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr,
 				      0, NULL), 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 
 	iov.iov_base = buf;
@@ -5058,7 +5058,7 @@ void test_efa_rdm_pke_handle_peer_error_recv_medium_msg_id_not_found_dropped(voi
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr,
 				      0, NULL), 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 
 	pkt_entry = efa_rdm_pke_alloc(ep, ep->efa_rx_pkt_pool,
@@ -5124,7 +5124,7 @@ void test_efa_rdm_pke_handle_peer_error_recv_medium_unexpected_tears_down(
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &peer_addr,
 				      0, NULL), 1);
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	assert_non_null(peer);
 
 	/* Allocate the inbound PEER_ERROR pke early (efa_rx_pkt_pool has

--- a/prov/efa/test/efa_unit_test_pke.c
+++ b/prov/efa/test/efa_unit_test_pke.c
@@ -141,7 +141,7 @@ void test_efa_rdm_pke_handle_longcts_rtm_send_completion(void **state)
     raw_addr.qkey = 0x1234;
     numaddr = fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL);
     assert_int_equal(numaddr, 1);
-    peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+    peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
     assert_non_null(peer);
 
     /* Construct a txe with read nack flag added */
@@ -247,7 +247,7 @@ void test_efa_rdm_pke_alloc_rta_rxe(void **state)
 		fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL),
 		1);
 
-	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer(efa_rdm_ep, 0);
+	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, 0);
 	pke->peer = peer;
 
 	rxe = efa_rdm_pke_alloc_rta_rxe(pke, ofi_op_atomic);
@@ -293,7 +293,7 @@ void test_efa_rdm_pke_alloc_rtw_rxe(void **state)
 	/* Clean the flags to avoid having garbage value */
 	base_hdr->flags = 0;
 
-	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer(efa_rdm_ep, 0);
+	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, 0);
 	pke->peer = peer;
 
 	rxe = efa_rdm_pke_alloc_rtw_rxe(pke);
@@ -342,7 +342,7 @@ void test_efa_rdm_pke_alloc_rtr_rxe(void **state)
 	/* Clean the flags to avoid having garbage value */
 	base_hdr->flags = 0;
 
-	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer(efa_rdm_ep, 0);
+	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, 0);
 	pke->peer = peer;
 
 	rxe = efa_rdm_pke_alloc_rtw_rxe(pke);
@@ -417,7 +417,7 @@ void test_efa_rdm_pke_flag_tracking(void **state)
 	raw_addr.qkey = 0x1234;
 	numaddr = fi_av_insert(resource->av, &raw_addr, 1, &peer_addr, 0, NULL);
 	assert_int_equal(numaddr, 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	assert_non_null(peer);
 
 	/* Create a txe */

--- a/prov/efa/test/efa_unit_test_rdm_domain.c
+++ b/prov/efa/test/efa_unit_test_rdm_domain.c
@@ -116,13 +116,13 @@ void test_efa_domain_peer_list_cleared(void **state)
 	assert_int_equal(num_addr, 1);
 
 	// Create peers through normal code path
-	peer1 = efa_rdm_ep_get_peer(efa_rdm_ep1, addr1);
+	peer1 = efa_rdm_ep_get_peer_explicit(efa_rdm_ep1, addr1);
 	assert_non_null(peer1);
-	peer2 = efa_rdm_ep_get_peer(efa_rdm_ep1, addr2);
+	peer2 = efa_rdm_ep_get_peer_explicit(efa_rdm_ep1, addr2);
 	assert_non_null(peer2);
-	peer3 = efa_rdm_ep_get_peer(efa_rdm_ep2, addr3);
+	peer3 = efa_rdm_ep_get_peer_explicit(efa_rdm_ep2, addr3);
 	assert_non_null(peer3);
-	peer4 = efa_rdm_ep_get_peer(efa_rdm_ep2, addr4);
+	peer4 = efa_rdm_ep_get_peer_explicit(efa_rdm_ep2, addr4);
 	assert_non_null(peer4);
 
 	// Manually add peers to domain lists to simulate the conditions

--- a/prov/efa/test/efa_unit_test_rdm_peer.c
+++ b/prov/efa/test/efa_unit_test_rdm_peer.c
@@ -41,7 +41,7 @@ void test_efa_rdm_peer_reorder_msg_impl(struct efa_resource *resource,
 	raw_addr.qkey = 0x1234;
 	ret = fi_av_insert(resource->av, &raw_addr, 1, &addr, 0 /* flags */, NULL /* context */);
 	assert_int_equal(ret, 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	assert_non_null(peer);
 
 	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool,
@@ -191,7 +191,7 @@ void test_efa_rdm_peer_move_overflow_pke_to_recvwin_impl(
 	raw_addr.qkey = 0x1234;
 	ret = fi_av_insert(resource->av, &raw_addr, 1, &addr, 0 /* flags */, NULL /* context */);
 	assert_int_equal(ret, 1);
-	*peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	*peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	assert_non_null(*peer);
 
 	*pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool,
@@ -307,7 +307,7 @@ void test_efa_rdm_peer_append_overflow_pke_to_recvwin(void **state) {
 	raw_addr.qkey = 0x1234;
 	ret = fi_av_insert(resource->av, &raw_addr, 1, &addr, 0 /* flags */, NULL /* context */);
 	assert_int_equal(ret, 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	assert_non_null(peer);
 
 	alloc_pke_in_overflow_list(efa_rdm_ep, &pkt_entry2, peer, raw_addr, EFA_RDM_PEER_DEFAULT_REORDER_BUFFER_SIZE + EFA_RDM_PEER_DEFAULT_REORDER_BUFFER_SIZE / 2);
@@ -360,7 +360,7 @@ void test_efa_rdm_peer_recvwin_queue_or_append_pke(void **state)
 	ret = fi_av_insert(resource->av, &raw_addr, 1, &addr, 0 /* flags */, NULL /* context */);
 	assert_int_equal(ret, 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	assert_non_null(peer);
 
 	pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep, efa_rdm_ep->efa_rx_pkt_pool,
@@ -431,7 +431,7 @@ void test_efa_rdm_peer_destruct_clears_rnr_flag(void **state)
 	wr_id = (uint64_t) g_ibv_submitted_wr_id_vec[0];
 	pkt_entry = efa_rdm_cq_get_pke_from_wr_id(ibv_cq, wr_id);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	assert_non_null(peer);
 
 	/* Simulate RNR: record completion and queue for retransmit */
@@ -497,7 +497,7 @@ void test_efa_rdm_peer_abort_ooo_in_overflow(void **state)
 	raw_addr.qpn = 1;
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL), 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	assert_non_null(peer);
 
 	/* Place a pke in the overflow list with msg_id beyond the window. */
@@ -535,7 +535,7 @@ void test_efa_rdm_peer_abort_ooo_in_recvwin(void **state)
 	raw_addr.qpn = 1;
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL), 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	assert_non_null(peer);
 
 	/* Queue an OOO pke into the recvwin at msg_id = 3 (exp is 0). */
@@ -600,7 +600,7 @@ void test_efa_rdm_peer_abort_ooo_recvwin_drain_progresses(void **state)
 	raw_addr.qpn = 1;
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL), 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	assert_non_null(peer);
 
 	/* This test borrows two rx-pool pkes (pke1, pke2) that the drain
@@ -681,7 +681,7 @@ void test_efa_rdm_peer_abort_ooo_miss(void **state)
 	raw_addr.qpn = 1;
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL), 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	assert_non_null(peer);
 
 	/* msg_id 42 is nowhere in the reorder state. */
@@ -758,7 +758,7 @@ void test_efa_rdm_peer_skip_aborted_msg_id_never_arrived_unblocks_window(
 	raw_addr.qpn = 1;
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL), 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	assert_non_null(peer);
 
 	/* pke1, pke2 and the PEER_ERROR abort marker packet are all rx-pool
@@ -837,7 +837,7 @@ void test_efa_rdm_peer_skip_aborted_msg_id_head_advances(void **state)
 	raw_addr.qpn = 1;
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL), 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	assert_non_null(peer);
 
 	/* One rx-pool pke (the abort marker) is released by the drain. */
@@ -881,7 +881,7 @@ void test_efa_rdm_peer_skip_aborted_msg_id_already_processed_noop(
 	raw_addr.qpn = 1;
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL), 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	assert_non_null(peer);
 
 	/* The abort marker packet is released immediately (case 1), counting
@@ -925,7 +925,7 @@ void test_efa_rdm_peer_skip_aborted_msg_id_buffered_abort_markers(
 	raw_addr.qpn = 1;
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL), 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	assert_non_null(peer);
 
 	/* Three rx-pool pkes are allocated and returned to the pool by the
@@ -1002,7 +1002,7 @@ void test_efa_rdm_peer_skip_aborted_msg_id_abort_marker_behind_head(
 	raw_addr.qpn = 1;
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL), 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	assert_non_null(peer);
 
 	/* Three abort marker packets are queued and later drained, each
@@ -1086,7 +1086,7 @@ void test_efa_rdm_pke_handle_peer_error_recv_longcts_skip_unblocks_window(
 	raw_addr.qpn = 1;
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL), 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	assert_non_null(peer);
 
 	/* pke1 (buffered) and the SKIP packet are rx-pool pkes the drain
@@ -1189,7 +1189,7 @@ void test_efa_rdm_peer_abort_ooo_msg_overflow_multi_segment(void **state)
 	raw_addr.qkey = 0x1234;
 	assert_int_equal(fi_av_insert(resource->av, &raw_addr, 1, &addr, 0,
 				      NULL), 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	assert_non_null(peer);
 
 	/* Window expects msg_id 0; these ids are out of window -> overflow. */

--- a/prov/efa/test/efa_unit_test_rdm_rma.c
+++ b/prov/efa/test/efa_unit_test_rdm_rma.c
@@ -277,7 +277,7 @@ void test_efa_rdm_rma_should_write_using_rdma_unsolicited_write_recv_not_match(
 	 * Fake a peer that has made handshake and
 	 * does not support unsolicited write recv
 	 */
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	peer->flags |= EFA_RDM_PEER_HANDSHAKE_RECEIVED;
 	peer->extra_info[0] |= EFA_RDM_EXTRA_FEATURE_RDMA_WRITE;
 	peer->extra_info[0] &= ~EFA_RDM_EXTRA_FEATURE_UNSOLICITED_WRITE_RECV;
@@ -497,7 +497,7 @@ void test_efa_rdm_rma_post_remote_write_partial_fail_no_txe_release(
 	ret = fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL);
 	assert_int_equal(ret, 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	peer->flags |= EFA_RDM_PEER_HANDSHAKE_RECEIVED;
 	peer->extra_info[0] |= EFA_RDM_EXTRA_FEATURE_RDMA_WRITE |
 				EFA_RDM_EXTRA_FEATURE_RDMA_READ |
@@ -620,7 +620,7 @@ void test_efa_rdm_rma_partial_post_retry_no_double_free(
 	ret = fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL);
 	assert_int_equal(ret, 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	peer->flags |= EFA_RDM_PEER_HANDSHAKE_RECEIVED;
 	peer->extra_info[0] |= EFA_RDM_EXTRA_FEATURE_RDMA_WRITE |
 				EFA_RDM_EXTRA_FEATURE_RDMA_READ |
@@ -739,7 +739,7 @@ void test_efa_rdm_rma_post_remote_read_partial_fail_no_txe_release(
 	ret = fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL);
 	assert_int_equal(ret, 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	peer->flags |= EFA_RDM_PEER_HANDSHAKE_RECEIVED;
 	peer->extra_info[0] |= EFA_RDM_EXTRA_FEATURE_RDMA_READ;
 	/* Match device versions so efa_rdm_interop_rdma_read returns true */
@@ -866,7 +866,7 @@ void test_efa_rdm_rma_partial_post_retry_no_double_free_read(
 	ret = fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL);
 	assert_int_equal(ret, 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	peer->flags |= EFA_RDM_PEER_HANDSHAKE_RECEIVED;
 	peer->extra_info[0] |= EFA_RDM_EXTRA_FEATURE_RDMA_READ;
 	vendor_part_id_orig = g_efa_selected_device_list[0].ibv_attr.vendor_part_id;
@@ -1225,7 +1225,7 @@ void test_efa_rdm_rma_inject_write_bumps_tx_counter(void **state)
 	ret = fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL);
 	assert_int_equal(ret, 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	peer->flags |= EFA_RDM_PEER_HANDSHAKE_RECEIVED;
 	peer->extra_info[0] |= EFA_RDM_EXTRA_FEATURE_RDMA_WRITE |
 				EFA_RDM_EXTRA_FEATURE_UNSOLICITED_WRITE_RECV;

--- a/prov/efa/test/efa_unit_test_rnr.c
+++ b/prov/efa/test/efa_unit_test_rnr.c
@@ -62,13 +62,13 @@ void test_efa_rnr_queue_and_resend_impl(void **state, uint32_t op)
 	efa_rdm_ep_queue_rnr_pkt(efa_rdm_ep, pkt_entry);
 	assert_int_equal(pkt_entry->flags & EFA_RDM_PKE_RNR_RETRANSMIT, EFA_RDM_PKE_RNR_RETRANSMIT);
 	assert_int_equal(efa_rdm_ep->efa_rnr_queued_pkt_cnt, 1);
-	assert_int_equal(efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr)->rnr_queued_pkt_cnt, 1);
+	assert_int_equal(efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr)->rnr_queued_pkt_cnt, 1);
 
 	ret = efa_rdm_ep_post_queued_pkts(efa_rdm_ep, &txe->queued_pkts);
 	assert_int_equal(ret, 0);
 	assert_int_equal(pkt_entry->flags & EFA_RDM_PKE_RNR_RETRANSMIT, 0);
 	assert_int_equal(efa_rdm_ep->efa_rnr_queued_pkt_cnt, 0);
-	assert_int_equal(efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr)->rnr_queued_pkt_cnt, 0);
+	assert_int_equal(efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr)->rnr_queued_pkt_cnt, 0);
 
 	efa_rdm_pke_handle_send_completion(pkt_entry);
 

--- a/prov/efa/test/efa_unit_test_runt.c
+++ b/prov/efa/test/efa_unit_test_runt.c
@@ -39,7 +39,7 @@ void test_efa_rdm_peer_get_runt_size_impl(
 	raw_addr.qkey = 0x1234;
 	ret = fi_av_insert(resource->av, &raw_addr, 1, &addr, 0 /* flags */, NULL /* context */);
 	assert_int_equal(ret, 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	peer->num_runt_bytes_in_flight = peer_num_runt_bytes_in_flight;
 
 	mock_mr.efa_mr.iface = iface;
@@ -307,7 +307,7 @@ void test_efa_rdm_peer_select_readbase_rtm_impl(
 	raw_addr.qkey = 0x1234;
 	ret = fi_av_insert(resource->av, &raw_addr, 1, &addr, 0 /* flags */, NULL /* context */);
 	assert_int_equal(ret, 1);
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	peer->num_runt_bytes_in_flight = peer_num_runt_bytes_in_flight;
 
 	mock_mr.efa_mr.iface = iface;

--- a/prov/efa/test/efa_unit_test_send.c
+++ b/prov/efa/test/efa_unit_test_send.c
@@ -117,7 +117,7 @@ void test_efa_rdm_msg_send_multi_pkt_sendv_fail_no_inflight(
 	ret = fi_av_insert(resource->av, &raw_addr, 1, &addr, 0, NULL);
 	assert_int_equal(ret, 1);
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, addr);
 	peer->flags |= EFA_RDM_PEER_HANDSHAKE_RECEIVED;
 
 	/*

--- a/prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.c
@@ -29,7 +29,7 @@ int efa_test_drive_rxe_unexp_handle_error(struct fid_ep *ep, void *op_context,
 	if (ret != 1)
 		return -FI_EINVAL;
 
-	peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	if (!peer)
 		return -FI_EINVAL;
 
@@ -76,7 +76,7 @@ int efa_test_queue_op_with_fi_more(struct fid_ep *ep_fid, struct fid_av *av_fid,
 	if (fi_av_insert(av_fid, &raw_addr, 1, &peer_addr, 0, NULL) != 1)
 		return -FI_EINVAL;
 
-	qop->peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	qop->peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 	if (!qop->peer)
 		return -FI_EINVAL;
 	/* REQ already sent, so enforce_handshake queues instead of posting a

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c
@@ -18,7 +18,7 @@ int efa_test_rtm_read_nack_missing_rxe(struct fid_ep *ep, fi_addr_t peer_addr,
 {
 	struct efa_rdm_ep *efa_rdm_ep =
 		container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
-	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	struct efa_rdm_pke *pke;
 	struct efa_rdm_rtm_base_hdr *rtm_hdr;
 
@@ -97,7 +97,7 @@ int efa_test_failed_reorder_msg_releases_rx_pkt(struct fid_ep *ep,
 {
 	struct efa_rdm_ep *efa_rdm_ep =
 		container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
-	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	struct efa_rdm_pke *pke;
 	struct efa_rdm_rtm_base_hdr *rtm_hdr;
 	uint32_t msg_id;
@@ -146,7 +146,7 @@ int efa_test_failed_reorder_msg_overflow_releases_rx_pkt_and_entry(
 {
 	struct efa_rdm_ep *efa_rdm_ep =
 		container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
-	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer(efa_rdm_ep, peer_addr);
+	struct efa_rdm_peer *peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, peer_addr);
 	struct efa_rdm_pke *pke;
 	struct efa_rdm_rtm_base_hdr *rtm_hdr;
 	uint32_t msg_id;
@@ -249,7 +249,7 @@ static struct efa_rdm_ope *efa_test_rtm_alloc_txe(struct efa_rdm_ep *ep,
 	if (efa_test_av_insert_self(&ep->base_ep.util_ep.ep_fid, av,
 				    &peer_addr) != 1)
 		return NULL;
-	peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
 
 	iov.iov_base = buf;
 	iov.iov_len = len;


### PR DESCRIPTION
The peer map moves from the shared efa_conn (a uthash keyed by endpoint) to efa_rdm_ep as an fi_addr-indexed ofi_dyn_arr of peer pointers. Because the array is per-endpoint and a lookup is a direct index that never mutates shared state, a peer lookup no longer contends with peer creation on another endpoint. This is a structural step toward removing the SRX lock from the fi_send/CQ-read peer lookup; the locking itself is unchanged here.