### PR TITLE
[v2.5.x] prov/efa: add lsan suppression file

### DIFF
--- a/prov/efa/test/lsan.supp
+++ b/prov/efa/test/lsan.supp
@@ -1,0 +1,4 @@
+# LeakSanitizer suppressions for the EFA unit-test binaries.
+#
+# benign suppression: persistent glibc allocation
+leak:_dlerror_run


### PR DESCRIPTION
the lsan suppression defined in __lsan_default_suppressions can be ignored by libasan sometimes. we now add an explicit suppression file lsan.supp to make sure these are suppressed


(cherry picked from commit 8508edb14a843bc5efb796f91e02160b50fc86f7)