### PR TITLE
prov/efa: fix deadlock in efa_ah_alloc nomem release

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -288,6 +288,7 @@ nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
 	prov/efa/test/gtest/efa_gtest_common_helpers.c \
 	prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c \
 	prov/efa/test/gtest/efa_gtest_conn.cc \
+	prov/efa/test/gtest/efa_gtest_ah_utils.c \
 	prov/efa/test/gtest/efa_gtest_ah.cc \
 	prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc \
 	prov/efa/test/gtest/efa_gtest_rdm_mr.cc \
@@ -335,7 +336,8 @@ prov_efa_test_gtest_efa_gtest_LDFLAGS = \
 	-Wl,--wrap=efa_qp_post_recv \
 	-Wl,--wrap=efa_qp_post_send \
 	-Wl,--wrap=efa_qp_post_read \
-	-Wl,--wrap=efa_qp_post_write
+	-Wl,--wrap=efa_qp_post_write \
+	-Wl,--wrap=malloc
 
 prov_efa_test_gtest_efa_gtest_LIBS = $(linkback)
 

--- a/prov/efa/src/efa_ah.c
+++ b/prov/efa/src/efa_ah.c
@@ -150,6 +150,7 @@ struct efa_ah *efa_ah_alloc(struct efa_domain *domain, const uint8_t *gid,
 	if (!efa_ah) {
 		errno = FI_ENOMEM;
 		EFA_WARN(FI_LOG_AV, "cannot allocate memory for efa_ah\n");
+		ofi_genlock_unlock(&domain->util_domain.lock);
 		return NULL;
 	}
 

--- a/prov/efa/test/gtest/efa_gtest_ah.cc
+++ b/prov/efa/test/gtest/efa_gtest_ah.cc
@@ -1,10 +1,12 @@
 /* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
 /* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
 
+#include "efa_gtest_ah_utils.h"
 #include "efa_gtest_common_helpers.h"
 #include "efa_gtest_common_mocks.h"
 #include "efa_gtest_common_resource.h"
 #include <cerrno>
+#include <thread>
 #include <gtest/gtest.h>
 
 using testing::Test;
@@ -113,4 +115,30 @@ TEST_F(EfaAhTest, alloc_enomem_no_evictable_ah_fails)
 
 	addr = efa_test_av_insert_new_ah(resource.ep, resource.av);
 	EXPECT_EQ(addr, (fi_addr_t) FI_ADDR_NOTAVAIL);
+}
+
+/**
+ * @brief Assert that efa_ah_alloc's malloc-failure path must release
+ * domain->util_domain.lock before returning NULL
+ */
+TEST_F(EfaAhTest, alloc_malloc_failure_releases_domain_lock)
+{
+	struct efa_ah *ah;
+	int trylock_ret = -1;
+
+	errno = 0;
+	efa_test_fail_mallocs({0});
+	ah = efa_test_ah_alloc_fabricated_gid(resource.ep);
+
+	EXPECT_EQ(ah, nullptr);
+	EXPECT_EQ(errno, FI_ENOMEM);
+
+	std::thread observer([&] {
+		trylock_ret = efa_test_util_domain_trylock(resource.domain);
+	});
+	observer.join();
+	EXPECT_EQ(trylock_ret, 0);
+
+	if (trylock_ret != 0)
+		efa_test_util_domain_unlock(resource.domain);
 }

--- a/prov/efa/test/gtest/efa_gtest_ah_utils.c
+++ b/prov/efa/test/gtest/efa_gtest_ah_utils.c
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa.h"
+#include "efa_ah.h"
+#include "efa_base_ep.h"
+#include "efa_gtest_ah_utils.h"
+#include "efa_gtest_common_helpers.h"
+
+struct efa_ah *efa_test_ah_alloc_fabricated_gid(struct fid_ep *ep)
+{
+	struct efa_base_ep *base_ep =
+		container_of(ep, struct efa_base_ep, util_ep.ep_fid);
+	struct efa_ep_addr raw_addr;
+
+	efa_test_fabricate_addr(ep, &raw_addr);
+	return efa_ah_alloc(base_ep->domain, raw_addr.raw, false);
+}

--- a/prov/efa/test/gtest/efa_gtest_ah_utils.h
+++ b/prov/efa/test/gtest/efa_gtest_ah_utils.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#ifndef EFA_GTEST_AH_UTILS_H
+#define EFA_GTEST_AH_UTILS_H
+
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct efa_ah;
+
+/**
+ * @brief Call efa_ah_alloc with a fabricated GID that's not in the ah_map
+ */
+struct efa_ah *efa_test_ah_alloc_fabricated_gid(struct fid_ep *ep);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFA_GTEST_AH_UTILS_H */

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.c
@@ -195,3 +195,23 @@ int efa_test_get_util_domain_ref(struct fid_domain *domain)
 
 	return ofi_atomic_get32(&efa_domain->util_domain.ref);
 }
