### PR TITLE
prov/efa: refactor efa_av_insert_one to reduce AV lock contention 

### DIFF
--- a/prov/efa/src/efa_ah.c
+++ b/prov/efa/src/efa_ah.c
@@ -40,7 +40,8 @@ void efa_ah_implicit_av_lru_ah_move(struct efa_domain *domain,
 			  &rdm_domain->ah_lru_list);
 }
 
-static inline int efa_ah_implicit_av_evict_ah(struct efa_domain *domain) {
+static inline int efa_ah_implicit_av_evict_ah(struct efa_domain *domain,
+					      bool insert_implicit_av) {
 	struct efa_conn *conn_to_release;
 	struct efa_ah *ah_tmp, *ah_to_release = NULL;
 	struct dlist_entry *tmp;
@@ -73,7 +74,17 @@ static inline int efa_ah_implicit_av_evict_ah(struct efa_domain *domain) {
 		assert(conn_to_release->implicit_fi_addr != FI_ADDR_NOTAVAIL &&
 		       conn_to_release->fi_addr == FI_ADDR_NOTAVAIL);
 
+		/*
+		 * The implicit insert path already holds util_av_implicit.lock.
+		 * The explicit insert path does not, so acquire it here.
+		 */
+		if (!insert_implicit_av)
+			ofi_genlock_lock(&conn_to_release->av->util_av_implicit.lock);
+		else
+			assert(ofi_genlock_held(&conn_to_release->av->util_av_implicit.lock));
 		efa_conn_release_ah_unsafe(conn_to_release->av, conn_to_release, true);
+		if (!insert_implicit_av)
+			ofi_genlock_unlock(&conn_to_release->av->util_av_implicit.lock);
 	}
 
 	if (ah_to_release->implicit_refcnt == 0 &&
@@ -153,10 +164,11 @@ struct efa_ah *efa_ah_alloc(struct efa_domain *domain, const uint8_t *gid,
 		if (errno == FI_ENOMEM && domain->info_type == EFA_INFO_RDM) {
 			EFA_INFO(
 				FI_LOG_AV,
-				"ibv_create_ah failed with ENOMEM for implicit "
-				"AV insertion. Attempting to evict AH entry\n");
+				"ibv_create_ah failed with ENOMEM for %s "
+				"AV insertion. Attempting to evict AH entry\n",
+				insert_implicit_av ? "implicit" : "explicit");
 
-			err = efa_ah_implicit_av_evict_ah(domain);
+			err = efa_ah_implicit_av_evict_ah(domain, insert_implicit_av);
 			if (err)
 				goto err_free_efa_ah;
 
@@ -166,8 +178,9 @@ struct efa_ah *efa_ah_alloc(struct efa_domain *domain, const uint8_t *gid,
 					efa_ah_warn_create_einval(domain, gid);
 				} else {
 					EFA_WARN(FI_LOG_AV,
-						 "ibv_create_ah failed for implicit AV "
+						 "ibv_create_ah failed for %s AV "
 						 "insertion! errno: %d\n",
+						 insert_implicit_av ? "implicit" : "explicit",
 						 errno);
 				}
 				goto err_free_efa_ah;

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -459,28 +459,11 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 	return FI_SUCCESS;
 }
 
-/**
- * @brief insert one address into address vector (AV)
- *
- * @param[in]	av	address vector
- * @param[in]	addr	raw address, in the format of gid:qpn:qkey
- * @param[out]	fi_addr pointer to the output fi address. This address is used by fi_send
- * @param[in]	flags	flags user passed to fi_av_insert.
- * @param[in]	context	context user passed to fi_av_insert
- * @param[in]	insert_shm_av	whether insert address to shm av
- * @param[in]	insert_implicit_av	whether insert address to implicit AV
- * @return	0 on success, a negative error code on failure
- */
-int efa_av_insert_one(struct efa_av *av, struct efa_ep_addr *addr,
-		      fi_addr_t *fi_addr, uint64_t flags, void *context,
-		      bool insert_shm_av, bool insert_implicit_av)
+static inline int efa_av_insert_one_validate(struct efa_av *av,
+				     struct efa_ep_addr *addr,
+				     fi_addr_t *fi_addr,
+				     char *raw_gid_str)
 {
-	struct efa_conn *conn;
-	char raw_gid_str[INET6_ADDRSTRLEN];
-	fi_addr_t efa_fiaddr;
-	fi_addr_t implicit_fi_addr;
-	int ret = 0;
-
 	if (!efa_av_is_valid_address(addr)) {
 		EFA_WARN(FI_LOG_AV, "Failed to insert bad addr\n");
 		*fi_addr = FI_ADDR_NOTAVAIL;
@@ -492,89 +475,188 @@ int efa_av_insert_one(struct efa_av *av, struct efa_ep_addr *addr,
 
 	if (av->domain->info_type == EFA_INFO_RDM)
 		assert(ofi_genlock_held(&((struct efa_rdm_domain *) av->domain)->srx_lock));
-	ofi_genlock_lock(&av->util_av_implicit.lock);
-	ofi_genlock_lock(&av->util_av.lock);
 
-	memset(raw_gid_str, 0, sizeof(raw_gid_str));
+	memset(raw_gid_str, 0, INET6_ADDRSTRLEN);
 	if (!inet_ntop(AF_INET6, addr->raw, raw_gid_str, INET6_ADDRSTRLEN)) {
 		EFA_WARN(FI_LOG_AV, "cannot convert address to string. errno: %d\n", errno);
-		ret = -FI_EINVAL;
 		*fi_addr = FI_ADDR_NOTAVAIL;
-		goto out;
+		return -FI_EINVAL;
 	}
+
+	return 0;
+}
+
+/**
+ * @brief insert one address into the explicit address vector
+ *
+ * If the address already exists in the explicit AV, return the existing
+ * fi_addr. If it exists in the implicit AV, move it from implicit to
+ * explicit. Otherwise allocate a new connection entry in the explicit AV.
+ *
+ * @param[in]	av	address vector
+ * @param[in]	addr	raw address, in the format of gid:qpn:qkey
+ * @param[out]	fi_addr pointer to the output fi address
+ * @param[in]	flags	flags user passed to fi_av_insert
+ * @param[in]	context	context user passed to fi_av_insert
+ * @param[in]	insert_shm_av	whether insert address to shm av
+ * @return	0 on success, a negative error code on failure
+ */
+int efa_av_insert_one_explicit(struct efa_av *av,
+			       struct efa_ep_addr *addr,
+			       fi_addr_t *fi_addr, uint64_t flags,
+			       void *context, bool insert_shm_av)
+{
+	char raw_gid_str[INET6_ADDRSTRLEN];
+	struct efa_conn *conn;
+	fi_addr_t efa_fiaddr;
+	fi_addr_t implicit_fi_addr;
+	int ret;
+
+	ret = efa_av_insert_one_validate(av, addr, fi_addr, raw_gid_str);
+	if (ret)
+		return ret;
 
 	EFA_INFO(FI_LOG_AV,
-		 "Inserting address GID[%s] QP[%u] QKEY[%u] to %s AV ....\n",
-		 raw_gid_str, addr->qpn, addr->qkey,
-		 insert_implicit_av ? "implicit" : "explicit");
+		 "Inserting address GID[%s] QP[%u] QKEY[%u] to explicit AV\n",
+		 raw_gid_str, addr->qpn, addr->qkey);
 
-	/*
-	 * Check if this address already has been inserted, if so set *fi_addr
-	 * to existing address, and return 0 for success.
-	 */
+	ofi_genlock_lock(&av->util_av.lock);
+
+	/* Check if this address already exists in the explicit AV */
 	efa_fiaddr = ofi_av_lookup_fi_addr_unsafe(&av->util_av, addr);
 	if (efa_fiaddr != FI_ADDR_NOTAVAIL) {
-		/* We should never try to insert into the implicit AV an address
-		 * that's already in the explicit AV */
-		assert(!insert_implicit_av);
-
-		EFA_INFO(FI_LOG_AV, "Found existing AV entry pointing to this address! fi_addr: %ld\n", efa_fiaddr);
+		EFA_INFO(FI_LOG_AV,
+			 "Found existing AV entry pointing to this "
+			 "address! fi_addr: %" PRId64 "\n",
+			 efa_fiaddr);
 		*fi_addr = efa_fiaddr;
-		ret = 0;
-		goto out;
+		ofi_genlock_unlock(&av->util_av.lock);
+		return 0;
 	}
 
-	implicit_fi_addr =
-		ofi_av_lookup_fi_addr_unsafe(&av->util_av_implicit, addr);
+	/* Check if this address exists in the implicit AV */
+	ofi_genlock_lock(&av->util_av_implicit.lock);
+	implicit_fi_addr = ofi_av_lookup_fi_addr_unsafe(&av->util_av_implicit, addr);
 	if (implicit_fi_addr != FI_ADDR_NOTAVAIL) {
 		EFA_INFO(FI_LOG_AV,
-			 "Found implicit AV entry id %ld for the same "
-			 "address\n",
+			 "Found implicit AV entry id %" PRId64
+			 " for the same address\n",
 			 implicit_fi_addr);
-
-		if (insert_implicit_av) {
-			/* Move to the end of the LRU list */
-			conn = efa_av_addr_to_conn_implicit(av,
-							    implicit_fi_addr);
-			efa_av_implicit_av_lru_conn_move(av, conn);
-
-			*fi_addr = implicit_fi_addr;
-			goto out;
-		}
 
 		ret = efa_conn_implicit_to_explicit(av, addr, implicit_fi_addr,
 						    fi_addr);
 		if (ret)
 			*fi_addr = FI_ADDR_NOTAVAIL;
-		goto out;
-	}
 
-	conn = efa_conn_alloc(av, addr, flags, context, insert_shm_av, insert_implicit_av);
+		ofi_genlock_unlock(&av->util_av_implicit.lock);
+		ofi_genlock_unlock(&av->util_av.lock);
+		return ret;
+	}
+	ofi_genlock_unlock(&av->util_av_implicit.lock);
+
+	/* Address not found in either AV, allocate a new explicit entry */
+	conn = efa_conn_alloc(av, addr, flags, context, insert_shm_av, false);
 	if (!conn) {
 		*fi_addr = FI_ADDR_NOTAVAIL;
-		ret = -FI_EADDRNOTAVAIL;
-		goto out;
+		ofi_genlock_unlock(&av->util_av.lock);
+		return -FI_EADDRNOTAVAIL;
 	}
 
-	if (insert_implicit_av) {
-		*fi_addr = conn->implicit_fi_addr;
-		EFA_INFO(FI_LOG_AV,
-			 "Successfully inserted address GID[%s] QP[%u] "
-			 "QKEY[%u] to implicit AV. fi_addr: %ld\n",
-			 raw_gid_str, addr->qpn, addr->qkey, *fi_addr);
-	} else {
-		*fi_addr = conn->fi_addr;
-		EFA_INFO(FI_LOG_AV,
-			 "Successfully inserted address GID[%s] QP[%u] "
-			 "QKEY[%u] to explicit AV. fi_addr: %ld\n",
-			 raw_gid_str, addr->qpn, addr->qkey, *fi_addr);
-	}
-	ret = 0;
-
-out:
+	*fi_addr = conn->fi_addr;
 	ofi_genlock_unlock(&av->util_av.lock);
+
+	EFA_INFO(FI_LOG_AV,
+		 "Successfully inserted address GID[%s] QP[%u] "
+		 "QKEY[%u] to explicit AV. fi_addr: %" PRId64 "\n",
+		 raw_gid_str, addr->qpn, addr->qkey, *fi_addr);
+
+	return 0;
+}
+
+/**
+ * @brief insert one address into the implicit address vector
+ *
+ * If the address already exists in the explicit AV, return the existing
+ * explicit fi_addr (no implicit insertion needed). If it already exists in
+ * the implicit AV, update its LRU position. Otherwise allocate a new
+ * connection entry in the implicit AV.
+ *
+ * @param[in]	av	address vector
+ * @param[in]	addr	raw address, in the format of gid:qpn:qkey
+ * @param[out]	fi_addr pointer to the output fi address
+ * @param[in]	flags	flags user passed to fi_av_insert
+ * @param[in]	context	context user passed to fi_av_insert
+ * @return	0 on success, a negative error code on failure
+ */
+int efa_av_insert_one_implicit(struct efa_av *av,
+			       struct efa_ep_addr *addr,
+			       fi_addr_t *fi_addr, uint64_t flags,
+			       void *context)
+{
+	char raw_gid_str[INET6_ADDRSTRLEN];
+	struct efa_conn *conn;
+	fi_addr_t implicit_fi_addr;
+	fi_addr_t efa_fiaddr;
+	int ret;
+
+	ret = efa_av_insert_one_validate(av, addr, fi_addr, raw_gid_str);
+	if (ret)
+		return ret;
+
+	EFA_INFO(FI_LOG_AV,
+		 "Inserting address GID[%s] QP[%u] QKEY[%u] to implicit AV\n",
+		 raw_gid_str, addr->qpn, addr->qkey);
+
+	/* Check if this address already exists in the explicit AV */
+	ofi_genlock_lock(&av->util_av.lock);
+	efa_fiaddr = ofi_av_lookup_fi_addr_unsafe(&av->util_av, addr);
+	if (efa_fiaddr != FI_ADDR_NOTAVAIL) {
+		*fi_addr = efa_fiaddr;
+		ofi_genlock_unlock(&av->util_av.lock);
+		EFA_INFO(FI_LOG_AV,
+			 "Found existing AV entry pointing to this "
+			 "address! fi_addr: %" PRId64 "\n",
+			 efa_fiaddr);
+		return 0;
+	}
+	ofi_genlock_unlock(&av->util_av.lock);
+
+	/* Check if address already exists in the implicit AV */
+	ofi_genlock_lock(&av->util_av_implicit.lock);
+	implicit_fi_addr =
+		ofi_av_lookup_fi_addr_unsafe(&av->util_av_implicit, addr);
+	if (implicit_fi_addr != FI_ADDR_NOTAVAIL) {
+		EFA_INFO(FI_LOG_AV,
+			 "Found implicit AV entry id %" PRId64
+			 " for the same address\n",
+			 implicit_fi_addr);
+
+		/* Move to the end of the LRU list */
+		conn = efa_av_addr_to_conn_implicit(av, implicit_fi_addr);
+		efa_av_implicit_av_lru_conn_move(av, conn);
+
+		*fi_addr = implicit_fi_addr;
+		ofi_genlock_unlock(&av->util_av_implicit.lock);
+		return 0;
+	}
+
+	/* Address not found in either AV, allocate a new implicit entry */
+	conn = efa_conn_alloc(av, addr, flags, context, false, true);
+	if (!conn) {
+		*fi_addr = FI_ADDR_NOTAVAIL;
+		ofi_genlock_unlock(&av->util_av_implicit.lock);
+		return -FI_EADDRNOTAVAIL;
+	}
+
+	*fi_addr = conn->implicit_fi_addr;
 	ofi_genlock_unlock(&av->util_av_implicit.lock);
-	return ret;
+
+	EFA_INFO(FI_LOG_AV,
+		 "Successfully inserted address GID[%s] QP[%u] "
+		 "QKEY[%u] to implicit AV. fi_addr: %" PRId64 "\n",
+		 raw_gid_str, addr->qpn, addr->qkey, *fi_addr);
+
+	return 0;
 }
 
 int efa_av_insert(struct fid_av *av_fid, const void *addr,
@@ -608,7 +690,7 @@ int efa_av_insert(struct fid_av *av_fid, const void *addr,
 	for (i = 0; i < count; i++) {
 		addr_i = (struct efa_ep_addr *) ((uint8_t *)addr + i * EFA_EP_ADDR_LEN);
 
-		ret = efa_av_insert_one(av, addr_i, &fi_addr_res, flags, context, true, false);
+		ret = efa_av_insert_one_explicit(av, addr_i, &fi_addr_res, flags, context, true);
 		if (ret) {
 			EFA_WARN(FI_LOG_AV, "insert raw_addr to av failed! ret=%d\n",
 				 ret);

--- a/prov/efa/src/efa_av.h
+++ b/prov/efa/src/efa_av.h
@@ -86,9 +86,13 @@ struct efa_av {
 int efa_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 		struct fid_av **av_fid, void *context);
 
-int efa_av_insert_one(struct efa_av *av, struct efa_ep_addr *addr,
-		      fi_addr_t *fi_addr, uint64_t flags, void *context,
-		      bool insert_shm_av, bool insert_implicit_av);
+int efa_av_insert_one_explicit(struct efa_av *av, struct efa_ep_addr *addr,
+			       fi_addr_t *fi_addr, uint64_t flags,
+			       void *context, bool insert_shm_av);
+
+int efa_av_insert_one_implicit(struct efa_av *av, struct efa_ep_addr *addr,
+			       fi_addr_t *fi_addr, uint64_t flags,
+			       void *context);
 
 struct efa_conn *efa_av_addr_to_conn(struct efa_av *av, fi_addr_t fi_addr);
 struct efa_conn *efa_av_addr_to_conn_implicit(struct efa_av *av,

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -494,8 +494,8 @@ efa_rdm_cq_get_peer_for_pkt_entry(struct efa_rdm_ep *ep,
 	 * not local or shm is disabled for transmission. We shouldn't insert
 	 * in to shm av in this case.
 	 */
-	ret = efa_av_insert_one(ep->base_ep.av, &efa_ep_addr, &implicit_fi_addr,
-				0, NULL, false, true);
+	ret = efa_av_insert_one_implicit(ep->base_ep.av, &efa_ep_addr, &implicit_fi_addr,
+				0, NULL);
 	if (OFI_UNLIKELY(ret != 0)) {
 		efa_base_ep_write_eq_error(&ep->base_ep, ret,
 					   FI_EFA_ERR_AV_INSERT);

--- a/prov/efa/test/efa_unit_test_av.c
+++ b/prov/efa/test/efa_unit_test_av.c
@@ -436,7 +436,7 @@ static struct efa_rdm_peer *test_av_get_peer_from_implicit_av(struct efa_resourc
 	/* Manually insert into implicit AV */
 	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 
-	err = efa_av_insert_one(av, &raw_addr, &implicit_fi_addr, 0, NULL, true, true);
+	err = efa_av_insert_one_implicit(av, &raw_addr, &implicit_fi_addr, 0, NULL);
 
 	peer = efa_rdm_ep_get_peer_implicit(efa_rdm_ep, implicit_fi_addr);
 
@@ -615,7 +615,7 @@ void test_av_implicit_av_lru_insertion(void **state)
 
 	/* Access peer1 through repeated AV insertion path */
 	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
-	err = efa_av_insert_one(av, peer1->conn->ep_addr, &implicit_fi_addr, 0, NULL, true, true);
+	err = efa_av_insert_one_implicit(av, peer1->conn->ep_addr, &implicit_fi_addr, 0, NULL);
 	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	assert_int_equal(err, 0);
 	assert_int_equal(implicit_fi_addr, 1);
@@ -626,7 +626,7 @@ void test_av_implicit_av_lru_insertion(void **state)
 
 	/* Access peer2 through repeated AV insertion path */
 	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
-	err = efa_av_insert_one(av, peer2->conn->ep_addr, &implicit_fi_addr, 0, NULL, true, true);
+	err = efa_av_insert_one_implicit(av, peer2->conn->ep_addr, &implicit_fi_addr, 0, NULL);
 	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	assert_int_equal(err, 0);
 	assert_int_equal(implicit_fi_addr, 2);
@@ -703,7 +703,7 @@ void test_av_implicit_av_lru_eviction(void **state)
 
 	/* Access peer0 through repeated AV insertion path */
 	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
-	err = efa_av_insert_one(av, peer0->conn->ep_addr, &implicit_fi_addr, 0, NULL, true, true);
+	err = efa_av_insert_one_implicit(av, peer0->conn->ep_addr, &implicit_fi_addr, 0, NULL);
 	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	assert_int_equal(err, 0);
 	assert_int_equal(implicit_fi_addr, 0);
@@ -772,7 +772,7 @@ void test_ah_refcnt(void **state)
 
 	/* Manually insert into implicit AV */
 	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
-	err = efa_av_insert_one(av, &raw_addr, &fi_addr, 0, NULL, true, true);
+	err = efa_av_insert_one_implicit(av, &raw_addr, &fi_addr, 0, NULL);
 	peer = efa_rdm_ep_get_peer_implicit(efa_rdm_ep, fi_addr);
 	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 
@@ -895,7 +895,7 @@ void test_ah_lru_eviction_impl(bool explicit)
 
 	/* Manually insert into implicit AV in first domain */
 	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep[0])->srx_lock);
-	err = efa_av_insert_one(efa_av[0], &raw_addr[0], &fi_addr, 0, NULL, true, true);
+	err = efa_av_insert_one_implicit(efa_av[0], &raw_addr[0], &fi_addr, 0, NULL);
 	peer = efa_rdm_ep_get_peer_implicit(efa_rdm_ep[0], fi_addr);
 	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep[0])->srx_lock);
 
@@ -910,7 +910,7 @@ void test_ah_lru_eviction_impl(bool explicit)
 		peer = efa_rdm_ep_get_peer(efa_rdm_ep[0], fi_addr);
 	} else {
 		ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep[0])->srx_lock);
-		err = efa_av_insert_one(efa_av[0], &raw_addr[1], &fi_addr, 0, NULL, true, true);
+		err = efa_av_insert_one_implicit(efa_av[0], &raw_addr[1], &fi_addr, 0, NULL);
 		peer = efa_rdm_ep_get_peer_implicit(efa_rdm_ep[0], fi_addr);
 		ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep[0])->srx_lock);
 	}

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.c
@@ -64,8 +64,7 @@ fi_addr_t efa_test_av_insert_new_ah(struct fid_ep *ep, struct fid_av *av)
 	efa_test_fabricate_addr(ep, &raw_addr);
 
 	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
-	err = efa_av_insert_one(efa_av, &raw_addr, &fi_addr, 0, NULL, true,
-				true);
+	err = efa_av_insert_one_implicit(efa_av, &raw_addr, &fi_addr, 0, NULL);
 	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 
 	if (err)

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.h
@@ -54,7 +54,7 @@ int efa_test_av_insert_self(struct fid_ep *ep, struct fid_av *av,
 			    fi_addr_t *addr);
 
 /**
- * @brief Insert a fabricated-GID peer via the RDM-internal efa_av_insert_one.
+ * @brief Insert a fabricated-GID peer via efa_av_insert_one_implicit.
  */
 fi_addr_t efa_test_av_insert_new_ah(struct fid_ep *ep, struct fid_av *av);
 

--- a/prov/efa/test/gtest/efa_gtest_conn.cc
+++ b/prov/efa/test/gtest/efa_gtest_conn.cc
@@ -63,7 +63,7 @@ TEST_F(EfaConnTest, alloc_reverse_av_add_failure_rdm_cleanup)
  * @brief Test that efa_conn_alloc cleans up RDM resources when
  * efa_av_reverse_av_add fails via the explicit fi_av_insert path
  * (insert_implicit_av=false). The explicit path acquires the SRX lock
- * itself before calling efa_av_insert_one.
+ * itself before calling efa_av_insert_one_explicit.
  */
 TEST_F(EfaConnTest, alloc_reverse_av_add_failure_explicit_insert)
 {


### PR DESCRIPTION
Narrow the lock scopes of efa_av_insert_one by splitting into explicit and implicit AV insert functions.
The original function held both util_av.lock and util_av_implicit.lock for the entire operation regardless of which AV was being inserted into, and took util_av_implicit.lock outside of util_av.lock. 
Now each path only acquires the locks it actually needs.
Explicit path holds util_av.lock throughout, only briefly takes util_av_implicit.lock to check for implicit-to-explicit migration.
Implicit path briefly takes util_av.lock for the explicit AV check, then only holds util_av_implicit.lock for the insertion.