### PR TITLE
fabtests/efa: Add low latency SL parametrization to MR abort fabtest

### DIFF
--- a/fabtests/prov/efa/src/efa_shared.c
+++ b/fabtests/prov/efa/src/efa_shared.c
@@ -14,6 +14,7 @@ static struct option efa_extra_opts[] = {
 	{"high-pps", no_argument, NULL, OPT_HIGH_PPS},
 	{"post-list", required_argument, NULL, OPT_POST_LIST},
 	{"num-eps", required_argument, NULL, OPT_NUM_EPS},
+	{"sl-low-latency", no_argument, NULL, OPT_SL_LOW_LATENCY},
 	{0, 0, 0, 0}
 };
 
@@ -47,6 +48,8 @@ void efa_longopts_usage(void)
 		"Batch n posts per doorbell using FI_MORE (default: 1)");
 	FT_PRINT_OPTS_USAGE("-q <n>, --num-eps <n>",
 		"Number of endpoints/QPs (default: 1)");
+	FT_PRINT_OPTS_USAGE("--sl-low-latency",
+		"Enable FI_TC_LOW_LATENCY on all endpoints used in the test");
 	ft_longopts_usage();
 }
 

--- a/fabtests/prov/efa/src/efa_shared.h
+++ b/fabtests/prov/efa/src/efa_shared.h
@@ -22,6 +22,7 @@ enum {
 	OPT_HIGH_PPS = 256,
 	OPT_POST_LIST,
 	OPT_NUM_EPS,
+	OPT_SL_LOW_LATENCY,
 };
 
 /*

--- a/fabtests/prov/efa/src/mr_abort.c
+++ b/fabtests/prov/efa/src/mr_abort.c
@@ -133,6 +133,7 @@ static enum test_mode test_mode = TEST_ABORT;
 static int close_ep_first;
 static int set_homogeneous_peers;
 static bool use_high_pps = false;
+static bool sl_low_latency = false;
 
 /*
  * -r <file>: replay a previously dumped close order instead of generating
@@ -1966,6 +1967,9 @@ int main(int argc, char **argv)
 		case OPT_HIGH_PPS:
 			use_high_pps = true;
 			break;
+		case OPT_SL_LOW_LATENCY:
+			sl_low_latency = true;
+			break;
 		case 'W':
 			num_mrs = atoi(optarg);
 			break;
@@ -2145,6 +2149,9 @@ int main(int argc, char **argv)
 	hints->domain_attr->mr_mode = opts.mr_mode;
 	hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
 	hints->addr_format = opts.address_format;
+
+	if (sl_low_latency)
+		hints->tx_attr->tclass = FI_TC_LOW_LATENCY;
 
 	/*
 	 * For writedata, fabtests' ft_getinfo() auto-adds FI_RX_CQ_DATA to

--- a/fabtests/pytest/efa/test_mr_abort.py
+++ b/fabtests/pytest/efa/test_mr_abort.py
@@ -12,35 +12,52 @@ pytestmark = pytest.mark.pre_release
 # instance.
 MR_ABORT_NUM_MRS = 2046
 
-
 BASE_MESSAGE_SIZES = [
+    64,
     4096,
     65536,
     1048576,
     10485760,
 ]
 
+SL_LOW_LATENCY_MAX_WRITE_SIZE = 128
+
+
 def combined_msg_size_params():
     for rma_op in ["write", "read", "writedata"]:
         for size in BASE_MESSAGE_SIZES:
 
             high_pps_vals = [None]
+            sl_low_latency_vals = [None]
 
             if (rma_op == "write" or rma_op == "writedata"):
                 # High PPS parametrization is only applicable for RDMA writes
                 high_pps_vals = [True, False]
 
+                # Low latency SL is only applicable for small RDMA writes
+                if size < SL_LOW_LATENCY_MAX_WRITE_SIZE:
+                    sl_low_latency_vals = [True, False]
+
             marks = []
             if size == 10485760:
+                # 10 MiB: large transfers consume far more memory/NIC resources
+                # Run this size serially to avoid resource contention with
+                # parallel workers
                 marks = [pytest.mark.serial]
 
             for high_pps_val in high_pps_vals:
-                id = f"{rma_op}-{size}"
-                if high_pps_val is not None:
-                    id += f"-high_pps-{high_pps_val}"
+                for sl_low_latency_val in sl_low_latency_vals:
 
-                yield pytest.param(size, rma_op, high_pps_val,
-                                   marks=marks, id=id)
+                    id = f"{rma_op}-{size}"
+
+                    if high_pps_val is not None:
+                        id += f"-high_pps-{high_pps_val}"
+
+                    if sl_low_latency_val is not None:
+                        id += f"-sl_low_lat-{sl_low_latency_val}"
+
+                    yield pytest.param(size, rma_op, high_pps_val,
+                                       sl_low_latency_val, marks=marks, id=id)
 
 
 # --- Test: abort (RMA) ---
@@ -49,9 +66,10 @@ def combined_msg_size_params():
 @pytest.mark.parametrize("cancel_order", ["reverse", "random"])
 @pytest.mark.parametrize("close_side", ["initiator", "target"])
 @pytest.mark.parametrize("ops_per_mr", [1, 4])
-@pytest.mark.parametrize("message_size, rma_op, high_pps",
+@pytest.mark.parametrize("message_size, rma_op, high_pps, sl_low_latency",
                          list(combined_msg_size_params()))
-def test_mr_abort(cmdline_args, rma_fabric, rma_op, cancel_order, close_side, ops_per_mr, high_pps, message_size, memory_type_symm):
+def test_mr_abort(cmdline_args, rma_fabric, rma_op, cancel_order, close_side, ops_per_mr,
+                  high_pps, sl_low_latency, message_size, memory_type_symm):
     if rma_fabric == "efa" and cmdline_args.server_id == cmdline_args.client_id:
         pytest.skip("fi_mr_abort not supported with efa with SHM")
 
@@ -66,6 +84,11 @@ def test_mr_abort(cmdline_args, rma_fabric, rma_op, cancel_order, close_side, op
         assert(rma_op != "read")
         command += " --high-pps"
 
+    if sl_low_latency:
+        assert(rma_op != "read")
+        assert(message_size < 128)
+        command += " --sl-low-latency"
+
     test = ClientServerTest(cmdline_args, command, timeout=300, fabric=rma_fabric, memory_type=memory_type_symm)
     test.run()
 
@@ -73,9 +96,10 @@ def test_mr_abort(cmdline_args, rma_fabric, rma_op, cancel_order, close_side, op
 # --- Test: partial (2 MRs on same buffer) ---
 @pytest.mark.functional
 @pytest.mark.fabric(params=["efa-direct"]) # TODO add test for efa fabric
-@pytest.mark.parametrize("message_size, rma_op, high_pps",
+@pytest.mark.parametrize("message_size, rma_op, high_pps, sl_low_latency",
                          list(combined_msg_size_params()))
-def test_mr_abort_partial(cmdline_args, rma_fabric, rma_op, high_pps, message_size, memory_type_symm):
+def test_mr_abort_partial(cmdline_args, rma_fabric, rma_op, high_pps,
+                          sl_low_latency, message_size, memory_type_symm):
     if rma_fabric == "efa" and cmdline_args.server_id == cmdline_args.client_id:
         pytest.skip("fi_mr_abort not supported with efa with SHM")
 
@@ -84,6 +108,11 @@ def test_mr_abort_partial(cmdline_args, rma_fabric, rma_op, high_pps, message_si
     if high_pps:
         assert(rma_op != "read")
         command += " --high-pps"
+
+    if sl_low_latency:
+        assert(rma_op != "read")
+        assert(message_size < 128)
+        command += " --sl-low-latency"
 
     test = ClientServerTest(cmdline_args, command, timeout=300, fabric=rma_fabric, memory_type=memory_type_symm)
     test.run()

--- a/fabtests/pytest/efa/test_mr_abort.py
+++ b/fabtests/pytest/efa/test_mr_abort.py
@@ -13,23 +13,44 @@ pytestmark = pytest.mark.pre_release
 MR_ABORT_NUM_MRS = 2046
 
 
-# --- Test: abort (RMA) ---
-@pytest.mark.functional
-@pytest.mark.fabric(params=["efa-direct"])  # TODO add test for efa fabric
-@pytest.mark.parametrize("rma_op", ["write", "read", "writedata"])
-@pytest.mark.parametrize("cancel_order", ["reverse", "random"])
-@pytest.mark.parametrize("close_side", ["initiator", "target"])
-@pytest.mark.parametrize("ops_per_mr", [1, 4])
-@pytest.mark.parametrize("high_pps", [True, False])
-@pytest.mark.parametrize("message_size", [
+BASE_MESSAGE_SIZES = [
     4096,
     65536,
     1048576,
-    # 10 MiB: large transfers consume far more memory/NIC resources, so
-    # run this size serially to avoid resource contention with parallel
-    # workers.
-    pytest.param(10485760, marks=pytest.mark.serial),
-])
+    10485760,
+]
+
+def combined_msg_size_params():
+    for rma_op in ["write", "read", "writedata"]:
+        for size in BASE_MESSAGE_SIZES:
+
+            high_pps_vals = [None]
+
+            if (rma_op == "write" or rma_op == "writedata"):
+                # High PPS parametrization is only applicable for RDMA writes
+                high_pps_vals = [True, False]
+
+            marks = []
+            if size == 10485760:
+                marks = [pytest.mark.serial]
+
+            for high_pps_val in high_pps_vals:
+                id = f"{rma_op}-{size}"
+                if high_pps_val is not None:
+                    id += f"-high_pps-{high_pps_val}"
+
+                yield pytest.param(size, rma_op, high_pps_val,
+                                   marks=marks, id=id)
+
+
+# --- Test: abort (RMA) ---
+@pytest.mark.functional
+@pytest.mark.fabric(params=["efa-direct"])  # TODO add test for efa fabric
+@pytest.mark.parametrize("cancel_order", ["reverse", "random"])
+@pytest.mark.parametrize("close_side", ["initiator", "target"])
+@pytest.mark.parametrize("ops_per_mr", [1, 4])
+@pytest.mark.parametrize("message_size, rma_op, high_pps",
+                         list(combined_msg_size_params()))
 def test_mr_abort(cmdline_args, rma_fabric, rma_op, cancel_order, close_side, ops_per_mr, high_pps, message_size, memory_type_symm):
     if rma_fabric == "efa" and cmdline_args.server_id == cmdline_args.client_id:
         pytest.skip("fi_mr_abort not supported with efa with SHM")
@@ -42,8 +63,7 @@ def test_mr_abort(cmdline_args, rma_fabric, rma_op, cancel_order, close_side, op
                f" -S {message_size}")
 
     if high_pps:
-        if rma_op == "read":
-            pytest.skip("High PPS not supported with RDMA read")
+        assert(rma_op != "read")
         command += " --high-pps"
 
     test = ClientServerTest(cmdline_args, command, timeout=300, fabric=rma_fabric, memory_type=memory_type_symm)
@@ -53,15 +73,8 @@ def test_mr_abort(cmdline_args, rma_fabric, rma_op, cancel_order, close_side, op
 # --- Test: partial (2 MRs on same buffer) ---
 @pytest.mark.functional
 @pytest.mark.fabric(params=["efa-direct"]) # TODO add test for efa fabric
-@pytest.mark.parametrize("rma_op", ["write", "read", "writedata"])
-@pytest.mark.parametrize("high_pps", [True, False])
-@pytest.mark.parametrize("message_size", [
-    4096,
-    65536,
-    1048576,
-    # 10 MiB: run serially to avoid resource contention (see test_mr_abort).
-    pytest.param(10485760, marks=pytest.mark.serial),
-])
+@pytest.mark.parametrize("message_size, rma_op, high_pps",
+                         list(combined_msg_size_params()))
 def test_mr_abort_partial(cmdline_args, rma_fabric, rma_op, high_pps, message_size, memory_type_symm):
     if rma_fabric == "efa" and cmdline_args.server_id == cmdline_args.client_id:
         pytest.skip("fi_mr_abort not supported with efa with SHM")
@@ -69,8 +82,7 @@ def test_mr_abort_partial(cmdline_args, rma_fabric, rma_op, high_pps, message_si
     command = (f"fi_mr_abort -T partial -o {rma_op} -S {message_size}")
 
     if high_pps:
-        if rma_op == "read":
-            pytest.skip("High PPS not supported with RDMA read")
+        assert(rma_op != "read")
         command += " --high-pps"
 
     test = ClientServerTest(cmdline_args, command, timeout=300, fabric=rma_fabric, memory_type=memory_type_symm)


### PR DESCRIPTION
Low latency SL is a property of the QP but it only affects the
performance of small RDMA writes. So run the test with low latency SL
only for message sizes and RDMA operations where it is applicable.