### PR TITLE
[v2.6.x] prov/efa: Use ibv_query_comp_cntr_caps for device max cntr values

### DIFF
--- a/prov/efa/configure.m4
+++ b/prov/efa/configure.m4
@@ -92,9 +92,8 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	have_efadv_wr_processing_hints=0
 	have_ibv_create_comp_channel=0
 	have_ibv_get_cq_event=0
-	have_ibv_device_attr_ex_max_comp_cntr=0
-	have_ibv_create_comp_cntr=0
 	have_efadv_create_comp_cntr=0
+	have_ibv_query_comp_cntr_caps=0
 
 	dnl $have_neuron is defined at top-level configure.ac
 	AM_CONDITIONAL([HAVE_NEURON], [ test x"$have_neuron" = x1 ])
@@ -251,20 +250,16 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 			[have_ibv_get_cq_event=0],
 			[[#include <infiniband/verbs.h>]])
 
-		AC_CHECK_MEMBER([struct ibv_device_attr_ex.max_comp_cntr],
-			[have_ibv_device_attr_ex_max_comp_cntr=1],
-			[have_ibv_device_attr_ex_max_comp_cntr=0],
-			[[#include <infiniband/verbs.h>]])
-
-		AC_CHECK_DECL([ibv_create_comp_cntr],
-			[have_ibv_create_comp_cntr=1],
-			[have_ibv_create_comp_cntr=0],
-			[[#include <infiniband/verbs.h>]])
 		AC_CHECK_DECL([efadv_create_comp_cntr],
 			[have_efadv_create_comp_cntr=1],
 			[have_efadv_create_comp_cntr=0],
 			[[#include <infiniband/efadv.h>]])
-		
+
+		AC_CHECK_DECL([ibv_query_comp_cntr_caps],
+			[have_ibv_query_comp_cntr_caps=1],
+			[have_ibv_query_comp_cntr_caps=0],
+			[[#include <infiniband/verbs.h>]])
+
 		AC_CHECK_MEMBER([struct efadv_device_attr.inline_buf_size_ex],
 			[have_inline_buf_size_ex=1],
 			[have_inline_buf_size_ex=0],
@@ -334,15 +329,12 @@ AC_DEFUN([FI_EFA_CONFIGURE],[
 	AC_DEFINE_UNQUOTED([HAVE_EFA_CQ_NOTIFICATION],
 		[$have_efa_cq_notification],
 		[Indicates if EFA supports CQ notification (requires ibv_create_comp_channel and ibv_get_cq_event)])
-	AC_DEFINE_UNQUOTED([HAVE_IBV_DEVICE_ATTR_EX_MAX_COMP_CNTR],
-		[$have_ibv_device_attr_ex_max_comp_cntr],
-		[Indicates if ibv_device_attr_ex has max_comp_cntr field])
-	AC_DEFINE_UNQUOTED([HAVE_IBV_CREATE_COMP_CNTR],
-		[$have_ibv_create_comp_cntr],
-		[Indicates if ibv_create_comp_cntr is available])
 	AC_DEFINE_UNQUOTED([HAVE_EFADV_CREATE_COMP_CNTR],
 		[$have_efadv_create_comp_cntr],
 		[Indicates if efadv_create_comp_cntr is available])
+	AC_DEFINE_UNQUOTED([HAVE_IBV_QUERY_COMP_CNTR_CAPS],
+		[$have_ibv_query_comp_cntr_caps],
+		[Indicates if ibv_query_comp_cntr_caps is available])
 
 
 	CPPFLAGS=$save_CPPFLAGS

--- a/prov/efa/src/efa_device.c
+++ b/prov/efa/src/efa_device.c
@@ -98,52 +98,27 @@ err_close:
 }
 
 /**
- * @brief set the max completion counter value from the device
- *
- * @param	efa_device[in]	pointer to a struct efa_device
- * @return	max_comp_cntr value from device, or 0 if unavailable
- */
-static void efa_device_set_max_comp_cntr(struct efa_device *efa_device)
-{
-	efa_device->max_comp_cntr = 0;
-#if HAVE_IBV_DEVICE_ATTR_EX_MAX_COMP_CNTR
-	struct ibv_device_attr_ex attr_ex = {0};
-	struct ibv_query_device_ex_input input = {0};
-	int err;
-
-	err = ibv_query_device_ex(efa_device->ibv_ctx, &input, &attr_ex);
-	if (err) {
-		EFA_WARN_ERRNO(FI_LOG_FABRIC, "ibv_query_device_ex failed", err);
-		return;
-	}
-	efa_device->max_comp_cntr = attr_ex.max_comp_cntr;
-#endif
-}
-
-/**
  * @brief set the max comp/err count values from the device
  *
  * @param	efa_device[in,out]	pointer to a struct efa_device
  */
 static void efa_device_set_cntr_max_values(struct efa_device *efa_device)
 {
+	efa_device->max_comp_cntr = 0;
 	efa_device->comp_count_max_value = 0;
 	efa_device->err_count_max_value = 0;
-#if HAVE_IBV_CREATE_COMP_CNTR
+#if HAVE_IBV_QUERY_COMP_CNTR_CAPS
 	{
-		struct ibv_comp_cntr_init_attr cc_attr = {0};
-		struct ibv_comp_cntr *comp_cntr;
+		struct ibv_comp_cntr_caps caps = {0};
 		int err;
 
-		comp_cntr = ibv_create_comp_cntr(efa_device->ibv_ctx, &cc_attr);
-		if (!comp_cntr) {
-			EFA_WARN_ERRNO(FI_LOG_CNTR, "ibv_create_comp_cntr failed.", errno);
+		err = ibv_query_comp_cntr_caps(efa_device->ibv_ctx, &caps);
+		if (err) {
+			EFA_INFO_ERRNO(FI_LOG_CNTR, "ibv_query_comp_cntr_caps failed", err);
 		} else {
-			efa_device->comp_count_max_value = comp_cntr->comp_count_max_value;
-			efa_device->err_count_max_value = comp_cntr->err_count_max_value;
-			err = ibv_destroy_comp_cntr(comp_cntr);
-			if (err)
-				EFA_WARN_ERRNO(FI_LOG_CNTR, "ibv_destroy_comp_cntr failed", err);
+			efa_device->max_comp_cntr = caps.max_counters;
+			efa_device->comp_count_max_value = caps.max_value;
+			efa_device->err_count_max_value = caps.max_value;
 		}
 	}
 #endif
@@ -191,7 +166,6 @@ int efa_device_construct_data(struct efa_device *efa_device,
 	efa_device->max_rdma_size = 0;
 	efa_device->device_caps = 0;
 #endif
-	efa_device_set_max_comp_cntr(efa_device);
 	efa_device_set_cntr_max_values(efa_device);
 	efa_device->rdm_info = NULL;
 	err = efa_prov_info_alloc(&efa_device->rdm_info, efa_device, FI_EP_RDM);

--- a/prov/efa/src/efa_hw_cntr.c
+++ b/prov/efa/src/efa_hw_cntr.c
@@ -30,24 +30,29 @@ static int efa_hw_cntr_check_attr(struct efa_domain *efa_domain,
 				  const struct fi_cntr_attr *attr,
 				  struct ibv_comp_cntr_init_attr *cc_attr)
 {
+	uint32_t api_version;
+
+	api_version = efa_domain->util_domain.fabric->fabric_fid.api_version;
+
 	if (efa_domain->info->domain_attr->max_cntr_value >
 	    efa_domain->device->comp_count_max_value) {
-		EFA_INFO(FI_LOG_CNTR,
-			 "Domain max_cntr_value (%lu) exceeds completion "
-			 "counter limit (%lu). Hardware counter cannot be used.\n",
-			 efa_domain->info->domain_attr->max_cntr_value,
-			 efa_domain->device->comp_count_max_value);
+		if (FI_VERSION_GE(api_version, FI_VERSION(2, 5)))
+			EFA_WARN(FI_LOG_CNTR,
+				 "Domain max_cntr_value (%lu) exceeds completion "
+				 "counter limit (%lu). Hardware counter cannot be used.\n",
+				 efa_domain->info->domain_attr->max_cntr_value,
+				 efa_domain->device->comp_count_max_value);
 		return -FI_EOPNOTSUPP;
 	}
 
 	if (efa_domain->info->domain_attr->max_err_cntr_value >
 	    efa_domain->device->err_count_max_value) {
-		EFA_INFO(
-			FI_LOG_CNTR,
-			"Domain max_err_cntr_value (%lu) exceeds error counter "
-			"limit (%lu). Hardware counter cannot be used.\n",
-			efa_domain->info->domain_attr->max_err_cntr_value,
-			efa_domain->device->err_count_max_value);
+		if (FI_VERSION_GE(api_version, FI_VERSION(2, 5)))
+			EFA_WARN(FI_LOG_CNTR,
+				 "Domain max_err_cntr_value (%lu) exceeds error counter "
+				 "limit (%lu). Hardware counter cannot be used.\n",
+				 efa_domain->info->domain_attr->max_err_cntr_value,
+				 efa_domain->device->err_count_max_value);
 		return -FI_EOPNOTSUPP;
 	}
 


### PR DESCRIPTION
backport https://github.com/ofiwg/libfabric/pull/12591