### PR TITLE
prov/efa: add efa_av_array, a lock-free fi_addr-indexed pointer array

### DIFF
--- a/include/ofi_mb.h
+++ b/include/ofi_mb.h
@@ -181,6 +181,9 @@
  * SOFTWARE.
  */
 
+#ifndef _OFI_MB_H_
+#define _OFI_MB_H_
+
 #include "config.h"
 #include <stdbool.h>
 
@@ -192,6 +195,11 @@ static inline void ofi_wmb(void)
 	atomic_thread_fence(memory_order_release);
 }
 
+static inline void ofi_rmb(void)
+{
+	atomic_thread_fence(memory_order_acquire);
+}
+
 #elif defined(HAVE_BUILTIN_MM_ATOMICS)
 
 static inline void ofi_wmb(void)
@@ -199,6 +207,26 @@ static inline void ofi_wmb(void)
 	__atomic_thread_fence(__ATOMIC_RELEASE);
 }
 
+static inline void ofi_rmb(void)
+{
+	__atomic_thread_fence(__ATOMIC_ACQUIRE);
+}
+
+#elif defined(_MSC_VER)
+#include <intrin.h>
+
+static inline void ofi_wmb(void)
+{
+	_mm_sfence();
+}
+
+static inline void ofi_rmb(void)
+{
+	_mm_lfence();
+}
+
 #else
 #error "Neither built-in atomics nor C11 atomics is supported by compiler."
 #endif
+
+#endif /* _OFI_MB_H_ */

--- a/libfabric.vcxproj
+++ b/libfabric.vcxproj
@@ -872,6 +872,7 @@
   <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Debug-Efa-v142|x64' OR '$(Configuration)|$(Platform)'=='Release-Efa-v142|x64'">
     <ClCompile Include="prov\efa\src\windows\efawin.c" />
     <ClCompile Include="prov\efa\src\efa_av.c" />
+    <ClCompile Include="prov\efa\src\efa_av_array.c" />
     <ClCompile Include="prov\efa\src\efa_ah.c" />
     <ClCompile Include="prov\efa\src\efa_conn.c" />
     <ClCompile Include="prov\efa\src\efa_hmem.c" />
@@ -1023,6 +1024,7 @@
     <ClInclude Include="prov\efa\src\efa.h" />
     <ClInclude Include="prov\efa\src\efa_fabric_util.h" />
     <ClInclude Include="prov\efa\src\efa_av.h" />
+    <ClInclude Include="prov\efa\src\efa_av_array.h" />
     <ClInclude Include="prov\efa\src\efa_ah.h" />
     <ClInclude Include="prov\efa\src\efa_conn.h" />
     <ClInclude Include="prov\efa\src\efa_base_ep.h" />

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -35,6 +35,7 @@ _efa_files = \
 	prov/efa/src/efa_hmem.c \
 	prov/efa/src/efa_shm.c \
 	prov/efa/src/efa_av.c \
+	prov/efa/src/efa_av_array.c \
 	prov/efa/src/efa_ah.c \
 	prov/efa/src/efa_conn.c \
 	prov/efa/src/rdm/efa_rdm_domain.c \
@@ -93,6 +94,7 @@ endif ENABLE_EFA_UNIT_TEST
 _efa_headers = \
 	prov/efa/src/efa.h \
 	prov/efa/src/efa_av.h \
+	prov/efa/src/efa_av_array.h \
 	prov/efa/src/efa_ah.h \
 	prov/efa/src/efa_conn.h \
 	prov/efa/src/efa_mr.h \

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -290,6 +290,8 @@ nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
 	prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c \
 	prov/efa/test/gtest/efa_gtest_conn.cc \
 	prov/efa/test/gtest/efa_gtest_ah.cc \
