### PR TITLE
prov/efa: Fix missing argument of efa_ibv_post_write

### DIFF
--- a/prov/efa/test/efa_unit_test_rma.c
+++ b/prov/efa/test/efa_unit_test_rma.c
@@ -776,7 +776,7 @@ static void test_efa_ibv_post_write_processing_hints_impl(struct efa_resource *r
 	sge.length = local_buff.size;
 	sge.lkey = ((struct efa_mr *)fi_mr_desc(local_buff.mr))->ibv_mr->lkey;
 
-	efa_ibv_post_write(qp, &sge, 1, 123456, 0x87654321, 0, 0,
+	efa_ibv_post_write(qp, &sge, 1, NULL, false, 123456, 0x87654321, 0, 0,
 			   flags, &fake_ah, 0, 0);
 
 	efa_unit_test_buff_destruct(&local_buff);

--- a/prov/efa/test/efa_unit_test_rma.c
+++ b/prov/efa/test/efa_unit_test_rma.c
@@ -746,7 +746,6 @@ static void test_efa_ibv_post_write_processing_hints_impl(struct efa_resource *r
 	struct ibv_qp_ex *ibv_qpx;
 	struct efadv_qp *efadv_qp;
 	struct efa_ah fake_ah = {0};
-	bool enable_high_pps_orig;
 
 	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
 


### PR DESCRIPTION
efa_ibv_post_write takes inline_data_list and use_inline.