### PR TITLE
prov/verbs: Enable HMEM support for RoCE interfaces

### DIFF
--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -799,11 +799,13 @@ static bool vrb_hmem_supported(const char *dev_name)
 		return false;
 
 	if (vrb_gl_data.peer_mem_support && (strstr(dev_name, "mlx") ||
-					     strstr(dev_name, "bnxt_re")))
+					     strstr(dev_name, "bnxt_re") ||
+					     strstr(dev_name, "roce")))
 		return true;
 
 	if (vrb_gl_data.dmabuf_support && (strstr(dev_name, "mlx") ||
-					   strstr(dev_name, "bnxt_re")))
+					   strstr(dev_name, "bnxt_re") ||
+					   strstr(dev_name, "roce")))
 		return true;
 
 	return false;

--- a/prov/verbs/src/verbs_info.c
+++ b/prov/verbs/src/verbs_info.c
@@ -793,8 +793,10 @@ static int vrb_have_device(void)
 	return ret;
 }
 
-static bool vrb_hmem_supported(const char *dev_name)
+static bool vrb_hmem_supported(struct ibv_context *ctx)
 {
+	const char *dev_name = ibv_get_device_name(ctx->device);
+
 	if (ofi_hmem_p2p_disabled())
 		return false;
 
@@ -803,10 +805,18 @@ static bool vrb_hmem_supported(const char *dev_name)
 					     strstr(dev_name, "roce")))
 		return true;
 
-	if (vrb_gl_data.dmabuf_support && (strstr(dev_name, "mlx") ||
-					   strstr(dev_name, "bnxt_re") ||
-					   strstr(dev_name, "roce")))
-		return true;
+#if VERBS_HAVE_DMABUF_MR
+	if (vrb_gl_data.dmabuf_support) {
+		struct ibv_pd *pd = ibv_alloc_pd(ctx);
+		if (pd) {
+			struct ibv_mr *mr = ibv_reg_dmabuf_mr(pd, 0, 0, 0, -1, 0);
+			bool supported = (!mr && errno != EOPNOTSUPP);
+			ibv_dealloc_pd(pd);
+			if (supported)
+				return true;
+		}
+	}
+#endif
 
 	return false;
 }
@@ -1553,7 +1563,7 @@ static int vrb_init_info(struct dlist_entry *verbs_devs,
 			/* If verbs HMEM is supported, duplicate previously
 			 * allocated fi_info and apply HMEM flags.
 			 */
-			if (vrb_hmem_supported(ctx_list[i]->device->name)) {
+			if (vrb_hmem_supported(ctx_list[i])) {
 				fi = fi_dupinfo(fi);
 				if (!fi)
 					continue;


### PR DESCRIPTION
Add RoCE interface detection to the HMEM (Heterogeneous Memory) support check by including devices with 'roce' in their name alongside existing Mellanox ('mlx') and Broadcom ('bnxt_re') device checks.

This enables both peer memory and dmabuf-based HMEM support for RoCE devices, allowing them to take advantage of GPU memory operations and other heterogeneous memory features.

## Testing 
Without the fix in this PR, RoCE adapters can't be used with GPU Direct (GPU-backed memory) as libfabric doesn’t recognize RoCE adapters as dmabuf-capable interfaces:

```
$ ~/usr/libfabric/bin/fi_rdm_bw -D cuda -p verbs  -S all
fi_getinfo(): common/shared.c:1079, ret=-61 (No data available)
```

With the fix, RoCE verbs interfaces starting with `roce` can be detected as HMEM-compatible interfaces and used to transfer GPU-backed memory:
```
$ ~/usr/libfabric/bin/fi_rdm_bw -D cuda -p verbs  -S all -i 0 
bytes   iters   total       time     MB/sec    usec/xfer   Mxfers/sec
1       20k     19k         0.16s      0.13       7.92       0.13
2       20k     39k         0.16s      0.25       7.91       0.13
3       20k     58k         0.16s      0.38       7.95       0.13
4       20k     78k         0.16s      0.51       7.91       0.13
...
```

## Limitations 
The detection of HMEM is currently based on the names of the verbs devices. The `mlx` prefix is assumed to indicate Mellanox adapters, and `bnxt_re` is assumed to indicate Broadcom adapters. However, the `roce` prefix is toogeneric and does not allow fine-grained selection based on the adapter's actual vendor.
A more effective filtering strategy would be to use the [vendor_id](https://github.com/linux-rdma/rdma-core/blob/master/libibverbs/verbs.h#L189) field instead.