+	prov/efa/test/gtest/efa_gtest_av_array.cc \
+	prov/efa/test/gtest/efa_gtest_av_array_utils.c \
 	prov/efa/test/gtest/efa_gtest_rdm_pke_rtm.cc \
 	prov/efa/test/gtest/efa_gtest_rdm_mr.cc \
 	prov/efa/test/gtest/efa_gtest_rdm_pke.cc \

--- a/prov/efa/src/efa_av_array.c
+++ b/prov/efa/src/efa_av_array.c
@@ -1,0 +1,131 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include <stdlib.h>
+#include <ofi_mb.h>
+#include "efa.h"
+#include "efa_av_array.h"
+
+int efa_av_array_init_attr(struct efa_av_array **arr_out,
+			   const struct efa_av_array_attr *attr)
+{
+	struct efa_av_array *arr;
+	unsigned max_idx = attr ? attr->max_idx : 0;
+
+	*arr_out = NULL;
+
+	if (max_idx == 0)
+		max_idx = EFA_AV_ARRAY_DEFAULT_MAX_IDX;
+	if (max_idx > EFA_AV_ARRAY_MAX_IDX_CEILING) {
+		EFA_WARN(FI_LOG_AV, "efa_av_array max_idx %u out of range\n",
+			 max_idx);
+		return -FI_EINVAL;
+	}
+
+	arr = calloc(1, sizeof(*arr));
+	if (!arr)
+		return -FI_ENOMEM;
+
+	arr->max_idx = max_idx;
+	if (max_idx >= EFA_AV_ARRAY_FAST_CUTOFF) {
+		size_t span = (size_t) max_idx - EFA_AV_ARRAY_FAST_CUTOFF + 1;
+
+		arr->chunk_table_len = (span + EFA_AV_ARRAY_CHUNK_SIZE - 1) /
+				       EFA_AV_ARRAY_CHUNK_SIZE;
+	}
+
+	*arr_out = arr;
+	return FI_SUCCESS;
+}
+
+int efa_av_array_init(struct efa_av_array **arr)
+{
+	return efa_av_array_init_attr(arr, NULL);
+}
+
+void efa_av_array_destroy(struct efa_av_array *arr)
+{
+	size_t i;
+
+	if (!arr)
+		return;
+
+	if (arr->chunk_table) {
+		for (i = 0; i < arr->chunk_table_len; i++)
+			free(arr->chunk_table[i]);
+		free(arr->chunk_table);
+	}
+	free(arr);
+}
+
+/* This function must be protected by a lock. The lock will guarantee that
+ * only 1 writer can insert at a time and will make sure there is a memory
+ * barrier before entering and after exiting.
+ * This is sufficient because the man pages state that a program must wait
+ * for fi_av_insert to return before doing work that requires that AV.
+ */
+int efa_av_array_insert(struct efa_av_array *arr, unsigned index, void *entry)
+{
+	void **table = NULL;
+	void **chunk = NULL;
+	size_t rel, chunk_idx;
+
+	if (index > arr->max_idx)
+		return -FI_EINVAL;
+
+	if (index < EFA_AV_ARRAY_FAST_CUTOFF) {
+		arr->fast[index] = entry;
+		return FI_SUCCESS;
+	}
+
+	if (OFI_UNLIKELY(!arr->chunk_table)) {
+		table = calloc(arr->chunk_table_len, sizeof(*table));
+		if (!table)
+			return -FI_ENOMEM;
+
+		arr->chunk_table = table;
+	}
+
+	table = arr->chunk_table;
+
+	rel = (size_t) index - EFA_AV_ARRAY_FAST_CUTOFF;
+	chunk_idx = rel / EFA_AV_ARRAY_CHUNK_SIZE;
+
+	chunk = table[chunk_idx];
+	if (OFI_UNLIKELY(!chunk)) {
+		chunk = calloc(EFA_AV_ARRAY_CHUNK_SIZE, sizeof(*chunk));
+		if (!chunk)
+			return -FI_ENOMEM;
+
+		table[chunk_idx] = chunk;
+	}
+
+	chunk[rel % EFA_AV_ARRAY_CHUNK_SIZE] = entry;
+	return FI_SUCCESS;
+}
+
+void efa_av_array_iter(struct efa_av_array *arr, void *context,
+		       int (*fn)(struct efa_av_array *arr, void *entry,
+				 void *context))
+{
+	size_t i, j;
+
+	for (i = 0; i < EFA_AV_ARRAY_FAST_CUTOFF; i++) {
+		if (arr->fast[i] && fn(arr, arr->fast[i], context))
+			return;
+	}
+
+	if (!arr->chunk_table)
+		return;
+
+	for (i = 0; i < arr->chunk_table_len; i++) {
+		void **chunk = (void **) arr->chunk_table[i];
+
+		if (!chunk)
+			continue;
+		for (j = 0; j < EFA_AV_ARRAY_CHUNK_SIZE; j++) {
+			if (chunk[j] && fn(arr, chunk[j], context))
+				return;
+		}
+	}
+}

