### PR TITLE
[v2.6.x] prov/lnx: Pick fix Makefile.include fi_la_LDFLAGS

### DIFF
--- a/prov/lnx/Makefile.include
+++ b/prov/lnx/Makefile.include
@@ -53,7 +53,7 @@ liblnx_fi_la_CPPFLAGS = 				\
 	-I$(top_srcdir)/prov/lnx/include		\
 	$(AM_CPPFLAGS) $(lnx_CPPFLAGS)
 liblnx_fi_la_LIBADD = $(top_builddir)/src/libfabric.la $(linkback) $(lnx_LIBS)
-libverbs_fi_la_LDFLAGS =				\
+liblnx_fi_la_LDFLAGS =				\
 	-module -avoid-version -shared -export-dynamic	\
 	$(lnx_LDFLAGS)
 liblnx_fi_la_DEPENDENCIES = $(linkback)


### PR DESCRIPTION
Fix name typo from verbs->lnx


(cherry picked from commit 61b6203111e2f9d2fbc64a18dd56b00f2bbfd5e6)