### PR TITLE
prov/efa: Add missing thread safty annotation for qp_table

### DIFF
--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -409,6 +409,7 @@ void efa_base_ep_construct_ibv_qp_init_attr_ex(struct efa_base_ep *ep,
 static int efa_base_ep_create_qp(struct efa_base_ep *base_ep,
 				  struct efa_ibv_cq *tx_cq,
 				  struct efa_ibv_cq *rx_cq)
+	OFI_TSA_REQUIRES(efa_qp_table_lock_sym)
 {
 	int ret;
 	struct ibv_qp_init_attr_ex attr_ex = { 0 };
@@ -573,6 +574,7 @@ void efa_qp_destruct(struct efa_qp *qp)
 }
 
 int efa_base_ep_enable(struct efa_base_ep *base_ep)
+	OFI_TSA_REQUIRES(efa_qp_table_lock_sym)
 {
 	int err;
 

--- a/prov/efa/src/efa_data_path_direct_entry.h
+++ b/prov/efa/src/efa_data_path_direct_entry.h
@@ -165,6 +165,7 @@ efa_data_path_direct_is_valid_wrid_qp_gen(struct efa_io_cdesc_common *cqe,
  */
 static inline int efa_data_path_direct_start_poll(struct efa_ibv_cq *ibv_cq,
 						   struct ibv_poll_cq_attr *attr)
+	OFI_TSA_NO_ANALYSIS
 {
 	uint32_t qpn;
 	struct efa_domain *efa_domain;


### PR DESCRIPTION
Fix ./prov/efa/src/efa_data_path_direct_entry.h:186:23: error: reading variable 'qp_table' requires holding mutex 'efa_qp_table_lock_sym'. Hot-path function intentionally reads qp_table without the lock as it is protected by generation count validation.

Fix prov/efa/src/efa_base_ep.c:445:4: error: calling function 'efa_base_ep_destruct_qp_unsafe' requires holding mutex 'efa_qp_table_lock_sym' exclusively. Add OFI_TSA_REQUIRES to the caller efa_base_ep_create_qp.