--- a/prov/efa/src/efa_av_array.h
+++ b/prov/efa/src/efa_av_array.h
@@ -1,0 +1,100 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#ifndef EFA_AV_ARRAY_H
+#define EFA_AV_ARRAY_H
+
+#include <stddef.h>
+#include <ofi_mb.h>
+
+/* Indexes below this are served from the embedded fast array. */
+#define EFA_AV_ARRAY_FAST_CUTOFF 8192
+/* Indexes per chunk for the region at or above the fast array. */
+#define EFA_AV_ARRAY_CHUNK_SIZE 8192
+/* Largest max_idx an array may be created with. */
+#define EFA_AV_ARRAY_MAX_IDX_CEILING 1000000000
+/* max_idx applied when the caller passes 0. */
+#define EFA_AV_ARRAY_DEFAULT_MAX_IDX \
+	(EFA_AV_ARRAY_FAST_CUTOFF * EFA_AV_ARRAY_CHUNK_SIZE - 1)
+
+/*
+ * A pointer array indexed by an unsigned int in [0, max_idx] for endpoint peer
+ * lookup by fi_addr. Each slot holds a caller-owned pointer or NULL.
+ *
+ * Indexes below EFA_AV_ARRAY_FAST_CUTOFF live in the embedded fast array and are
+ * reached by direct indexing. Higher indexes live in chunks reached through a
+ * chunk table that is sized once at creation and never reallocated; chunks are
+ * allocated on first use and are neither freed nor moved before destroy.
+ *
+ * Note that while this struct is thread-safe, it is not safe for
+ * for concurrent writes and reads, only concurrent reads.
+ */
+struct efa_av_array {
+	void **chunk_table;
+	size_t chunk_table_len;
+	unsigned max_idx;
+	void *fast[EFA_AV_ARRAY_FAST_CUTOFF];
+};
+
+struct efa_av_array_attr {
+	/* Largest valid index; 0 selects EFA_AV_ARRAY_DEFAULT_MAX_IDX. */
+	unsigned max_idx;
+};
+
+/*
+ * Allocate and initialize an array. On success returns FI_SUCCESS and sets
+ * *arr; on failure returns a negative libfabric error and sets *arr to NULL.
+ * index arguments to at and insert must be in [0, max_idx].
+ */
+int efa_av_array_init(struct efa_av_array **arr);
+int efa_av_array_init_attr(struct efa_av_array **arr,
+			   const struct efa_av_array_attr *attr);
+void efa_av_array_destroy(struct efa_av_array *arr);
+
+int efa_av_array_insert(struct efa_av_array *arr, unsigned index, void *entry);
+
+/* Calls fn for each non-NULL entry, stopping early if fn returns non-zero. */
+void efa_av_array_iter(struct efa_av_array *arr, void *context,
+		       int (*fn)(struct efa_av_array *arr, void *entry,
+				 void *context));
+
+/*
+ * Returns the pointer stored at index, or NULL if the index is out of range or
+ * holds no entry.
+ */
+static inline void *efa_av_array_at(const struct efa_av_array *arr, unsigned index)
+{
+	void **table;
+	void *chunk;
+	void *entry;
+	size_t rel;
+
+	/* Single read memory barrier. Since this code is thread safe, but
+	 * non-concurrent, we just need to make sure that we don't have
+	 * stale, cached reads from before the last insert() call was made.
+	 * This can be accomplished with a single rmb here.
+	 */
+	ofi_rmb();
+
+	if (index > arr->max_idx)
+		return NULL;
+
+	if (index < EFA_AV_ARRAY_FAST_CUTOFF) {
+		entry = arr->fast[index];
+	} else {
+		table = arr->chunk_table;
+		if (!table)
+			return NULL;
+
+		rel = (size_t) index - EFA_AV_ARRAY_FAST_CUTOFF;
+		chunk = table[rel / EFA_AV_ARRAY_CHUNK_SIZE];
+		if (!chunk)
+			return NULL;
+
+		entry = ((void **) chunk)[rel % EFA_AV_ARRAY_CHUNK_SIZE];
+	}
+
+	return entry;
+}
+
+#endif /* EFA_AV_ARRAY_H */