+
+int efa_test_util_domain_trylock(struct fid_domain *domain)
+{
+	struct efa_domain *efa_domain = container_of(
+		domain, struct efa_domain, util_domain.domain_fid);
+	int ret;
+
+	ret = ofi_mutex_trylock(&efa_domain->util_domain.lock.base.mutex);
+	if (!ret)
+		ofi_mutex_unlock(&efa_domain->util_domain.lock.base.mutex);
+	return ret;
+}
+
+void efa_test_util_domain_unlock(struct fid_domain *domain)
+{
+	struct efa_domain *efa_domain = container_of(
+		domain, struct efa_domain, util_domain.domain_fid);
+
+	ofi_genlock_unlock(&efa_domain->util_domain.lock);
+}

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.h
@@ -24,6 +24,14 @@
 extern "C" {
 #endif
 
+struct efa_ep_addr;
+
+/**
+ * @brief Fabricate a unique peer address from the ep's own address, perturbed
+ * so it differs from the ep's real GID (and from prior fabricated addrs).
+ */
+void efa_test_fabricate_addr(struct fid_ep *ep, struct efa_ep_addr *addr);
+
 /**
  * @brief Whether the real selected EFA device advertises both RDMA read and write.
  */
@@ -117,6 +125,19 @@ void efa_test_set_shm_domain(struct fid_domain *domain,
  * @brief Get util_domain's refcount.
  */
 int efa_test_get_util_domain_ref(struct fid_domain *domain);
+
+/**
+ * @brief Try to acquire domain->util_domain.lock, releasing it again on
+ * success. Should be run on an observer thread to check whether the lock is
+ * currently held.
+ * @return 0 if the lock was free, else EBUSY.
+ */
+int efa_test_util_domain_trylock(struct fid_domain *domain);
+
+/**
+ * @brief Unlock domain->util_domain.lock from the current thread.
+ */
+void efa_test_util_domain_unlock(struct fid_domain *domain);
 
 #ifdef __cplusplus
 }

--- a/prov/efa/test/gtest/efa_gtest_common_mocks.cc
+++ b/prov/efa/test/gtest/efa_gtest_common_mocks.cc
@@ -2,6 +2,7 @@
 /* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
 
 #include "efa_gtest_common_mocks.h"
+#include <cassert>
 
 static MockEfa *g_mock_efa = nullptr;
 
@@ -30,4 +31,36 @@ void MockEfa::set(MockEfa *instance)
 
 extern "C" {
 EFA_MOCK_FUNCTIONS(EFA_MOCK_GEN_WRAP)
+}
+
+/*
+ * malloc arming mechanism is intentionally outside MockEfa since gmock calls
+ * malloc internally, which would recurse.
+ */
+static std::bitset<EFA_TEST_MALLOC_FAIL_MAX> g_malloc_fail;
+static unsigned g_malloc_count = 0;
+
+extern "C" void *__real_malloc(size_t size);
+
+extern "C" void *__wrap_malloc(size_t size)
+{
+	if (g_malloc_fail.any()) {
+		unsigned ord = g_malloc_count++;
+		if (ord < EFA_TEST_MALLOC_FAIL_MAX && g_malloc_fail[ord]) {
+			g_malloc_fail[ord] = false;
+			return nullptr;
+		}
+	}
+	return __real_malloc(size);
+}
+
+void efa_test_fail_mallocs(const std::vector<unsigned> &ordinals)
+{
+	g_malloc_fail.reset();
+	g_malloc_count = 0;
+
+	for (unsigned n : ordinals) {
+		assert(n < EFA_TEST_MALLOC_FAIL_MAX);
+		g_malloc_fail[n] = true;
+	}
 }

--- a/prov/efa/test/gtest/efa_gtest_common_mocks.h
+++ b/prov/efa/test/gtest/efa_gtest_common_mocks.h
@@ -7,6 +7,7 @@
 
 #include <bitset>
 #include <gmock/gmock.h>
+#include <vector>
 #include <infiniband/efadv.h>
 #include <infiniband/verbs.h>
 
@@ -132,5 +133,17 @@ class MockEfa
 extern "C" {
 EFA_MOCK_FUNCTIONS(EFA_MOCK_GEN_REAL_DECL)
 }
+
+/* Largest number of malloc failures we can inject */
+#define EFA_TEST_MALLOC_FAIL_MAX 64
+
+/**
+ * @brief Fail selected mallocs by 0-based ordinal after calling this function;
+ * all others go to real malloc.
+ * @param[in] ordinals	0-based malloc ordinals to fail (each in
+ *			[0, EFA_TEST_MALLOC_FAIL_MAX)), e.g. {1, 3} fails the 2nd
+ *			and 4th malloc. Order and duplicates don't matter.
+ */
+void efa_test_fail_mallocs(const std::vector<unsigned> &ordinals);
 
 #endif /* EFA_GTEST_COMMON_MOCKS_H */


### PR DESCRIPTION
Previously, if the efa_ah malloc fails, the util_domain lock isn't released. 
This will lead to a potential deadlock. 
This commit fixes it and adds a unit test to assert on this. 
A mechanism to inject malloc failure in the gtest suite is introduced.