### PR TITLE
prov/tcp: Reject invalid RMA iov counts from peers

### DIFF
--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -891,6 +891,13 @@ static int xnet_handle_read_req(struct xnet_ep *ep)
 	int ret;
 
 	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
+	if (ep->cur_rx.hdr.base_hdr.rma_iov_cnt > XNET_IOV_LIMIT) {
+		FI_WARN(&xnet_prov, FI_LOG_EP_DATA,
+			"invalid rma iov count %u\n",
+			ep->cur_rx.hdr.base_hdr.rma_iov_cnt);
+		return -FI_EIO;
+	}
+
 	resp = xnet_alloc_xfer(xnet_ep2_progress(ep));
 	if (!resp)
 		return -FI_ENOMEM;
@@ -946,6 +953,13 @@ static int xnet_handle_write(struct xnet_ep *ep)
 	int ret;
 
 	assert(xnet_progress_locked(xnet_ep2_progress(ep)));
+	if (ep->cur_rx.hdr.base_hdr.rma_iov_cnt > XNET_IOV_LIMIT) {
+		FI_WARN(&xnet_prov, FI_LOG_EP_DATA,
+			"invalid rma iov count %u\n",
+			ep->cur_rx.hdr.base_hdr.rma_iov_cnt);
+		return -FI_EIO;
+	}
+
 	rx_entry = xnet_alloc_xfer(xnet_ep2_progress(ep));
 	if (!rx_entry)
 		return -FI_ENOMEM;


### PR DESCRIPTION
## Summary

`rma_iov_cnt` is taken from the wire header and used to index `xnet_xfer_entry::iov`, which only has `XNET_IOV_LIMIT + 1` entries. A peer that sends a larger count overflows the heap object (intra-object corruption of fields after `iov[]`, starting with adjacent state such as `saving_ep` / `cq`).

Validate the count in the read-request and write handlers **before** allocating a transfer entry or writing into `iov[]`.

## Problem

In `xnet_handle_read_req()` and `xnet_handle_write()`:

- `ep->cur_rx.hdr.base_hdr.rma_iov_cnt` is attacker-controlled
- It is used in loops that fill `resp->iov[]` / `rx_entry->iov[]`
- There is no upper/lower bound check against `XNET_IOV_LIMIT` (4)

Application-side asserts on the sender do not protect a receiver from a malicious peer crafting packets.

## Fix

In both handlers, before `xnet_alloc_xfer()`:

```c
if (!ep->cur_rx.hdr.base_hdr.rma_iov_cnt ||
    ep->cur_rx.hdr.base_hdr.rma_iov_cnt > XNET_IOV_LIMIT) {
	FI_WARN(&xnet_prov, FI_LOG_EP_DATA,
		"invalid rma iov count %u\n",
		ep->cur_rx.hdr.base_hdr.rma_iov_cnt);
	return -FI_EIO;
}
```

Rejects:

- `rma_iov_cnt == 0`
- `rma_iov_cnt > XNET_IOV_LIMIT`

Returns `-FI_EIO` without touching `iov[]`.

### Files

- `prov/tcp/src/xnet_progress.c` — bounds checks in `xnet_handle_read_req()` and `xnet_handle_write()`

## Testing

### Overflow reproduction (dual-binary)

Stock senders assert `rma_iov_count` against the local limit, so verification used two libfabric builds:

| Role | Build | Notes |
|------|--------|--------|
| **Victim (server)** | `XNET_IOV_LIMIT = 4` | Receiver under test |
| **Attacker (client)** | larger local IOV limit | Can legally post multi-IOV RMA |

The victim accepted an on-wire header carrying more RMA IOVs than its local `iov[]`, so the packet reached the vulnerable handlers.

#### Without the fix

With an `iov_canary` immediately after `iov[]` for detection:

```text
iov canary corrupted at xnet_handle_read_req (got 0x...) — likely rma_iov_cnt overflow past iov[]
Assertion `xfer->iov_canary == XNET_IOV_CANARY' failed.
```

Without a canary, the same path can complete while still corrupting fields after `iov[]`. ASAN often does **not** report this: the overflow is intra-object within the xfer pool entry (which also has a large `msg_data[]` tail of size `xnet_buf_size`, default 16 KiB). ASAN redzones sit between heap objects, not between struct fields.

#### With the fix

```text
invalid rma iov count 8
```

No canary corruption and no abort from overflow. The connection/op is canceled after the peer error; `iov[]` is never indexed with the bogus count.

Signed-off-by: Sylvain Didelot <sdidelot@ddn.com>