--- a/prov/efa/test/gtest/efa_gtest_av_array.cc
+++ b/prov/efa/test/gtest/efa_gtest_av_array.cc
@@ -1,0 +1,232 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_av_array_utils.h"
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <rdma/fi_errno.h>
+
+using testing::Test;
+
+/* Distinct non-NULL pointer values used only as opaque entries (never read). */
+static void *entry_ptr(int k)
+{
+	return reinterpret_cast<void *>(static_cast<uintptr_t>(0x1000 + k * 0x40));
+}
+
+class EfaAvArrayTest : public Test
+{
+	protected:
+	struct efa_av_array *arr = nullptr;
+
+	void SetUp() override
+	{
+		arr = efa_test_av_array_create();
+		ASSERT_NE(arr, nullptr);
+	}
+
+	void TearDown() override
+	{
+		if (arr)
+			efa_test_av_array_destroy(arr);
+	}
+
+	int cutoff() { return efa_test_av_array_fast_cutoff; }
+	int chunk() { return efa_test_av_array_chunk_size; }
+};
+
+/* A fresh array is empty and has not allocated its chunk table. */
+TEST_F(EfaAvArrayTest, fresh_array_is_empty_and_has_no_chunk_table)
+{
+	EXPECT_EQ(efa_test_av_array_at(arr, 0), nullptr);
+	EXPECT_EQ(efa_test_av_array_has_chunk_table(arr), 0);
+}
+
+/* Insert and read back an entry in the fast region. */
+TEST_F(EfaAvArrayTest, insert_and_read_fast)
+{
+	EXPECT_EQ(efa_test_av_array_insert(arr, 5, entry_ptr(5)), 0);
+	EXPECT_EQ(efa_test_av_array_at(arr, 5), entry_ptr(5));
+	EXPECT_EQ(efa_test_av_array_at(arr, 6), nullptr);
+}
+
+/* An insert within the fast region does not allocate the chunk table. */
+TEST_F(EfaAvArrayTest, fast_insert_allocates_no_chunk_table)
+{
+	EXPECT_EQ(efa_test_av_array_insert(arr, cutoff() - 1, entry_ptr(1)), 0);
+	EXPECT_EQ(efa_test_av_array_has_chunk_table(arr), 0);
+	EXPECT_EQ(efa_test_av_array_at(arr, cutoff() - 1), entry_ptr(1));
+}
+
+/* The first index at the cutoff allocates the chunk table and reads back. */
+TEST_F(EfaAvArrayTest, chunk_insert_allocates_chunk_table)
+{
+	EXPECT_EQ(efa_test_av_array_insert(arr, cutoff(), entry_ptr(2)), 0);
+	EXPECT_EQ(efa_test_av_array_has_chunk_table(arr), 1);
+	EXPECT_EQ(efa_test_av_array_at(arr, cutoff()), entry_ptr(2));
+}
+
+/* Fast-region and chunk-region entries do not affect one another. */
+TEST_F(EfaAvArrayTest, fast_and_chunk_regions_isolated)
+{
+	EXPECT_EQ(efa_test_av_array_insert(arr, 5, entry_ptr(1)), 0);
+	EXPECT_EQ(efa_test_av_array_at(arr, cutoff()), nullptr);
+	EXPECT_EQ(efa_test_av_array_has_chunk_table(arr), 0);
+	EXPECT_EQ(efa_test_av_array_insert(arr, cutoff(), entry_ptr(2)), 0);
+	EXPECT_EQ(efa_test_av_array_at(arr, 5), entry_ptr(1));
+}
+
+/* cutoff-1 stays in the fast region; cutoff is the first chunk-region index. */
+TEST_F(EfaAvArrayTest, fast_chunk_boundary)
+{
+	EXPECT_EQ(efa_test_av_array_insert(arr, cutoff() - 1, entry_ptr(1)), 0);
+	EXPECT_EQ(efa_test_av_array_has_chunk_table(arr), 0);
+	EXPECT_EQ(efa_test_av_array_insert(arr, cutoff(), entry_ptr(2)), 0);
+	EXPECT_EQ(efa_test_av_array_has_chunk_table(arr), 1);
+	EXPECT_EQ(efa_test_av_array_at(arr, cutoff() - 1), entry_ptr(1));
+	EXPECT_EQ(efa_test_av_array_at(arr, cutoff()), entry_ptr(2));
+}
+
+/* A chunk-region lookup before the chunk table exists returns NULL and does not allocate. */
+TEST_F(EfaAvArrayTest, chunk_lookup_before_chunk_table_is_null)
+{
+	EXPECT_EQ(efa_test_av_array_at(arr, cutoff() + 100), nullptr);
+	EXPECT_EQ(efa_test_av_array_has_chunk_table(arr), 0);
+}
+
+/* With the chunk table allocated, an index in an unallocated chunk still returns NULL. */
+TEST_F(EfaAvArrayTest, unallocated_chunk_returns_null)
+{
+	EXPECT_EQ(efa_test_av_array_insert(arr, cutoff(), entry_ptr(2)), 0);
+	EXPECT_EQ(efa_test_av_array_has_chunk_table(arr), 1);
+	EXPECT_EQ(efa_test_av_array_at(arr, cutoff() + 3 * chunk()), nullptr);
+	/* The lookup did not create an entry. */
+	EXPECT_EQ(efa_test_av_array_count(arr), 1);
+}
+
+/* Entries in different chunks are independent; an untouched chunk is NULL. */
+TEST_F(EfaAvArrayTest, distinct_chunks_independent)
+{
+	EXPECT_EQ(efa_test_av_array_insert(arr, cutoff(), entry_ptr(1)), 0);
+	EXPECT_EQ(efa_test_av_array_insert(arr, cutoff() + chunk(), entry_ptr(2)), 0);
+	EXPECT_EQ(efa_test_av_array_at(arr, cutoff()), entry_ptr(1));
+	EXPECT_EQ(efa_test_av_array_at(arr, cutoff() + chunk()), entry_ptr(2));
+	EXPECT_EQ(efa_test_av_array_at(arr, cutoff() + 2 * chunk()), nullptr);
+}
+
+/* A second insert at an index overwrites the stored pointer. */
+TEST_F(EfaAvArrayTest, overwrite_slot)
+{
+	EXPECT_EQ(efa_test_av_array_insert(arr, 5, entry_ptr(1)), 0);
+	EXPECT_EQ(efa_test_av_array_insert(arr, 5, entry_ptr(2)), 0);
+	EXPECT_EQ(efa_test_av_array_at(arr, 5), entry_ptr(2));
+}
+
+/* Inserting NULL clears a slot. */
+TEST_F(EfaAvArrayTest, insert_null_clears_slot)
+{
+	EXPECT_EQ(efa_test_av_array_insert(arr, 5, entry_ptr(1)), 0);
+	EXPECT_EQ(efa_test_av_array_insert(arr, 5, nullptr), 0);
+	EXPECT_EQ(efa_test_av_array_at(arr, 5), nullptr);
+}
+
+/* Out-of-range indices are rejected by both at and insert. */
+TEST_F(EfaAvArrayTest, out_of_range_is_rejected)
+{
+	struct efa_av_array *a = efa_test_av_array_create_max(100);
+	ASSERT_NE(a, nullptr);
+
+	EXPECT_EQ(efa_test_av_array_at(a, 101), nullptr);
+	EXPECT_EQ(efa_test_av_array_insert(a, 101, entry_ptr(1)), -FI_EINVAL);
+
+	/* The largest valid index is reachable. */
+	EXPECT_EQ(efa_test_av_array_insert(a, 100, entry_ptr(9)), 0);
+	EXPECT_EQ(efa_test_av_array_at(a, 100), entry_ptr(9));
+
+	efa_test_av_array_destroy(a);
+}
+
+/* A max_idx below the fast cutoff never allocates a chunk table. */
+TEST_F(EfaAvArrayTest, small_max_idx_allocates_no_chunk_table)
+{
+	struct efa_av_array *a = efa_test_av_array_create_max(100);
+	ASSERT_NE(a, nullptr);
+
+	EXPECT_EQ(efa_test_av_array_insert(a, 50, entry_ptr(1)), 0);
+	EXPECT_EQ(efa_test_av_array_at(a, 50), entry_ptr(1));
+	EXPECT_EQ(efa_test_av_array_has_chunk_table(a), 0);
+
+	efa_test_av_array_destroy(a);
+}
+
+/* A max_idx above the cap is rejected; the cap itself is accepted. */
+TEST_F(EfaAvArrayTest, bad_max_idx_is_rejected)
+{
+	EXPECT_EQ(efa_test_av_array_create_max(efa_test_av_array_max_idx_ceiling + 1), nullptr);
+
+	struct efa_av_array *a = efa_test_av_array_create_max(efa_test_av_array_max_idx_ceiling);
+	ASSERT_NE(a, nullptr);
+	efa_test_av_array_destroy(a);
+}
+
+/* max_idx of zero selects the default: the default max index is reachable and
+ * one past it is rejected. */
+TEST_F(EfaAvArrayTest, zero_max_idx_uses_default)
+{
+	struct efa_av_array *a = efa_test_av_array_create_max(0);
+	ASSERT_NE(a, nullptr);
+
+	int m = efa_test_av_array_default_max_idx;
+	EXPECT_EQ(efa_test_av_array_insert(a, m, entry_ptr(1)), 0);
+	EXPECT_EQ(efa_test_av_array_at(a, m), entry_ptr(1));
+	EXPECT_EQ(efa_test_av_array_at(a, m + 1), nullptr);
+	EXPECT_EQ(efa_test_av_array_insert(a, m + 1, entry_ptr(1)), -FI_EINVAL);
+
+	efa_test_av_array_destroy(a);
+}
+
+/* The largest index at the cap is reachable and reads back. */
+TEST_F(EfaAvArrayTest, max_idx_at_cap_reachable)
+{
+	struct efa_av_array *a = efa_test_av_array_create_max(efa_test_av_array_max_idx_ceiling);
+	ASSERT_NE(a, nullptr);
+
+	int m = efa_test_av_array_max_idx_ceiling;
+	EXPECT_EQ(efa_test_av_array_insert(a, m, entry_ptr(7)), 0);
+	EXPECT_EQ(efa_test_av_array_at(a, m), entry_ptr(7));
+	EXPECT_EQ(efa_test_av_array_has_chunk_table(a), 1);
+
+	efa_test_av_array_destroy(a);
+}
+
+/* iter visits every non-NULL entry across the fast and chunk regions. */
+TEST_F(EfaAvArrayTest, iter_counts_non_null_entries)
+{
+	EXPECT_EQ(efa_test_av_array_insert(arr, 1, entry_ptr(1)), 0);
+	EXPECT_EQ(efa_test_av_array_insert(arr, cutoff() + 5, entry_ptr(2)), 0);
+	EXPECT_EQ(efa_test_av_array_insert(arr, cutoff() + chunk() + 9, entry_ptr(3)), 0);
+	EXPECT_EQ(efa_test_av_array_count(arr), 3);
+}
+
+/* iter skips slots that were cleared back to NULL. */
+TEST_F(EfaAvArrayTest, iter_skips_cleared_slots)
+{
+	EXPECT_EQ(efa_test_av_array_insert(arr, 5, entry_ptr(1)), 0);
+	EXPECT_EQ(efa_test_av_array_insert(arr, 5, nullptr), 0);
+	EXPECT_EQ(efa_test_av_array_count(arr), 0);
+}
+
+/* iter stops early when the callback returns non-zero, across regions. */
+TEST_F(EfaAvArrayTest, iter_stops_early)
+{
+	EXPECT_EQ(efa_test_av_array_insert(arr, 1, entry_ptr(8)), 0);
+	EXPECT_EQ(efa_test_av_array_insert(arr, cutoff() + 5, entry_ptr(8)), 0);
+	EXPECT_EQ(efa_test_av_array_iter_first_hit(arr, entry_ptr(8)), 1);
+}
+
+/* Destroying a NULL array is a no-op. */
+TEST_F(EfaAvArrayTest, destroy_null_is_safe)
+{
+	efa_test_av_array_destroy(nullptr);
+	SUCCEED();
+}

