### PR TITLE
[v2.5.x] contrib/aws: Add Neuron SDK compilation test stage

### DIFF
--- a/contrib/aws/Jenkinsfile
+++ b/contrib/aws/Jenkinsfile
@@ -327,6 +327,7 @@ pipeline {
                     def timeout = "--timeout 90"
                     def test_suite_pkg = "--test-suite-package subspace_nightly_tests --owner subspace"
                     def generic_pf = "--cluster-type manual_cluster --test-target libfabric --test-type pr --test-libfabric-pr $env.CHANGE_ID ${test_suite_pkg}"
+                    def unit_tests = "--test-list test_run_efa_unit_tests"
                     def pr_ci_tests = "--test-list test_pr_ci_fabtests test_run_efa_unit_tests"
                     def pr_ci_tests_hpc = "--test-list test_pr_ci_fabtests test_pr_ci_imb test_run_efa_unit_tests"
 
@@ -337,6 +338,7 @@ pipeline {
                     def sockets_provider = "--test-libfabric-provider sockets --enable-efa false"
 
                     def addl_args_efa = "${timeout} ${generic_pf} ${efa_provider} ${pr_ci_tests}"
+                    def addl_args_neuron = "${timeout} ${generic_pf} ${efa_provider} --test-list test_neuron_sdk_compilation --use-prebuilt-accelerator-ami neuron"
                     def addl_args_efa_hpc = "${timeout} ${generic_pf} ${efa_provider} ${pr_ci_tests_hpc}"
                     def addl_args_efa_hpc_dso = "${addl_args_efa_hpc} test_pr_ci_dso"
                     def addl_args_shm = "${timeout} ${generic_pf} ${shm_provider} ${pr_ci_tests}"
@@ -377,6 +379,9 @@ pipeline {
                     stages["1_g4dn_alinux2023_sm2"]              = get_test_stage_with_lock("1_g4dn_alinux2023_sm2",              env.BUILD_TAG, "alinux2023", "g4dn.16xlarge", 1, "us-west-2", g4dn16x_lock_label, "--odcr cr-02a4720192f900b53 ${addl_args_sm2}")
                     stages["1_g4dn_ubuntu2404_shm"]              = get_test_stage_with_lock("1_g4dn_ubuntu2404_shm",              env.BUILD_TAG, "ubuntu2404", "g4dn.16xlarge", 1, "us-west-2", g4dn16x_lock_label, "--odcr cr-02a4720192f900b53 ${addl_args_shm}")
                     stages["1_g4dn_ubuntu2404_shm_disable-cma"]  = get_test_stage_with_lock("1_g4dn_ubuntu2404_shm_disable-cma",  env.BUILD_TAG, "ubuntu2404", "g4dn.16xlarge", 1, "us-west-2", g4dn16x_lock_label, "--odcr cr-02a4720192f900b53 ${addl_args_shm} --enable-cma false")
+
+                    // Single Node Tests - Compilation wtih Neuron SDK
+                    stages["1_c5n_alinux2023_neuron"]  = get_test_stage_with_lock("1_c5n_alinux2023_neuron", env.BUILD_TAG, "alinux2023", "c5n.18xlarge",  1, "us-east-1", c5n18x_lock_label, "--odcr cr-03c9932f13d83e2d9 ${addl_args_neuron}")
 
                     parallel stages
                 }


### PR DESCRIPTION
Backport of #12578 to v2.5.x.

Add test stage that compiles Libfabric with the Neuron SDK on an instance without Neuron devices.

(cherry picked from commit e9bd0fa7415447b8d0b49e86e46e9e4ac62edce8)