### PR TITLE
Core,prov/efa: make ofi_dyn_arr variable sized

### DIFF
--- a/include/ofi_indexer.h
+++ b/include/ofi_indexer.h
@@ -271,18 +271,38 @@ static inline void *ofi_idm_lookup(struct index_map *idm, int index)
 
 struct ofi_dyn_arr
 {
-	char *chunk[OFI_IDX_MAX_CHUNKS];
+	char **chunk;
+	size_t max_chunks;
+	size_t chunk_size;
+	unsigned int chunk_shift;
+	size_t max_index;
 	size_t item_size;
 	void (*init)(struct ofi_dyn_arr *arr, void *item);
 };
+
+struct ofi_dyn_arr_attr {
+	size_t item_size;
+	/* items per chunk; rounded up to a power of two.
+	 * Zero selects the default (OFI_IDX_CHUNK_SIZE). */
+	size_t chunk_cnt;
+	/* maximum item count; rounded up to a multiple of the
+	 * chunk size. Zero selects default of ~1M (OFI_IDX_MAX_INDEX). */
+	size_t max_cnt;
+	void (*init)(struct ofi_dyn_arr *arr, void *item);
+};
+
+int ofi_array_init_attr(struct ofi_dyn_arr *arr,
+			const struct ofi_dyn_arr_attr *attr);
 
 static inline void
 ofi_array_init(struct ofi_dyn_arr *arr, size_t item_size,
 	       void (*init)(struct ofi_dyn_arr *arr, void *item))
 {
-	memset(arr, 0, sizeof(*arr));
-	arr->item_size = item_size;
-	arr->init = init;
+	struct ofi_dyn_arr_attr attr = {0};
+
+	attr.item_size = item_size;
+	attr.init = init;
+	ofi_array_init_attr(arr, &attr);
 }
 
 int ofi_array_grow(struct ofi_dyn_arr *arr, int index);
@@ -294,8 +314,11 @@ void ofi_array_destroy(struct ofi_dyn_arr *arr);
 
 static inline char *ofi_array_chunk(struct ofi_dyn_arr *arr, int index)
 {
-	assert(arr->chunk);
-	return arr->chunk[ofi_idx_chunk_id(index)];
+	char **table = arr->chunk;
+
+	if (!table)
+		return NULL;
+	return table[(size_t) index >> arr->chunk_shift];
 }
 
 static inline void *
@@ -306,7 +329,8 @@ ofi_array_item(struct ofi_dyn_arr *arr, char *chunk, int offset)
 
 static inline void *ofi_array_at(struct ofi_dyn_arr *arr, int index)
 {
-	assert(index <= OFI_IDX_MAX_INDEX);
+	if (index < 0 || (size_t) index > arr->max_index)
+		return NULL;
 
 	if (!ofi_array_chunk(arr, index)) {
 		if (ofi_array_grow(arr, index) < 0)
@@ -314,17 +338,18 @@ static inline void *ofi_array_at(struct ofi_dyn_arr *arr, int index)
 	}
 
 	return ofi_array_item(arr, ofi_array_chunk(arr, index),
-			      ofi_idx_offset(index));
+			      (int) ((size_t) index & (arr->chunk_size - 1)));
 }
 
 static inline void *ofi_array_at_max(struct ofi_dyn_arr *arr, int index,
 				     int max_size)
 {
-	if (index >= max_size || !ofi_array_chunk(arr, index))
+	if (index < 0 || index >= max_size || (size_t) index > arr->max_index ||
+	    !ofi_array_chunk(arr, index))
 		return NULL;
 
 	return ofi_array_item(arr, ofi_array_chunk(arr, index),
-			      ofi_idx_offset(index));
+			      (int) ((size_t) index & (arr->chunk_size - 1)));
 }
 
 #endif /* _OFI_INDEXER_H_ */

--- a/include/ofi_mb.h
+++ b/include/ofi_mb.h
@@ -199,6 +199,16 @@ static inline void ofi_wmb(void)
 	__atomic_thread_fence(__ATOMIC_RELEASE);
 }
 
