### PR TITLE
prov/efa: Remove srx lock from av remove and av close

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -784,10 +784,6 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 	if (av->type != FI_AV_TABLE)
 		return -FI_EINVAL;
 
-	/* The order in which the util AV and SRX locks are acquired must match
-	 in the AV insertion, removal and CQ read paths to prevent deadlocks */
-	if (av->domain->info_type == EFA_INFO_RDM)
-		ofi_genlock_lock(&((struct efa_rdm_domain *) av->domain)->srx_lock);
 	ofi_genlock_lock(&av->util_av.lock);
 	for (i = 0; i < count; i++) {
 		conn = efa_av_addr_to_conn(av, fi_addr[i]);
@@ -805,8 +801,6 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 	}
 
 	ofi_genlock_unlock(&av->util_av.lock);
-	if (av->domain->info_type == EFA_INFO_RDM)
-		ofi_genlock_unlock(&((struct efa_rdm_domain *) av->domain)->srx_lock);
 	return err;
 }
 
@@ -831,11 +825,6 @@ static void efa_av_close_reverse_av(struct efa_av *av)
 	struct efa_cur_reverse_av *cur_entry, *curtmp;
 	struct efa_prv_reverse_av *prv_entry, *prvtmp;
 
-	/* The order in which the util AV and SRX locks are acquired must match
-	 in the AV insertion, removal and CQ read paths to prevent deadlocks */
-	if (av->domain->info_type == EFA_INFO_RDM)
-		ofi_genlock_lock(&((struct efa_rdm_domain *) av->domain)->srx_lock);
-
 	ofi_genlock_lock(&av->util_av.lock);
 
 	HASH_ITER(hh, av->cur_reverse_av, cur_entry, curtmp) {
@@ -859,9 +848,6 @@ static void efa_av_close_reverse_av(struct efa_av *av)
 	}
 
 	EFA_GENLOCK_UNLOCK(&av->util_av_implicit.lock, efa_implicit_av_lock_sym);
-
-	if (av->domain->info_type == EFA_INFO_RDM)
-		ofi_genlock_unlock(&((struct efa_rdm_domain *) av->domain)->srx_lock);
 }
 
 static int efa_av_close(struct fid *fid)

--- a/prov/efa/src/efa_conn.c
+++ b/prov/efa/src/efa_conn.c
@@ -195,7 +195,6 @@ void efa_conn_rdm_deinit(struct efa_av *av, struct efa_conn *conn)
 		}
 	}
 
-	assert(ofi_genlock_held(&((struct efa_rdm_domain *) av->domain)->srx_lock));
 	HASH_ITER(hh, conn->ep_peer_map, peer_map_entry, tmp) {
 		dlist_remove(&peer_map_entry->peer.ep_peer_list_entry);
 		efa_rdm_peer_destruct(&peer_map_entry->peer, peer_map_entry->ep_ptr);
@@ -395,9 +394,6 @@ void efa_conn_release_util_av(struct efa_av *av, struct efa_conn *conn,
 void efa_conn_release(struct efa_av *av, struct efa_conn *conn,
 		      bool release_from_implicit_av)
 {
-	assert(av->domain->info_type != EFA_INFO_RDM ||
-	       ofi_genlock_held(&((struct efa_rdm_domain *) av->domain)->srx_lock));
-
 	efa_conn_release_reverse_av(av, conn, release_from_implicit_av);
 	if (av->domain->info_type == EFA_INFO_RDM)
 		efa_conn_rdm_deinit(av, conn);


### PR DESCRIPTION
According to the man page, the behavior of operations in progress that reference the removed addresses is undefined. There is no need to protect race with data operations.