--- a/prov/efa/test/gtest/efa_gtest_av_array_utils.c
+++ b/prov/efa/test/gtest/efa_gtest_av_array_utils.c
@@ -1,0 +1,100 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_av_array_utils.h"
+#include "efa_av_array.h"
+
+const int efa_test_av_array_fast_cutoff = EFA_AV_ARRAY_FAST_CUTOFF;
+const int efa_test_av_array_chunk_size = EFA_AV_ARRAY_CHUNK_SIZE;
+const int efa_test_av_array_max_idx_ceiling = EFA_AV_ARRAY_MAX_IDX_CEILING;
+const int efa_test_av_array_default_max_idx = EFA_AV_ARRAY_DEFAULT_MAX_IDX;
+
+struct efa_av_array *efa_test_av_array_create(void)
+{
+	struct efa_av_array *arr;
+
+	if (efa_av_array_init(&arr))
+		return NULL;
+	return arr;
+}
+
+struct efa_av_array *efa_test_av_array_create_max(unsigned max_idx)
+{
+	struct efa_av_array *arr;
+	struct efa_av_array_attr attr = {0};
+
+	attr.max_idx = max_idx;
+	if (efa_av_array_init_attr(&arr, &attr))
+		return NULL;
+	return arr;
+}
+
+void efa_test_av_array_destroy(struct efa_av_array *arr)
+{
+	efa_av_array_destroy(arr);
+}
+
+int efa_test_av_array_insert(struct efa_av_array *arr, unsigned index,
+			     void *entry)
+{
+	return efa_av_array_insert(arr, index, entry);
+}
+
+void *efa_test_av_array_at(struct efa_av_array *arr, unsigned index)
+{
+	return efa_av_array_at(arr, index);
+}
+
+int efa_test_av_array_has_chunk_table(struct efa_av_array *arr)
+{
+	return arr->chunk_table != NULL;
+}
+
+struct efa_test_av_array_count_ctx {
+	int count;
+};
+
+static int efa_test_av_array_count_cb(struct efa_av_array *arr, void *entry,
+				      void *context)
+{
+	struct efa_test_av_array_count_ctx *ctx = context;
+
+	(void) arr;
+	(void) entry;
+	ctx->count++;
+	return 0;
+}
+
+int efa_test_av_array_count(struct efa_av_array *arr)
+{
+	struct efa_test_av_array_count_ctx ctx = { 0 };
+
+	efa_av_array_iter(arr, &ctx, efa_test_av_array_count_cb);
+	return ctx.count;
+}
+
+struct efa_test_av_array_hit_ctx {
+	void *target;
+	int hits;
+};
+
+static int efa_test_av_array_hit_cb(struct efa_av_array *arr, void *entry,
+				    void *context)
+{
+	struct efa_test_av_array_hit_ctx *ctx = context;
+
+	(void) arr;
+	if (entry == ctx->target) {
+		ctx->hits++;
+		return 1;
+	}
+	return 0;
+}
+
+int efa_test_av_array_iter_first_hit(struct efa_av_array *arr, void *target)
+{
+	struct efa_test_av_array_hit_ctx ctx = { target, 0 };
+
+	efa_av_array_iter(arr, &ctx, efa_test_av_array_hit_cb);
+	return ctx.hits;
+}