+#elif defined(_MSC_VER)
+#include <intrin.h>
+
+/* MSVC exposes neither C11 nor GCC builtin atomics; the SFENCE intrinsic
+ * provides the release/store ordering ofi_wmb() requires. */
+static inline void ofi_wmb(void)
+{
+	_mm_sfence();
+}
+
 #else
 #error "Neither built-in atomics nor C11 atomics is supported by compiler."
 #endif

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -286,11 +286,13 @@ nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
 	prov/efa/test/gtest/efa_gtest_common_resource.cc \
 	prov/efa/test/gtest/efa_gtest_common_helpers.c \
 	prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c \
+	prov/efa/test/gtest/efa_gtest_dyn_arr_utils.c \
 	prov/efa/test/gtest/efa_gtest_conn.cc \
 	prov/efa/test/gtest/efa_gtest_ah.cc \
 	prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc \
 	prov/efa/test/gtest/efa_gtest_rdm_mr.cc \
 	prov/efa/test/gtest/efa_gtest_rdm_pke.cc \
+	prov/efa/test/gtest/efa_gtest_dyn_arr.cc \
 	prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.c \
 	prov/efa/test/gtest/efa_gtest_rdm_ope.cc \
 	prov/efa/test/gtest/efa_gtest_cq.cc \

