### PR TITLE
prov/efa: Honor tclass set in hints before fi_getinfo

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -300,7 +300,9 @@ nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
 	prov/efa/test/gtest/efa_gtest_rdm_peer.cc \
 	prov/efa/test/gtest/efa_gtest_msg.cc \
 	prov/efa/test/gtest/efa_gtest_rma.cc \
-	prov/efa/test/gtest/efa_gtest_hmem.cc
+	prov/efa/test/gtest/efa_gtest_hmem.cc \
+	prov/efa/test/gtest/efa_gtest_tclass_utils.c \
+	prov/efa/test/gtest/efa_gtest_tclass.cc
 
 prov_efa_test_gtest_efa_gtest_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
@@ -337,6 +339,7 @@ prov_efa_test_gtest_efa_gtest_LDFLAGS = \
 	-Wl,--wrap=efa_qp_post_send \
 	-Wl,--wrap=efa_qp_post_read \
 	-Wl,--wrap=efa_qp_post_write \
+	-Wl,--wrap=efadv_create_qp_ex \
 	-Wl,--wrap=malloc
 
 prov_efa_test_gtest_efa_gtest_LIBS = $(linkback)

--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -412,12 +412,16 @@ static int efa_base_ep_create_qp(struct efa_base_ep *base_ep,
 	OFI_TSA_REQUIRES(efa_qp_table_lock_sym)
 {
 	int ret;
-	struct ibv_qp_init_attr_ex attr_ex = { 0 };
+	struct ibv_qp_init_attr_ex attr_ex = {0};
 	bool use_unsolicited_write_recv = true;
+	uint32_t tclass;
+	struct efa_domain *domain = base_ep->domain;
 
-	efa_base_ep_construct_ibv_qp_init_attr_ex(base_ep, &attr_ex, tx_cq->ibv_cq_ex, rx_cq->ibv_cq_ex);
+	efa_base_ep_construct_ibv_qp_init_attr_ex(
+		base_ep, &attr_ex, tx_cq->ibv_cq_ex, rx_cq->ibv_cq_ex);
 
-	assert(tx_cq->unsolicited_write_recv_enabled == rx_cq->unsolicited_write_recv_enabled);
+	assert(tx_cq->unsolicited_write_recv_enabled ==
+	       rx_cq->unsolicited_write_recv_enabled);
 
 	/*
 	 * Unsolicited write recv requires hardware support
@@ -427,19 +431,57 @@ static int efa_base_ep_create_qp(struct efa_base_ep *base_ep,
 	 * the user intends to post rx buffers for cq data (FI_RX_CQ_DATA); the
 	 * efa-rdm full protocol does not set FI_RX_CQ_DATA in its mode.
 	 */
-	use_unsolicited_write_recv =
-		tx_cq->unsolicited_write_recv_enabled &&
-		base_ep->use_unsolicited_write_recv &&
-		!(base_ep->info->mode & FI_RX_CQ_DATA);
-	EFA_INFO(FI_LOG_EP_CTRL, "creating QP with unsolicited write recv status: %d\n", use_unsolicited_write_recv);
-	ret = efa_qp_create(&base_ep->qp, &attr_ex, base_ep->info->tx_attr->tclass,
+	use_unsolicited_write_recv = tx_cq->unsolicited_write_recv_enabled &&
+				     base_ep->use_unsolicited_write_recv &&
+				     !(base_ep->info->mode & FI_RX_CQ_DATA);
+	EFA_INFO(FI_LOG_EP_CTRL,
+		 "creating QP with unsolicited write recv status: %d\n",
+		 use_unsolicited_write_recv);
+
+	tclass = FI_TC_UNSPEC;
+
+	/* The domain level tclass applies to all endpoints in the domain.
+	 * The endpoint level tclass can override the domain level tclass.
+	 *
+	 * A QP is created with FI_TC_LOW_LATENCY if either
+	 * 1. The endpoint level tclass is set to FI_TC_LOW_LATENCY
+	 * 2. The endpoint level tclass is not set/set to FI_TC_UNSPEC and the
+	 * domain level tclass is set to FI_TC_LOW_LATENCY
+	 */
+	switch (base_ep->info->tx_attr->tclass) {
+	case FI_TC_LOW_LATENCY:
+		EFA_INFO(FI_LOG_EP_CTRL,
+			 "base_ep->info->tx_attr->tclass is set to "
+			 "FI_TC_LOW_LATENCY. Creating QP with "
+			 "FI_TC_LOW_LATENCY\n");
+		tclass = FI_TC_LOW_LATENCY;
+		break;
+	case FI_TC_UNSPEC:
+		if (domain->info->domain_attr->tclass == FI_TC_LOW_LATENCY) {
+			EFA_INFO(FI_LOG_EP_CTRL,
+				 "base_ep->info->tx_attr->tclass is set to "
+				 "FI_TC_UNSPEC but "
+				 "domain->info->domain_attr->tclass is set to "
+				 "FI_TC_LOW_LATENCY. Creating QP with "
+				 "FI_TC_LOW_LATENCY\n");
+			tclass = FI_TC_LOW_LATENCY;
+		}
+		break;
+	default:
+		EFA_INFO(FI_LOG_EP_CTRL,
+			 "Creating QP with default FI_TC_UNSPEC\n");
+		break;
+	}
+
+	ret = efa_qp_create(&base_ep->qp, &attr_ex, tclass,
 			    use_unsolicited_write_recv);
 	if (ret)
 		return ret;
 
 #if HAVE_EFA_DATA_PATH_DIRECT
 	/* Only enable direct QP when direct CQ is enabled */
-	assert(tx_cq->data_path_direct_enabled == rx_cq->data_path_direct_enabled);
+	assert(tx_cq->data_path_direct_enabled ==
+	       rx_cq->data_path_direct_enabled);
 	if (tx_cq->data_path_direct_enabled) {
 		ret = efa_data_path_direct_qp_initialize(base_ep->qp);
 		if (ret) {

--- a/prov/efa/src/efa_domain_util.c
+++ b/prov/efa/src/efa_domain_util.c
@@ -112,6 +112,9 @@ int efa_domain_init_base(struct efa_domain *efa_domain,
 	efa_domain->info->domain_attr->max_cntr_value = info->domain_attr->max_cntr_value;
 	efa_domain->info->domain_attr->max_err_cntr_value = info->domain_attr->max_err_cntr_value;
 
+	/* Also store the tclass which is read during fi_endpoint */
+	efa_domain->info->domain_attr->tclass = info->domain_attr->tclass;
+
 	if (efa_env.track_mr)
 		dlist_init(&efa_domain->base_ep_list);
 

--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -328,6 +328,78 @@ void efa_user_info_set_max_cntr_value(int version, struct fi_info *info,
 }
 
 /**
+ * @brief Check whether the EFA provider can honor
+ * a given traffic class
+ *
+ * @param tclass traffic class to check
+ * @return true if EFA supports tclass, false otherwise
+ */
+static bool efa_tclass_supported(uint32_t tclass)
+{
+	switch (tclass) {
+	case FI_TC_UNSPEC:
+	case FI_TC_BEST_EFFORT:
+		return true;
+	case FI_TC_LOW_LATENCY:
+#if HAVE_EFADV_SL
+		return true;
+#else
+		return false;
+#endif
+	default:
+		return false;
+	}
+}
+
+/**
+ * @brief validate and propagate the traffic class hints into info
+ *
+ * fi_info carries two traffic class fields: domain_attr->tclass is the
+ * default for all endpoints opened on the domain, and tx_attr->tclass is
+ * the per-endpoint override. A tx_attr->tclass of FI_TC_UNSPEC means
+ * "inherit the domain default", so the two are propagated independently
+ * and the distinction is preserved for fi_endpoint() to resolve.
+ *
+ * @param	info[in,out]	info to be updated
+ * @param	hints[in]	user provided hints
+ * @return	0 on success
+ * 		-FI_ENODATA if EFA cannot honor a requested traffic class
+ */
+static
+int efa_user_info_alter_tclass(struct fi_info *info, const struct fi_info *hints)
+{
+	uint32_t domain_tclass, tx_tclass;
+
+	domain_tclass = (hints && hints->domain_attr) ?
+			hints->domain_attr->tclass : FI_TC_UNSPEC;
+	tx_tclass = (hints && hints->tx_attr) ?
+		    hints->tx_attr->tclass : FI_TC_UNSPEC;
+
+	if (!efa_tclass_supported(domain_tclass)) {
+		EFA_INFO(FI_LOG_CORE,
+			 "Unsupported domain_attr->tclass: 0x%x\n",
+			 domain_tclass);
+
+		domain_tclass = FI_TC_UNSPEC;
+	}
+
+	if (!efa_tclass_supported(tx_tclass)) {
+		EFA_INFO(FI_LOG_CORE,
+			 "Unsupported tx_attr->tclass: 0x%x\n", tx_tclass);
+
+		tx_tclass = FI_TC_UNSPEC;
+	}
+
+	if (domain_tclass != FI_TC_UNSPEC)
+		info->domain_attr->tclass = domain_tclass;
+
+	if (tx_tclass != FI_TC_UNSPEC)
+		info->tx_attr->tclass = tx_tclass;
+
+	return 0;
+}
+
+/**
  * @brief update RDM info to match user hints
  *
  * the input info is a duplicate of prov info, which matches
@@ -771,6 +843,12 @@ int efa_get_user_info(uint32_t version, const char *node,
 				fi_freeinfo(dupinfo);
 				continue;
 			}
+		}
+
+		ret = efa_user_info_alter_tclass(dupinfo, hints);
+		if (ret) {
+			fi_freeinfo(dupinfo);
+			continue;
 		}
 
 		ofi_alter_info(dupinfo, hints, version);

--- a/prov/efa/test/gtest/efa_gtest_common_mocks.h
+++ b/prov/efa/test/gtest/efa_gtest_common_mocks.h
@@ -93,7 +93,11 @@ struct efa_ah;
 	   uintptr_t wr_id, uint64_t data, uint64_t flags, struct efa_ah *ah,  \
 	   uint32_t qpn, uint32_t qkey),                                       \
 	  (qp, sge_list, sge_count, inline_data_list, use_inline, remote_key,  \
-	   remote_addr, wr_id, data, flags, ah, qpn, qkey))
+	   remote_addr, wr_id, data, flags, ah, qpn, qkey))                    \
+	X(struct ibv_qp *, efadv_create_qp_ex,                                 \
+	  (struct ibv_context * ibvctx, struct ibv_qp_init_attr_ex * attr_ex,  \
+	   struct efadv_qp_init_attr * efa_attr, uint32_t inlen),              \
+	  (ibvctx, attr_ex, efa_attr, inlen))
 
 /* --- Generator macros --- */
 

--- a/prov/efa/test/gtest/efa_gtest_common_resource.cc
+++ b/prov/efa/test/gtest/efa_gtest_common_resource.cc
@@ -30,6 +30,18 @@ void efa_test_resource_construct(struct efa_resource *resource,
 				 struct fi_info *hints)
 {
 	int ret;
+
+	ASSERT_NO_FATAL_FAILURE(
+		efa_test_resource_construct_no_enable(resource, hints));
+
+	ret = fi_enable(resource->ep);
+	ASSERT_EQ(ret, 0) << "fi_enable failed: " << fi_strerror(-ret);
+}
+
+void efa_test_resource_construct_no_enable(struct efa_resource *resource,
+					   struct fi_info *hints)
+{
+	int ret;
 	struct fi_av_attr av_attr = {};
 	struct fi_cq_attr cq_attr = {};
 	struct fi_eq_attr eq_attr = {};
@@ -76,9 +88,6 @@ void efa_test_resource_construct(struct efa_resource *resource,
 	ASSERT_EQ(ret, 0) << "fi_cq_open failed: " << fi_strerror(-ret);
 
 	fi_ep_bind(resource->ep, &resource->cq->fid, FI_SEND | FI_RECV);
-
-	ret = fi_enable(resource->ep);
-	ASSERT_EQ(ret, 0) << "fi_enable failed: " << fi_strerror(-ret);
 }
 
 void efa_test_resource_destruct(struct efa_resource *resource)

--- a/prov/efa/test/gtest/efa_gtest_common_resource.h
+++ b/prov/efa/test/gtest/efa_gtest_common_resource.h
@@ -58,6 +58,15 @@ void efa_test_resource_construct(struct efa_resource *resource,
 				 struct fi_info *hints);
 
 /**
+ * @brief Same as efa_test_resource_construct but stops short of fi_enable(),
+ * so the endpoint's QP has not been created yet. Use this when a test must
+ * install a mock that intercepts QP creation; call fi_enable() from the test
+ * body once the expectations are set.
+ */
+void efa_test_resource_construct_no_enable(struct efa_resource *resource,
+					   struct fi_info *hints);
+
+/**
  * @brief Destroy all OFI resources in the resource struct.
  * Closes resources in correct order. Uses gtest EXPECT macros so that
  * all cleanup is attempted even if one close fails.

--- a/prov/efa/test/gtest/efa_gtest_tclass.cc
+++ b/prov/efa/test/gtest/efa_gtest_tclass.cc
@@ -1,0 +1,352 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa_gtest_common_helpers.h"
+#include "efa_gtest_common_mocks.h"
+#include "efa_gtest_common_resource.h"
+#include "efa_gtest_tclass_utils.h"
+#include <gtest/gtest.h>
+#include <string>
+#include <vector>
+
+using testing::AtLeast;
+using testing::Invoke;
+using testing::StrictMock;
+using testing::Test;
+using testing::TestWithParam;
+using testing::Values;
+
+/* An unsupported label and an unsupported DSCP value, per efa_tclass_supported */
+#define EFA_TEST_TC_UNSUPPORTED	     FI_TC_BULK_DATA
+#define EFA_TEST_TC_UNSUPPORTED_DSCP fi_tc_dscp_set(5)
+
+/*
+ * fi_getinfo() must echo a supported tclass hint back in the info it returns,
+ * and must fall back to FI_TC_UNSPEC for anything EFA cannot honor.
+ */
+class EfaTclassInfoTest : public Test
+{
+	protected:
+	struct fi_info *hints = nullptr;
+	struct fi_info *info = nullptr;
+
+	void TearDown() override
+	{
+		if (info)
+			fi_freeinfo(info);
+		if (hints)
+			fi_freeinfo(hints);
+	}
+
+	/**
+	 * @brief Run fi_getinfo with the given tclass hints.
+	 *
+	 * @param ep_type	endpoint type to request
+	 * @param fabric_name	fabric to request
+	 * @param domain_tclass	hints->domain_attr->tclass
+	 * @param tx_tclass	hints->tx_attr->tclass
+	 */
+	void getinfo(enum fi_ep_type ep_type, const char *fabric_name,
+		     uint32_t domain_tclass, uint32_t tx_tclass)
+	{
+		uint32_t version = !strcmp(fabric_name, EFA_DIRECT_FABRIC_NAME) ?
+					   FI_VERSION(2, 0) :
+					   FI_VERSION(1, 14);
+
+		hints = efa_test_alloc_default_hints(ep_type, fabric_name);
+		ASSERT_NE(hints, nullptr);
+		hints->domain_attr->tclass = domain_tclass;
+		hints->tx_attr->tclass = tx_tclass;
+
+		int ret = fi_getinfo(version, NULL, NULL, 0ULL, hints, &info);
+		ASSERT_EQ(ret, 0) << "fi_getinfo failed: " << fi_strerror(-ret);
+		ASSERT_NE(info, nullptr);
+	}
+};
+
+TEST_F(EfaTclassInfoTest, unset_hint_returns_unspec)
+{
+	ASSERT_NO_FATAL_FAILURE(getinfo(FI_EP_RDM, EFA_FABRIC_NAME,
+					FI_TC_UNSPEC, FI_TC_UNSPEC));
+
+	EXPECT_EQ(info->domain_attr->tclass, (uint32_t) FI_TC_UNSPEC);
+	EXPECT_EQ(info->tx_attr->tclass, (uint32_t) FI_TC_UNSPEC);
+}
+
+TEST_F(EfaTclassInfoTest, low_latency_hint_propagates_to_both_fields)
+{
+	if (!efa_test_have_efadv_sl())
+		GTEST_SKIP() << "build lacks efadv_qp_init_attr::sl, so "
+				"FI_TC_LOW_LATENCY is not a supported tclass";
+
+	ASSERT_NO_FATAL_FAILURE(getinfo(FI_EP_RDM, EFA_FABRIC_NAME,
+					FI_TC_LOW_LATENCY,
+					FI_TC_LOW_LATENCY));
+
+	EXPECT_EQ(info->domain_attr->tclass, (uint32_t) FI_TC_LOW_LATENCY);
+	EXPECT_EQ(info->tx_attr->tclass, (uint32_t) FI_TC_LOW_LATENCY);
+}
+
+/*
+ * The two fields carry independent meanings (domain default vs. per-endpoint
+ * override), so a hint on one must not bleed into the other.
+ */
+TEST_F(EfaTclassInfoTest, domain_and_tx_hints_propagate_independently)
+{
+	if (!efa_test_have_efadv_sl())
+		GTEST_SKIP() << "build lacks efadv_qp_init_attr::sl, so "
+				"FI_TC_LOW_LATENCY is not a supported tclass";
+
+	ASSERT_NO_FATAL_FAILURE(getinfo(FI_EP_RDM, EFA_FABRIC_NAME,
+					FI_TC_LOW_LATENCY, FI_TC_UNSPEC));
+
+	EXPECT_EQ(info->domain_attr->tclass, (uint32_t) FI_TC_LOW_LATENCY);
+	EXPECT_EQ(info->tx_attr->tclass, (uint32_t) FI_TC_UNSPEC);
+}
+
+TEST_F(EfaTclassInfoTest, best_effort_hint_propagates_to_both_fields)
+{
+	ASSERT_NO_FATAL_FAILURE(getinfo(FI_EP_RDM, EFA_FABRIC_NAME,
+					FI_TC_BEST_EFFORT,
+					FI_TC_BEST_EFFORT));
+
+	EXPECT_EQ(info->domain_attr->tclass, (uint32_t) FI_TC_BEST_EFFORT);
+	EXPECT_EQ(info->tx_attr->tclass, (uint32_t) FI_TC_BEST_EFFORT);
+}
+
+TEST_F(EfaTclassInfoTest, unsupported_label_hint_falls_back_to_unspec)
+{
+	ASSERT_NO_FATAL_FAILURE(getinfo(FI_EP_RDM, EFA_FABRIC_NAME,
+					EFA_TEST_TC_UNSUPPORTED,
+					EFA_TEST_TC_UNSUPPORTED));
+
+	EXPECT_EQ(info->domain_attr->tclass, (uint32_t) FI_TC_UNSPEC);
+	EXPECT_EQ(info->tx_attr->tclass, (uint32_t) FI_TC_UNSPEC);
+}
+
+TEST_F(EfaTclassInfoTest, unsupported_dscp_hint_falls_back_to_unspec)
+{
+	ASSERT_NO_FATAL_FAILURE(getinfo(FI_EP_RDM, EFA_FABRIC_NAME,
+					EFA_TEST_TC_UNSUPPORTED_DSCP,
+					EFA_TEST_TC_UNSUPPORTED_DSCP));
+
+	EXPECT_EQ(info->domain_attr->tclass, (uint32_t) FI_TC_UNSPEC);
+	EXPECT_EQ(info->tx_attr->tclass, (uint32_t) FI_TC_UNSPEC);
+}
+
+/* An unsupported hint on one field must not discard a supported hint on the other. */
+TEST_F(EfaTclassInfoTest, unsupported_tx_hint_leaves_domain_hint_intact)
+{
+	if (!efa_test_have_efadv_sl())
+		GTEST_SKIP() << "build lacks efadv_qp_init_attr::sl, so "
+				"FI_TC_LOW_LATENCY is not a supported tclass";
+
+	ASSERT_NO_FATAL_FAILURE(getinfo(FI_EP_RDM, EFA_FABRIC_NAME,
+					FI_TC_LOW_LATENCY,
+					EFA_TEST_TC_UNSUPPORTED));
+
+	EXPECT_EQ(info->domain_attr->tclass, (uint32_t) FI_TC_LOW_LATENCY);
+	EXPECT_EQ(info->tx_attr->tclass, (uint32_t) FI_TC_UNSPEC);
+}
+
+/* dgram has no alter function of its own, so it exercises the shared hook. */
+TEST_F(EfaTclassInfoTest, dgram_hint_propagates)
+{
+	if (!efa_test_have_efadv_sl())
+		GTEST_SKIP() << "build lacks efadv_qp_init_attr::sl, so "
+				"FI_TC_LOW_LATENCY is not a supported tclass";
+
+	ASSERT_NO_FATAL_FAILURE(getinfo(FI_EP_DGRAM, EFA_FABRIC_NAME,
+					FI_TC_LOW_LATENCY,
+					FI_TC_LOW_LATENCY));
+
+	EXPECT_EQ(info->domain_attr->tclass, (uint32_t) FI_TC_LOW_LATENCY);
+	EXPECT_EQ(info->tx_attr->tclass, (uint32_t) FI_TC_LOW_LATENCY);
+}
+
+TEST_F(EfaTclassInfoTest, efa_direct_hint_propagates)
+{
+	if (!efa_test_have_efadv_sl())
+		GTEST_SKIP() << "build lacks efadv_qp_init_attr::sl, so "
+				"FI_TC_LOW_LATENCY is not a supported tclass";
+
+	ASSERT_NO_FATAL_FAILURE(getinfo(FI_EP_RDM, EFA_DIRECT_FABRIC_NAME,
+					FI_TC_LOW_LATENCY,
+					FI_TC_LOW_LATENCY));
+
+	EXPECT_EQ(info->domain_attr->tclass, (uint32_t) FI_TC_LOW_LATENCY);
+	EXPECT_EQ(info->tx_attr->tclass, (uint32_t) FI_TC_LOW_LATENCY);
+}
+
+struct EfaTclassQpCase {
+	uint32_t domain_tclass;
+	uint32_t ep_tclass;
+	/* whether the resulting QP should ask for the low latency service level */
+	bool expect_low_latency;
+	const char *name;
+};
+
+/*
+ * The service level the provider requests when creating the endpoint's QP is
+ * the observable effect of the domain/endpoint tclass resolution. Read it off
+ * efadv_qp_init_attr::sl at the efadv_create_qp_ex seam, whose only caller in
+ * the provider is efa_qp_create.
+ */
+class EfaTclassQpTest : public TestWithParam<EfaTclassQpCase>
+{
+	protected:
+	struct efa_resource resource = {};
+	StrictMock<MockEfa> mock_efa;
+
+	void SetUp() override
+	{
+		memset(&resource, 0, sizeof(resource));
+
+		/*
+		 * Without efadv_qp_init_attr::sl the provider has no way to
+		 * request a service level, so there is nothing to assert.
+		 */
+		if (!efa_test_have_efadv_sl())
+			GTEST_SKIP() << "build lacks efadv_qp_init_attr::sl";
+	}
+
+	void TearDown() override
+	{
+		MockEfa::set(nullptr);
+		efa_test_resource_destruct(&resource);
+	}
+
+	/* Service level of each QP creation attempt, in order. */
+	std::vector<uint8_t> qp_sls;
+
+	/**
+	 * @brief Bring up an endpoint with the given tclass hints, recording the
+	 * service level of every QP creation attempt into qp_sls.
+	 *
+	 * @param expect_low_latency	whether the resolved tclass should be
+	 *				FI_TC_LOW_LATENCY. Only that case may
+	 *				create the QP more than once, because
+	 *				efa_qp_create retries with the default
+	 *				service level if the device rejects the
+	 *				low latency one.
+	 */
+	void enable_ep_recording_qp_sl(const char *fabric_name,
+				       uint32_t domain_tclass,
+				       uint32_t ep_tclass,
+				       bool expect_low_latency)
+	{
+		struct fi_info *hints;
+		int ret;
+
+		hints = efa_test_alloc_default_hints(FI_EP_RDM, fabric_name);
+		ASSERT_NE(hints, nullptr);
+		hints->domain_attr->tclass = domain_tclass;
+		hints->tx_attr->tclass = ep_tclass;
+
+		/*
+		 * Stop before fi_enable so the QP is not created until the mock
+		 * that observes its service level is installed.
+		 */
+		ASSERT_NO_FATAL_FAILURE(
+			efa_test_resource_construct_no_enable(&resource, hints));
+
+		/* The hints must have survived getinfo into the domain and ep. */
+		ASSERT_EQ(efa_test_get_domain_tclass(resource.domain),
+			  domain_tclass);
+		ASSERT_EQ(efa_test_get_base_ep_tclass(resource.ep), ep_tclass);
+
+		MockEfa::set(&mock_efa);
+		/*
+		 * Armed to read efa_attr->sl in flight, then delegated to the
+		 * real call so a usable QP is still created.
+		 */
+		EFA_EXPECT_CALL(mock_efa, efadv_create_qp_ex)
+			.Times(AtLeast(1))
+			.WillRepeatedly(
+				Invoke([this](struct ibv_context *ibvctx,
+					      struct ibv_qp_init_attr_ex *attr_ex,
+					      struct efadv_qp_init_attr *efa_attr,
+					      uint32_t inlen) {
+					qp_sls.push_back(
+						efa_test_efadv_attr_sl(efa_attr));
+					return __real_efadv_create_qp_ex(
+						ibvctx, attr_ex, efa_attr, inlen);
+				}));
+
+		ret = fi_enable(resource.ep);
+		ASSERT_EQ(ret, 0) << "fi_enable failed: " << fi_strerror(-ret);
+
+		/*
+		 * Only a low latency request may be attempted twice, because
+		 * efa_qp_create retries with the default service level if the
+		 * device rejects the low latency one.
+		 */
+		ASSERT_GE(qp_sls.size(), 1u);
+		ASSERT_LE(qp_sls.size(), expect_low_latency ? 2u : 1u);
+	}
+
+	/* The service level the provider asked for is the first attempt's. */
+	void expect_requested_sl(bool low_latency)
+	{
+		EXPECT_EQ(qp_sls.front(), low_latency ?
+						  efa_test_qp_low_latency_sl :
+						  efa_test_qp_default_sl);
+
+		/* A retry, if it happened, must have fallen back to default. */
+		if (qp_sls.size() > 1)
+			EXPECT_EQ(qp_sls.back(), efa_test_qp_default_sl);
+	}
+};
+
+TEST_P(EfaTclassQpTest, resolves_qp_service_level)
+{
+	const EfaTclassQpCase &p = GetParam();
+
+	ASSERT_NO_FATAL_FAILURE(enable_ep_recording_qp_sl(
+		EFA_DIRECT_FABRIC_NAME, p.domain_tclass, p.ep_tclass,
+		p.expect_low_latency));
+
+	expect_requested_sl(p.expect_low_latency);
+}
+
+/*
+ * efa-rdm reaches the same resolution through its own ep implementation, so
+ * confirm the resolution still lands on the QP there.
+ */
+TEST_P(EfaTclassQpTest, resolves_qp_service_level_rdm)
+{
+	const EfaTclassQpCase &p = GetParam();
+
+	ASSERT_NO_FATAL_FAILURE(enable_ep_recording_qp_sl(
+		EFA_FABRIC_NAME, p.domain_tclass, p.ep_tclass,
+		p.expect_low_latency));
+
+	expect_requested_sl(p.expect_low_latency);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+	, EfaTclassQpTest,
+	Values(
+		EfaTclassQpCase{FI_TC_UNSPEC, FI_TC_UNSPEC, false,
+				"both_unspec"},
+		/* An unspecified ep tclass inherits the domain default. */
+		EfaTclassQpCase{FI_TC_LOW_LATENCY, FI_TC_UNSPEC, true,
+				"domain_low_latency_ep_unspec"},
+		EfaTclassQpCase{FI_TC_UNSPEC, FI_TC_LOW_LATENCY, true,
+				"domain_unspec_ep_low_latency"},
+		EfaTclassQpCase{FI_TC_LOW_LATENCY, FI_TC_LOW_LATENCY, true,
+				"both_low_latency"},
+		EfaTclassQpCase{FI_TC_UNSPEC, FI_TC_BEST_EFFORT, false,
+				"domain_unspec_ep_best_effort"},
+		/*
+		 * A tclass set on the endpoint overrides the domain default, so
+		 * best effort on the ep must not inherit the domain's low
+		 * latency.
+		 */
+		EfaTclassQpCase{FI_TC_LOW_LATENCY, FI_TC_BEST_EFFORT, false,
+				"domain_low_latency_ep_best_effort"},
+		EfaTclassQpCase{FI_TC_BEST_EFFORT, FI_TC_UNSPEC, false,
+				"domain_best_effort_ep_unspec"}),
+	[](const testing::TestParamInfo<EfaTclassQpCase> &i) {
+		return std::string(i.param.name);
+	});

--- a/prov/efa/test/gtest/efa_gtest_tclass_utils.c
+++ b/prov/efa/test/gtest/efa_gtest_tclass_utils.c
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa.h"
+#include "efa_gtest_tclass_utils.h"
+
+const uint8_t efa_test_qp_default_sl = EFA_QP_DEFAULT_SERVICE_LEVEL;
+const uint8_t efa_test_qp_low_latency_sl = EFA_QP_LOW_LATENCY_SERVICE_LEVEL;
+
+int efa_test_have_efadv_sl(void)
+{
+#if HAVE_EFADV_SL
+	return 1;
+#else
+	return 0;
+#endif
+}
+
+uint8_t efa_test_efadv_attr_sl(const struct efadv_qp_init_attr *attr)
+{
+#if HAVE_EFADV_SL
+	return attr->sl;
+#else
+	(void) attr;
+	return EFA_QP_DEFAULT_SERVICE_LEVEL;
+#endif
+}
+
+uint32_t efa_test_get_domain_tclass(struct fid_domain *domain)
+{
+	struct efa_domain *efa_domain =
+		container_of(domain, struct efa_domain, util_domain.domain_fid);
+
+	return efa_domain->info->domain_attr->tclass;
+}
+
+uint32_t efa_test_get_base_ep_tclass(struct fid_ep *ep)
+{
+	struct efa_base_ep *base_ep =
+		container_of(ep, struct efa_base_ep, util_ep.ep_fid);
+
+	return base_ep->info->tx_attr->tclass;
+}

--- a/prov/efa/test/gtest/efa_gtest_tclass_utils.h
+++ b/prov/efa/test/gtest/efa_gtest_tclass_utils.h
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#ifndef EFA_GTEST_TCLASS_UTILS_H
+#define EFA_GTEST_TCLASS_UTILS_H
+
+#include <stdint.h>
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct efadv_qp_init_attr;
+
+/**
+ * @brief Whether this build detected efadv_qp_init_attr::sl (HAVE_EFADV_SL).
+ * When 0 the provider cannot request a service level at all, so EFA reports
+ * FI_TC_LOW_LATENCY as unsupported and every QP is created with the default SL.
+ */
+int efa_test_have_efadv_sl(void);
+
+/**
+ * @brief Read efadv_qp_init_attr::sl, the QP's requested service level.
+ * Returns EFA_QP_DEFAULT_SERVICE_LEVEL when the field is not available.
+ */
+uint8_t efa_test_efadv_attr_sl(const struct efadv_qp_init_attr *attr);
+
+extern const uint8_t efa_test_qp_default_sl;
+extern const uint8_t efa_test_qp_low_latency_sl;
+
+/**
+ * @brief Read the tclass the domain stored from info->domain_attr->tclass.
+ */
+uint32_t efa_test_get_domain_tclass(struct fid_domain *domain);
+
+/**
+ * @brief Read the tclass the endpoint stored from info->tx_attr->tclass.
+ */
+uint32_t efa_test_get_base_ep_tclass(struct fid_ep *ep);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFA_GTEST_TCLASS_UTILS_H */


### PR DESCRIPTION
The fi_info object has two tclass fields:
info->domain_attr->tclass
info->tx_attr->tclass

When these fields are set in hints before getinfo call, the provider
should apply them to endpoints that are later created with the
returned info objects.

The EFA provider only supports two values for the tclass field: the
default values of FI_TC_UNSPEC/FI_TC_BEST_EFFORT and FI_TC_LOW_LATENCY.
If the application provides any other values, we ignore them.

This commit does the following:
1. Copies the tclass values from hints to the fi_info object returned to
   the application. For invalid values, we store and return FI_TC_UNSPEC.
2. Add tclass fields in efa_domain and efa_base_ep to store the tclass
   values from the fi_info objects used to create the domain and the
   endpoint.
3. During QP creation, we check both the domain level and endpoint level
   tclass values. If the endpoint level tclass is FI_TC_LOW_LATENCY, it
   overrides the domain level value and we create a QP with
   FI_TC_LOW_LATENCY. If the endpoint level value is left unspecified
   but the domain level value is FI_TC_LOW_LATENCY, we create a QP
   with FI_TC_LOW_LATENCY. In all other cases, we use the default
   tclass for QP creation.