--- a/prov/efa/test/gtest/efa_gtest_av_array_utils.h
+++ b/prov/efa/test/gtest/efa_gtest_av_array_utils.h
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+/* C-linkage wrappers exposing efa_av_array operations to C++ callers. */
+
+#ifndef EFA_GTEST_AV_ARRAY_UTILS_H
+#define EFA_GTEST_AV_ARRAY_UTILS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct efa_av_array;
+
+/* Create with the default max_idx; NULL on failure. */
+struct efa_av_array *efa_test_av_array_create(void);
+/* Create with a custom max_idx; NULL if the value is rejected. */
+struct efa_av_array *efa_test_av_array_create_max(unsigned max_idx);
+void efa_test_av_array_destroy(struct efa_av_array *arr);
+
+int efa_test_av_array_insert(struct efa_av_array *arr, unsigned index,
+			     void *entry);
+void *efa_test_av_array_at(struct efa_av_array *arr, unsigned index);
+
+/* Non-zero once the array has allocated its chunk table. */
+int efa_test_av_array_has_chunk_table(struct efa_av_array *arr);
+/* Number of non-NULL entries, via iteration. */
+int efa_test_av_array_count(struct efa_av_array *arr);
+/* Iterate, stopping at the first entry equal to target; 1 if found, else 0. */
+int efa_test_av_array_iter_first_hit(struct efa_av_array *arr, void *target);
+
+extern const int efa_test_av_array_fast_cutoff;
+extern const int efa_test_av_array_chunk_size;
+extern const int efa_test_av_array_max_idx_ceiling;
+extern const int efa_test_av_array_default_max_idx;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFA_GTEST_AV_ARRAY_UTILS_H */


### PR DESCRIPTION
    prov/efa: add efa_av_array, a lock-free fi_addr-indexed pointer array

    Add efa_av_array: a pointer array indexed by an int in [0, max_idx] for
    endpoint peer lookup by fi_addr. Each slot holds a caller-owned pointer or
    NULL. Indexes below EFA_AV_ARRAY_FAST_CUTOFF are stored in an embedded fast
    array reached by direct indexing; higher indexes are stored in chunks reached
    through a chunk table that is sized once at creation and never reallocated,
    with chunks allocated on first use and neither freed nor moved before destroy.

    ofi_mb.h gains an include guard and an MSVC ofi_wmb; efa_av_array.c is added to
    the Windows project.

    Also adds unit testing