--- a/prov/efa/test/gtest/efa_gtest_dyn_arr.cc
+++ b/prov/efa/test/gtest/efa_gtest_dyn_arr.cc
@@ -1,0 +1,210 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_dyn_arr_utils.h"
+#include <climits>
+#include <cstdint>
+#include <gtest/gtest.h>
+
+using testing::Test;
+
+class OfiDynArrTest : public Test
+{
+	protected:
+	struct ofi_dyn_arr *arr = nullptr;
+
+	void SetUp() override
+	{
+		arr = dyn_arr_create(sizeof(int));
+		ASSERT_NE(arr, nullptr);
+	}
+
+	void TearDown() override
+	{
+		if (arr)
+			dyn_arr_destroy(arr);
+	}
+
+	int *at(int index)
+	{
+		return (int *) dyn_arr_at(arr, index);
+	}
+
+	int *at_max(int index, int max)
+	{
+		return (int *) dyn_arr_at_max(arr, index, max);
+	}
+};
+
+/* A fresh array has no chunks, so at_max never returns a slot. */
+TEST_F(OfiDynArrTest, empty_lookup_returns_null)
+{
+	EXPECT_EQ(at_max(0, dyn_arr_default_max_index() + 1), nullptr);
+	EXPECT_EQ(at_max(1000, dyn_arr_default_max_index() + 1), nullptr);
+}
+
+/* at() allocates the backing chunk and zero-initializes the slot. */
+TEST_F(OfiDynArrTest, at_allocates_zeroed_slot)
+{
+	int *slot = at(7);
+	ASSERT_NE(slot, nullptr);
+	EXPECT_EQ(*slot, 0);
+}
+
+TEST_F(OfiDynArrTest, store_and_read_back)
+{
+	*at(7) = 42;
+	EXPECT_EQ(*at(7), 42);
+	EXPECT_EQ(*at_max(7, dyn_arr_default_max_index() + 1), 42);
+}
+
+/* Indices in the same chunk are reachable once any of them is touched. */
+TEST_F(OfiDynArrTest, same_chunk_indices_share_backing)
+{
+	*at(1) = 11;
+	int *neighbor = at_max(0, dyn_arr_default_max_index() + 1);
+	ASSERT_NE(neighbor, nullptr);
+	EXPECT_EQ(*neighbor, 0);
+	EXPECT_EQ(*at_max(1, dyn_arr_default_max_index() + 1), 11);
+}
+
+/* Indices in different chunks are independent. */
+TEST_F(OfiDynArrTest, distinct_chunks_are_independent)
+{
+	int other = dyn_arr_default_chunk_size();
+	*at(0) = 100;
+	*at(other) = 200;
+	EXPECT_EQ(*at(0), 100);
+	EXPECT_EQ(*at(other), 200);
+}
+
+/* The last valid index works. */
+TEST_F(OfiDynArrTest, max_index_is_valid)
+{
+	int *slot = at(dyn_arr_default_max_index());
+	ASSERT_NE(slot, nullptr);
+	*slot = 5;
+	EXPECT_EQ(*at(dyn_arr_default_max_index()), 5);
+}
+
+/* Anything past the capacity (or negative) is rejected, not stored. */
+TEST_F(OfiDynArrTest, out_of_range_is_rejected)
+{
+	EXPECT_EQ(at(dyn_arr_default_max_index() + 1), nullptr);
+	EXPECT_EQ(at(-1), nullptr);
+	EXPECT_EQ(at_max(dyn_arr_default_max_index() + 1, dyn_arr_default_max_index() + 100),
+		  nullptr);
+}
+
+/* at_max rejects indices at or beyond the caller-supplied max_size, even when
+ * the index is an otherwise-valid, allocated slot. */
+TEST_F(OfiDynArrTest, at_max_enforces_max_size)
+{
+	*at(5) = 55;
+	EXPECT_EQ(*at_max(5, 6), 55);     /* index <  max_size: returned */
+	EXPECT_EQ(at_max(5, 5), nullptr); /* index == max_size: rejected */
+	EXPECT_EQ(at_max(6, 5), nullptr); /* index >  max_size: rejected */
+}
+
+/* The init callback pre-fills each newly grown slot. */
+TEST_F(OfiDynArrTest, init_callback_prefills_slots)
+{
+	struct ofi_dyn_arr *sarr = dyn_arr_create_with_sentinel(sizeof(int));
+	ASSERT_NE(sarr, nullptr);
+	int *slot = (int *) dyn_arr_at(sarr, 3);
+	ASSERT_NE(slot, nullptr);
+	EXPECT_EQ(*slot, dyn_arr_sentinel());
+	dyn_arr_destroy(sarr);
+}
+
+/* iter visits every allocated slot; only written values are counted. */
+TEST_F(OfiDynArrTest, iter_visits_written_values)
+{
+	*at(2) = 777;
+	*at(5) = 777;
+	*at(9) = 123;
+	EXPECT_EQ(dyn_arr_count_value(arr, 777), 2);
+	EXPECT_EQ(dyn_arr_count_value(arr, 123), 1);
+}
+
+/* A larger max_cnt raises the ceiling above the default ~1M limit. */
+TEST_F(OfiDynArrTest, custom_max_cnt_indexes_past_default_limit)
+{
+	int past_default = dyn_arr_default_max_index() + 1;
+	struct ofi_dyn_arr *big =
+		dyn_arr_create_max(sizeof(int), (size_t) past_default * 2);
+	ASSERT_NE(big, nullptr);
+	EXPECT_GT(dyn_arr_get_max_index(big), (long) dyn_arr_default_max_index());
+
+	int *slot = (int *) dyn_arr_at(big, past_default);
+	ASSERT_NE(slot, nullptr);
+	*slot = 314;
+	EXPECT_EQ(*(int *) dyn_arr_at(big, past_default), 314);
+
+	dyn_arr_destroy(big);
+}
+
+/* The custom array still rejects indices past its own (larger) ceiling. */
+TEST_F(OfiDynArrTest, custom_max_cnt_rejects_past_new_limit)
+{
+	int past_default = dyn_arr_default_max_index() + 1;
+	struct ofi_dyn_arr *big =
+		dyn_arr_create_max(sizeof(int), (size_t) past_default * 2);
+	ASSERT_NE(big, nullptr);
+
+	long new_max = dyn_arr_get_max_index(big);
+	EXPECT_EQ(dyn_arr_at(big, (int) (new_max + 1)), nullptr);
+
+	dyn_arr_destroy(big);
+}
+
+/* iter walks every allocated chunk, skipping unallocated ones. */
+TEST_F(OfiDynArrTest, iter_visits_multiple_chunks)
+{
+	int cs = dyn_arr_default_chunk_size();
+
+	*at(0) = 555;          /* chunk 0 */
+	*at(2 * cs) = 555;     /* chunk 2 (chunk 1 left unallocated) */
+	*at(2 * cs + 1) = 555; /* chunk 2 */
+	EXPECT_EQ(dyn_arr_count_value(arr, 555), 3);
+}
+
+/* A non-zero callback return stops iteration early. */
+TEST_F(OfiDynArrTest, iter_stops_on_nonzero_callback)
+{
+	*at(2) = 888;
+	*at(6) = 888;
+	/* Two matches exist, but iteration must stop after the first. */
+	EXPECT_EQ(dyn_arr_iter_first_hit(arr, 888), 1);
+}
+
+/* A custom chunk_cnt is honored and cross-chunk addressing still works. */
+TEST_F(OfiDynArrTest, custom_chunk_cnt_addressing)
+{
+	struct ofi_dyn_arr *a = dyn_arr_create_chunk_cnt(sizeof(int), 4);
+	ASSERT_NE(a, nullptr);
+	EXPECT_EQ(dyn_arr_chunk_size(a), 4);
+
+	*(int *) dyn_arr_at(a, 0) = 10; /* chunk 0 */
+	*(int *) dyn_arr_at(a, 4) = 20; /* chunk 1 */
+	*(int *) dyn_arr_at(a, 5) = 30; /* chunk 1, offset 1 */
+	EXPECT_EQ(*(int *) dyn_arr_at(a, 0), 10);
+	EXPECT_EQ(*(int *) dyn_arr_at(a, 4), 20);
+	EXPECT_EQ(*(int *) dyn_arr_at(a, 5), 30);
+	dyn_arr_destroy(a);
+}
+
+/* A non-power-of-two chunk_cnt is rounded up to a power of two. */
+TEST_F(OfiDynArrTest, chunk_cnt_rounds_up_to_pow2)
+{
+	struct ofi_dyn_arr *a = dyn_arr_create_chunk_cnt(sizeof(int), 1000);
+	ASSERT_NE(a, nullptr);
+	EXPECT_EQ(dyn_arr_chunk_size(a), 1024);
+	dyn_arr_destroy(a);
+}
+
+/* A max_cnt beyond the int-index ceiling is rejected, not clamped. */
+TEST_F(OfiDynArrTest, huge_max_cnt_is_rejected)
+{
+	EXPECT_EQ(dyn_arr_create_max(sizeof(int), SIZE_MAX), nullptr);
+}

