### PR TITLE
[v2.6.x] prov/efa: fix global device count corruption in unit test

### DIFF
--- a/prov/efa/test/efa_unit_test_device.c
+++ b/prov/efa/test/efa_unit_test_device.c
@@ -9,10 +9,11 @@
 void test_efa_device_construct_error_handling(void **state)
 {
 	int ibv_err = 4242;
+	int num_devices;
 	struct ibv_device **ibv_device_list;
 	struct efa_device efa_device = {0};
 
-	ibv_device_list = ibv_get_device_list(&g_efa_selected_device_cnt);
+	ibv_device_list = ibv_get_device_list(&num_devices);
 	if (ibv_device_list == NULL) {
 		skip();
 		return;


### PR DESCRIPTION
test_efa_device_construct_error_handling passed &g_efa_selected_device_cnt to ibv_get_device_list(), which overwrites it with the total number of IBV devices (including non-EFA devices). On hosts with mixed device types like p6b200, this inflates the count beyond the number of initialized entries in g_efa_selected_device_list and causes subsequent unit tests to fail.


(cherry picked from commit f1ee984d09ae7d5dd262e4eee7523c81ce8024c3)