### PR TITLE
prov/efa: improve gtest malloc failure injection

### DIFF
--- a/prov/efa/test/gtest/AGENTS.md
+++ b/prov/efa/test/gtest/AGENTS.md
@@ -109,6 +109,13 @@ contract or copy a pattern from a nearby test when the docs can settle it.
   `efa_unit_test_data_path_ops.c`. `EFA_UNIT_TEST` is derived from *either* test
   suite (`--enable-efa-gtest` OR `--enable-efa-unit-test`), so `--enable-efa-gtest`
   alone makes them `--wrap`-able — the gtest suite does **not** need cmocka.
+- **Inject OOM with `efa_test_fail_mallocs(ordinals)`**, not a `MockEfa` row.
+  It arms 0-based `malloc` ordinals to return NULL (`{0}` = next malloc, `{1,3}` =
+  2nd and 4th; each failure is one-shot); all others hit `__real_malloc`. Counting
+  restarts at each call. It lives outside `MockEfa` because gmock allocates while
+  matching, which would recurse. No teardown call needed — a listener in
+  `efa_gtest_main.cc` resets it after every test. See
+  `EfaAhTest.alloc_malloc_failure_releases_domain_lock`.
 
 ### C/C++ bridge
 

--- a/prov/efa/test/gtest/README.md
+++ b/prov/efa/test/gtest/README.md
@@ -82,3 +82,16 @@ Declare the mock member as `testing::StrictMock<MockEfa>`, not bare `MockEfa`. A
 Strictness is a separate concern from the *return value* of an expected call: `StrictMock` only governs whether a call was expected, never what it returns. A `StrictMock` whose expectation omits an action still returns the gMock default (0/false/NULL/default-constructed). So always give every `EFA_EXPECT_CALL` an explicit action (`WillOnce`/`WillRepeatedly`/`Times(0)`) rather than relying on that implicit default.
 
 Because arming is opt-in, a wrapped call made during teardown falls through to `__real_<fn>` **unless the test armed that function** — so you generally do *not* need to expect the endpoint's teardown calls (e.g. the RDM CQ drain's `efa_ibv_cq_start_poll`). The exception is a function the test *does* arm that also fires during teardown: e.g. a test that arms `ibv_destroy_ah` for a peer AH must clear the mock (`MockEfa::set(nullptr)`) *before* `efa_test_resource_destruct`, or the real destroy of `self_ah` will route into the mock as an unexpected call. See `EfaConnTest`.
+
+### Injecting malloc failures
+
+To exercise out-of-memory error paths, call `efa_test_fail_mallocs(ordinals)` (declared in `efa_gtest_common_mocks.h`). It arms a set of 0-based `malloc` ordinals to fail: `{0}` fails the very next `malloc`, `{1, 3}` fails the 2nd and 4th, and so on. Every other allocation runs for real. Ordering and duplicates in the vector don't matter, and ordinals must be less than `EFA_TEST_MALLOC_FAIL_MAX`.
+
+```c
+efa_test_fail_mallocs({0});		/* fail the first malloc on the path */
+res = efa_func(args);
+```
+
+This deliberately lives *outside* `MockEfa` rather than being an `EFA_MOCK_FUNCTIONS` row. gMock itself allocates while matching expectations, so routing `malloc` through the mock would recurse. Instead `__wrap_malloc` consults a standalone process-global bitset and counter: it fails on the armed ordinals (each failure is one-shot — the bit is cleared as it fires so a repeated allocation size isn't re-failed) and forwards everything else to `__real_malloc`.
+
+Each call to `efa_test_fail_mallocs` resets the counter, and the counter is automatically cleared at the end of each test, if any is set.

--- a/prov/efa/test/gtest/efa_gtest_main.cc
+++ b/prov/efa/test/gtest/efa_gtest_main.cc
@@ -3,6 +3,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include "efa_gtest_common_mocks.h"
 
 // Harmless suppression: persistent allocation from glibc outside of EFA provider
 extern "C" const char *__lsan_default_suppressions(void)
@@ -10,8 +11,19 @@ extern "C" const char *__lsan_default_suppressions(void)
 	return "leak:_dlerror_run\n";
 }
 
+/* Automatically reset malloc failure injections, if any */
+class MallocFailReset : public testing::EmptyTestEventListener
+{
+	void OnTestEnd(const testing::TestInfo &) override
+	{
+		efa_test_fail_mallocs({});
+	}
+};
+
 int main(int argc, char **argv)
 {
 	::testing::InitGoogleMock(&argc, argv);
+	testing::UnitTest::GetInstance()->listeners().Append(
+		new MallocFailReset);
 	return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This commit adds a mechanism to automatically clear any malloc failure injections set in each test. Also adds documentation to README and AGENT.md for the malloc failure injection mechanism.