--- a/prov/efa/test/gtest/efa_gtest_dyn_arr_utils.c
+++ b/prov/efa/test/gtest/efa_gtest_dyn_arr_utils.c
@@ -1,0 +1,155 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_dyn_arr_utils.h"
+#include <stdlib.h>
+#include "ofi_indexer.h"
+
+#define DYN_ARR_TEST_SENTINEL 0x5a5a5a5a
+
+static void dyn_arr_sentinel_init(struct ofi_dyn_arr *arr, void *item)
+{
+	(void) arr;
+	*(int *) item = DYN_ARR_TEST_SENTINEL;
+}
+
+struct ofi_dyn_arr *dyn_arr_create(size_t item_size)
+{
+	struct ofi_dyn_arr *arr = malloc(sizeof(*arr));
+
+	if (arr)
+		ofi_array_init(arr, item_size, NULL);
+	return arr;
+}
+
+struct ofi_dyn_arr *dyn_arr_create_with_sentinel(size_t item_size)
+{
+	struct ofi_dyn_arr *arr = malloc(sizeof(*arr));
+
+	if (arr)
+		ofi_array_init(arr, item_size, dyn_arr_sentinel_init);
+	return arr;
+}
+
+void dyn_arr_destroy(struct ofi_dyn_arr *arr)
+{
+	ofi_array_destroy(arr);
+	free(arr);
+}
+
+void *dyn_arr_at(struct ofi_dyn_arr *arr, int index)
+{
+	return ofi_array_at(arr, index);
+}
+
+void *dyn_arr_at_max(struct ofi_dyn_arr *arr, int index, int max_size)
+{
+	return ofi_array_at_max(arr, index, max_size);
+}
+
+struct dyn_arr_count_ctx {
+	int value;
+	int count;
+};
+
+static int dyn_arr_count_cb(struct ofi_dyn_arr *arr, void *item, void *context)
+{
+	struct dyn_arr_count_ctx *ctx = context;
+
+	(void) arr;
+	if (*(int *) item == ctx->value)
+		ctx->count++;
+	return 0;
+}
+
+int dyn_arr_count_value(struct ofi_dyn_arr *arr, int value)
+{
+	struct dyn_arr_count_ctx ctx = { value, 0 };
+
+	ofi_array_iter(arr, &ctx, dyn_arr_count_cb);
+	return ctx.count;
+}
+
+struct dyn_arr_hit_ctx {
+	int value;
+	int hits;
+};
+
+static int dyn_arr_hit_cb(struct ofi_dyn_arr *arr, void *item, void *context)
+{
+	struct dyn_arr_hit_ctx *ctx = context;
+
+	(void) arr;
+	if (*(int *) item == ctx->value) {
+		ctx->hits++;
+		return 1; /* non-zero return stops iteration */
+	}
+	return 0;
+}
+
+int dyn_arr_iter_first_hit(struct ofi_dyn_arr *arr, int value)
+{
+	struct dyn_arr_hit_ctx ctx = { value, 0 };
+
+	ofi_array_iter(arr, &ctx, dyn_arr_hit_cb);
+	return ctx.hits;
+}
+
+int dyn_arr_default_max_index(void)
+{
+	return OFI_IDX_MAX_INDEX;
+}
+
+int dyn_arr_default_chunk_size(void)
+{
+	return OFI_IDX_CHUNK_SIZE;
+}
+
+int dyn_arr_sentinel(void)
+{
+	return DYN_ARR_TEST_SENTINEL;
+}
+
+struct ofi_dyn_arr *dyn_arr_create_max(size_t item_size, size_t max_cnt)
+{
+	struct ofi_dyn_arr *arr = malloc(sizeof(*arr));
+	struct ofi_dyn_arr_attr attr = {0};
+
+	if (!arr)
+		return NULL;
+
+	attr.item_size = item_size;
+	attr.max_cnt = max_cnt;
+	if (ofi_array_init_attr(arr, &attr)) {
+		free(arr);
+		return NULL;
+	}
+	return arr;
+}
+
+long dyn_arr_get_max_index(struct ofi_dyn_arr *arr)
+{
+	return (long) arr->max_index;
+}
+
+struct ofi_dyn_arr *dyn_arr_create_chunk_cnt(size_t item_size, size_t chunk_cnt)
+{
+	struct ofi_dyn_arr *arr = malloc(sizeof(*arr));
+	struct ofi_dyn_arr_attr attr = {0};
+
+	if (!arr)
+		return NULL;
+
+	attr.item_size = item_size;
+	attr.chunk_cnt = chunk_cnt;
+	if (ofi_array_init_attr(arr, &attr)) {
+		free(arr);
+		return NULL;
+	}
+	return arr;
+}
+
+int dyn_arr_chunk_size(struct ofi_dyn_arr *arr)
+{
+	return (int) arr->chunk_size;
+}

