### PR TITLE
fabtests/efa: Fix IndexError in CUDA EFA device selection

### DIFF
--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -526,7 +526,11 @@ def get_efa_device_name_for_cuda_device(ip, cuda_device_id, num_cuda_devices):
         return closest_nics[0]
 
     # Multiple GPUs share the same EFA NIC
-    return closest_nics[(cuda_device_id * num_efa) // num_cuda_devices]
+    # closest_nics only contains NICs at the same PCIe distance from this GPU,
+    # which may be fewer than the total EFA devices on the host
+    nic_idx = ((cuda_device_id * num_efa) // num_cuda_devices) % len(closest_nics)
+
+    return closest_nics[nic_idx]
 
 @retry(retry_on_exception=is_ssh_connection_error, stop_max_attempt_number=3, wait_fixed=5000)
 def support_cq_interrupts(hostname):


### PR DESCRIPTION
On platforms where there are more GPUs than EFA NICs (e.g., g7e: 2 EFA NICs, 4 GPUs), the BFS traversal returns only the NICs at the closest PCIe distance from a given GPU — typically 1. The index formula could exceed the length of the result list, causing an IndexError.

Add modulo to keep the index within bounds.

Fixes: fb38504a7 ("fabtests/efa: Use the closest EFA device for a given GPU")
Signed-off-by: Tal Yehoshua <talyeho@amazon.com>