### PR TITLE
prov/efa: Fix rxe->desc assert that always evaluates to true

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -2092,7 +2092,7 @@ int efa_rdm_rxe_post_local_read_or_queue(struct efa_rdm_ope *rxe,
 
 	/* setup iov */
 	assert(pkt_entry->ope == rxe);
-	assert(rxe->desc && efa_mr_is_hmem(rxe->desc[0]));
+	assert(efa_mr_is_hmem(rxe->desc[0]));
 	iov_count = rxe->iov_count;
 	memcpy(iov, rxe->iov, rxe->iov_count * sizeof(struct iovec));
 	memcpy(desc, rxe->desc, rxe->iov_count * sizeof(void *));


### PR DESCRIPTION
Fix warning: address of array 'rxe->desc' will always evaluate to 'true' [-Wpointer-bool-conversion] since rxe->desc is a pointer of array.