--- a/prov/efa/test/gtest/efa_gtest_dyn_arr_utils.h
+++ b/prov/efa/test/gtest/efa_gtest_dyn_arr_utils.h
@@ -1,0 +1,52 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+/* C-linkage wrappers for ofi_dyn_arr. ofi_indexer.h pulls in ofi_osd.h, which
+ * does not compile under C++, so tests reach the array through these. */
+
+#ifndef EFA_GTEST_DYN_ARR_UTILS_H
+#define EFA_GTEST_DYN_ARR_UTILS_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ofi_dyn_arr;
+
+/* item_size is the size of each element (tests store an int). */
+struct ofi_dyn_arr *dyn_arr_create(size_t item_size);
+/* Same, but every newly grown slot is pre-filled with dyn_arr_sentinel(). */
+struct ofi_dyn_arr *dyn_arr_create_with_sentinel(size_t item_size);
+void dyn_arr_destroy(struct ofi_dyn_arr *arr);
+
+void *dyn_arr_at(struct ofi_dyn_arr *arr, int index);
+void *dyn_arr_at_max(struct ofi_dyn_arr *arr, int index, int max_size);
+
+/* Count slots in allocated chunks whose leading int equals value. */
+int dyn_arr_count_value(struct ofi_dyn_arr *arr, int value);
+
+/* Iterate, stopping at the first slot equal to value (callback returns
+ * non-zero). Returns the number of matches visited before stopping. */
+int dyn_arr_iter_first_hit(struct ofi_dyn_arr *arr, int value);
+
+int dyn_arr_default_max_index(void);
+int dyn_arr_default_chunk_size(void);
+int dyn_arr_sentinel(void);
+
+/* Create an array with a custom maximum capacity (max_cnt items). */
+struct ofi_dyn_arr *dyn_arr_create_max(size_t item_size, size_t max_cnt);
+/* The array's highest valid index. */
+long dyn_arr_get_max_index(struct ofi_dyn_arr *arr);
+
+/* Create an array with a custom chunk size (items per chunk). */
+struct ofi_dyn_arr *dyn_arr_create_chunk_cnt(size_t item_size, size_t chunk_cnt);
+/* The array's actual (possibly rounded-up) chunk size. */
+int dyn_arr_chunk_size(struct ofi_dyn_arr *arr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFA_GTEST_DYN_ARR_UTILS_H */

--- a/src/indexer.c
+++ b/src/indexer.c
@@ -36,8 +36,12 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <stdlib.h>
+#include <string.h>
 #include <assert.h>
+#include <limits.h>
 #include <ofi_indexer.h>
+#include <ofi_mb.h>
+#include <ofi.h>
 
 /*
  * Indexer - to find a structure given an index
@@ -255,20 +259,42 @@ void ofi_idm_reset(struct index_map *idm, void (*callback)(void *item))
 
 int ofi_array_grow(struct ofi_dyn_arr *arr, int index)
 {
-	int c, i;
+	char *chunk, **table;
+	size_t c, i;
 
 	assert(arr->item_size);
-	assert(!ofi_array_chunk(arr, index));
 
-	c = ofi_idx_chunk_id(index);
-	arr->chunk[c] = calloc(OFI_IDX_CHUNK_SIZE, arr->item_size);
-	if (!arr->chunk[c])
+	if (index < 0 || (size_t) index > arr->max_index) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	if (!arr->chunk) {
+		table = calloc(arr->max_chunks, sizeof(*table));
+		if (!table)
+			goto nomem;
+		/* publish the zeroed chunk table with a release
+		 * barrier; lock-free readers consume it via dependency
+		 * ordering, so they need no read-side barrier. */
+		ofi_wmb();
+		arr->chunk = table;
+	}
+
+	c = (size_t) index >> arr->chunk_shift;
+	assert(!arr->chunk[c]);
+	chunk = calloc(arr->chunk_size, arr->item_size);
+	if (!chunk)
 		goto nomem;
 
 	if (arr->init) {
-		for (i = 0; i < OFI_IDX_CHUNK_SIZE; i++)
-			arr->init(arr, ofi_array_item(arr, arr->chunk[c], i));
+		for (i = 0; i < arr->chunk_size; i++)
+			arr->init(arr, ofi_array_item(arr, chunk, (int) i));
 	}
