### PR TITLE
fabtests/efa: Move peer calculation to efa_shared.c

### DIFF
--- a/fabtests/prov/efa/Makefile.include
+++ b/fabtests/prov/efa/Makefile.include
@@ -96,6 +96,7 @@ prov_efa_src_fi_efa_rdm_remote_exit_early_LDADD = libfabtests.la
 
 prov_efa_src_fi_efa_multi_ep_stress_SOURCES = \
 	prov/efa/src/multi_ep_stress.c \
+	prov/efa/src/efa_shared.c \
 	$(efa_rnr_srcs)
 prov_efa_src_fi_efa_multi_ep_stress_LDADD = libfabtests.la
 

--- a/fabtests/prov/efa/src/efa_shared.c
+++ b/fabtests/prov/efa/src/efa_shared.c
@@ -4,6 +4,7 @@
 
 #include <stdbool.h>
 #include <stdlib.h>
+#include <string.h>
 #include <getopt.h>
 
 #include <shared.h>
@@ -47,4 +48,53 @@ void efa_longopts_usage(void)
 	FT_PRINT_OPTS_USAGE("-q <n>, --num-eps <n>",
 		"Number of endpoints/QPs (default: 1)");
 	ft_longopts_usage();
+}
+
+/**
+ * efa_calc_peer_distribution - Distribute peers across workers
+ * @my_id: ID of the local worker to calculate distribution for
+ * @my_count: Total number of local workers
+ * @peer_count: Total number of peers to distribute
+ * @num_peers: Output - number of peers assigned to this worker
+ * @peer_ids: Output - dynamically allocated array of peer IDs for this worker
+ *
+ * Distributes a given number of remote peers across local workers
+ *
+ * When peers <= workers, each worker gets one peer.
+ * The index of the assigned peer is worker_id % total_peers
+ *
+ * When peers > workers, the peers are distributed in a
+ * round-robin fashion. If the number of peers is not divisible by
+ * the number of local workers, the remaining peers are distributed
+ * to lower-numbered workers.
+ *
+ * Returns: FI_SUCCESS on success, -FI_ENOMEM on allocation failure
+ *
+ * Note: Caller must free the allocated peer_ids array
+ */
+int efa_calc_peer_distribution(int my_idx, int my_count, int peer_count,
+			       int *num_peers, int **peer_ids)
+{
+	int n, i;
+
+	if (peer_count <= my_count) {
+		n = 1;
+		*peer_ids = malloc(sizeof(int));
+		if (!*peer_ids)
+			return -FI_ENOMEM;
+		(*peer_ids)[0] = my_idx % peer_count;
+	} else {
+		assert(my_count > 0);
+		n = peer_count / my_count;
+		if (my_idx < peer_count % my_count)
+			n++;
+		*peer_ids = malloc(n * sizeof(int));
+		if (!*peer_ids)
+			return -FI_ENOMEM;
+		for (i = 0; i < n; i++)
+			(*peer_ids)[i] = my_idx + i * my_count;
+	}
+
+	*num_peers = n;
+	return FI_SUCCESS;
 }

--- a/fabtests/prov/efa/src/efa_shared.h
+++ b/fabtests/prov/efa/src/efa_shared.h
@@ -34,4 +34,7 @@ void build_efa_long_opts(void);
 
 void efa_longopts_usage(void);
 
+int efa_calc_peer_distribution(int my_idx, int my_count, int peer_count,
+			       int *num_peers, int **peer_ids);
+
 #endif /* _EFA_SHARED_H */

--- a/fabtests/prov/efa/src/multi_ep_stress.c
+++ b/fabtests/prov/efa/src/multi_ep_stress.c
@@ -17,6 +17,7 @@
 
 #include "hmem.h"
 #include "shared.h"
+#include "efa_shared.h"
 #include "ft_random.h"
 
 #define MAX_WORKERS	64
@@ -208,8 +209,8 @@ struct context_pool {
 
 // Worker context structure
 struct worker_context {
-	size_t num_peers;
-	uint16_t *peer_ids;
+	int num_peers;
+	int *peer_ids;
 	struct ep_message_queue *control_queue;
 	struct fid_ep *ep;
 	struct fid_cq *cq;
@@ -359,55 +360,6 @@ static int setup_endpoint(struct worker_context *ctx, uint64_t total_ops)
 error:
 	cleanup_endpoint(ctx);
 	return ret;
-}
-
-/**
- * calculate_worker_distribution - Distribute peers across workers
- * @current_worker_id: ID of the worker to calculate distribution for
- * @total_workers: Total number of workers in the system
- * @total_peers: Total number of peers to distribute
- * @num_peers: Output - number of peers assigned to this worker
- * @peer_ids: Output - dynamically allocated array of peer IDs for this worker
- *
- * Distributes peers evenly across workers. When peers <= workers, each worker
- * gets one peer (worker_id % total_peers). When peers > workers, distributes
- * peers round-robin with remainder distributed to lower-numbered workers.
- *
- * Returns: FI_SUCCESS on success, -FI_ENOMEM on allocation failure
- *
- * Note: Caller must free the allocated peer_ids array
- */
-static int calculate_worker_distribution(uint16_t current_worker_id,
-					uint16_t total_workers,
-					uint16_t total_peers,
-					size_t *num_peers,
-					uint16_t **peer_ids)
-{
-	if (total_peers <= total_workers) {
-		// Each worker has one peer
-		*num_peers = 1;
-		*peer_ids = malloc(sizeof(int));
-		if (*peer_ids == NULL)
-			goto error;
-		**peer_ids = current_worker_id % total_peers;
-	} else {
-		// Multiple peers per worker
-		*num_peers = total_peers / total_workers;
-		if (current_worker_id < total_peers % total_workers)
-			(*num_peers)++;
-		*peer_ids = malloc(*num_peers * sizeof(int));
-		if (*peer_ids == NULL)
-			goto error;
-		for (size_t i = 0; i < *num_peers; i++) {
-			(*peer_ids)[i] = current_worker_id + i * total_workers;
-		}
-	}
-	return FI_SUCCESS;
-error:
-	fprintf(stderr,
-		"Failed to allocate peer_ids for worker %d\n",
-		current_worker_id);
-	return -FI_ENOMEM;
 }
 
 /**
@@ -922,7 +874,7 @@ static void *run_receiver_worker(void *arg)
 					ctx->worker_id, cycle);
 			}
 			printf("Receiver %u EP cycle %d: Posted %" PRIu64
-				" and completed %" PRIu64 " receives from %zu senders\n\n",
+				" and completed %" PRIu64 " receives from %d senders\n\n",
 				ctx->worker_id, cycle, ops_posted, ops_completed, ctx->num_peers);
 		}
 	}
@@ -1039,7 +991,7 @@ static int run_sender(void)
 		worker->worker_id = i;
 		worker->control_queue = &channels[i];
 
-		ret = calculate_worker_distribution(i,
+		ret = efa_calc_peer_distribution(i,
 						topts.num_sender_workers,
 						topts.num_receiver_workers,
 						&worker->num_peers,
@@ -1189,7 +1141,7 @@ static int run_receiver(void)
 		worker->worker_id = i;
 		worker->control_queue = &control_queue;
 
-		ret = calculate_worker_distribution(i,
+		ret = efa_calc_peer_distribution(i,
 						topts.num_receiver_workers,
 						topts.num_sender_workers,
 						&worker->num_peers,


### PR DESCRIPTION
Peer calculation logic will also be used in MR abort tests. Move the logic to shared function.