+
+	/* publish the fully initialized chunk only after a
+	 * release barrier so its contents are visible before the pointer. */
+	ofi_wmb();
+	arr->chunk[c] = chunk;
 
 	return index;
 
@@ -277,18 +303,64 @@ nomem:
 	return -1;
 }
 
+#define OFI_DYN_ARR_MAX_CNT ((size_t) INT_MAX + 1)
+
+int ofi_array_init_attr(struct ofi_dyn_arr *arr,
+			const struct ofi_dyn_arr_attr *attr)
+{
+	size_t chunk_size, max_cnt, pow2;
+	unsigned int shift = 0;
+
+	memset(arr, 0, sizeof(*arr));
+
+	chunk_size = attr->chunk_cnt ? attr->chunk_cnt : OFI_IDX_CHUNK_SIZE;
+	if (chunk_size > OFI_DYN_ARR_MAX_CNT) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"requested chunk size %zu over max supported %zu\n",
+			chunk_size, OFI_DYN_ARR_MAX_CNT);
+		return -FI_EINVAL;
+	}
+
+	/* Round chunk size up to a power of two so the intra-chunk offset is a
+	 * shift/mask. */
+	for (pow2 = 1; pow2 < chunk_size; pow2 <<= 1)
+		shift++;
+	chunk_size = pow2;
+
+	max_cnt = attr->max_cnt ? attr->max_cnt : (size_t) OFI_IDX_MAX_INDEX + 1;
+	if (max_cnt > OFI_DYN_ARR_MAX_CNT) {
+		FI_WARN(&core_prov, FI_LOG_CORE,
+			"requested array size %zu over max supported %zu\n",
+			max_cnt, OFI_DYN_ARR_MAX_CNT);
+		return -FI_EINVAL;
+	}
+
+	arr->chunk_size = chunk_size;
+	arr->chunk_shift = shift;
+	arr->max_chunks = (max_cnt + chunk_size - 1) / chunk_size;
+	arr->max_index = arr->max_chunks * chunk_size - 1;
+	arr->item_size = attr->item_size;
+	arr->init = attr->init;
+	return FI_SUCCESS;
+}
+
 int ofi_array_iter(struct ofi_dyn_arr *arr, void *context,
 		    int (*callback)(struct ofi_dyn_arr *arr, void *item,
 				    void *context))
 {
-	int ret, c, i;
+	int ret;
+	size_t c, i;
 
-	for (c = 0; c < OFI_IDX_MAX_CHUNKS; c++) {
+	if (!arr->chunk)
+		return 0;
+
+	for (c = 0; c < arr->max_chunks; c++) {
 		if (!arr->chunk[c])
 			continue;
 
-		for (i = 0; i < OFI_IDX_CHUNK_SIZE; i++) {
-			ret = callback(arr, ofi_array_item(arr, arr->chunk[c], i),
+		for (i = 0; i < arr->chunk_size; i++) {
+			ret = callback(arr,
+				       ofi_array_item(arr, arr->chunk[c], (int) i),
 				       context);
 			if (ret)
 				return ret;
@@ -299,13 +371,15 @@ int ofi_array_iter(struct ofi_dyn_arr *arr, void *context,
 
 void ofi_array_destroy(struct ofi_dyn_arr *arr)
 {
-	int c;
+	size_t c;
 
-	for (c = 0; c < OFI_IDX_MAX_CHUNKS; c++) {
-		if (!arr->chunk[c])
-			continue;
+	if (!arr->chunk)
+		return;
 
-		free(arr->chunk[c]);
-		arr->chunk[c] = NULL;
+	for (c = 0; c < arr->max_chunks; c++) {
+		if (arr->chunk[c])
+			free(arr->chunk[c]);
 	}
+	free(arr->chunk);
+	arr->chunk = NULL;
 }


### PR DESCRIPTION
This patch does 2 things:
1) adds gtest unit tests to the ofi_dyn_arr, testing things like bounds, chunk allocation, and basic functionality
2) Modifies the ofi_dyn_arr init to have a new way to init the array by passing in an attr struct so that the caller can specify max size. Legacy init is kept and it will call the new api with legacy default values. This means that ofi_dyn_arr can now be used for lists that need to grow >1M entries.