### PR TITLE
prov/efa: Strip stale FI_MORE when processing queued opes

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -2355,6 +2355,13 @@ int efa_rdm_ope_process_queued_ope(struct efa_rdm_ope *ope, uint32_t flag)
 	if (!(ope->internal_flags & flag))
 		return 0;
 
+	/*
+	 * Strip stale FI_MORE: the flushing (non-FI_MORE) operation that followed
+	 * this ope may have already been posted while it sat in the queue. Replaying
+	 * FI_MORE now could leave WQEs staged with no later post to ring the doorbell.
+	 */
+	ope->fi_flags &= ~FI_MORE;
+
 	if (efa_rdm_mr_gen_check_ope(ope)) {
 		switch (flag) {
 		case EFA_RDM_OPE_QUEUED_BEFORE_HANDSHAKE:

--- a/prov/efa/test/gtest/efa_gtest_rdm_ope.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_ope.cc
@@ -1,12 +1,21 @@
 /* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
 /* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
 
+#include "efa_gtest_common_helpers.h"
+#include "efa_gtest_common_mocks.h"
 #include "efa_gtest_common_resource.h"
 #include "efa_gtest_rdm_ope_helpers.h"
 #include <gtest/gtest.h>
 #include <rdma/fi_errno.h>
 
+using testing::_;
+using testing::DoAll;
+using testing::Return;
+using testing::SaveArg;
+using testing::StrictMock;
 using testing::Test;
+using testing::TestWithParam;
+using testing::Values;
 
 class EfaRdmOpeTest : public Test
 {
@@ -49,3 +58,100 @@ TEST_F(EfaRdmOpeTest, rxe_unexp_error_suppresses_op_context)
 	/* The sentinel should not be here */
 	EXPECT_EQ(err_entry.op_context, nullptr);
 }
+
+/**
+ * @brief Covers efa_rdm_ope_process_queued_ope's FI_MORE stripping.
+ *
+ * An op posted with FI_MORE to a peer with no handshake is queued in
+ * software; by the time it is replayed the application's flushing
+ * (non-FI_MORE) op has already passed, so the repost must not carry the
+ * stale FI_MORE into the QP post or the doorbell is never rung.
+ */
+class EfaRdmOpeQueuedFiMoreTest : public TestWithParam<int>
+{
+	protected:
+	struct efa_resource resource = {};
+	StrictMock<MockEfa> mock_efa;
+
+	void SetUp() override
+	{
+		memset(&resource, 0, sizeof(resource));
+
+		struct fi_info *hints = efa_test_alloc_default_hints(
+			FI_EP_RDM, EFA_FABRIC_NAME);
+		ASSERT_NE(hints, nullptr);
+		hints->caps |= FI_MSG | FI_RMA;
+
+		efa_test_resource_construct(&resource, hints);
+		ASSERT_NE(resource.ep, nullptr);
+
+		/* Checked after construct: the device list is only populated
+		 * by fi_getinfo. */
+		if (!efa_test_device_supports_rma())
+			GTEST_SKIP()
+				<< "device does not support RDMA read+write";
+
+		MockEfa::set(&mock_efa);
+	}
+
+	void TearDown() override
+	{
+		MockEfa::set(nullptr);
+		efa_test_resource_destruct(&resource);
+	}
+};
+
+TEST_P(EfaRdmOpeQueuedFiMoreTest, repost_does_not_carry_fi_more_to_qp)
+{
+	int op_kind = GetParam();
+	struct efa_test_queued_op qop = {};
+	uintptr_t wr_id = 0;
+	uint64_t seen_flags = 0;
+
+	ASSERT_EQ(efa_test_queue_op_with_fi_more(resource.ep, resource.av,
+						 resource.domain, op_kind,
+						 &qop),
+		  0);
+	/* Queued with the caller's FI_MORE preserved on the ope */
+	ASSERT_TRUE(qop.fi_more_was_set);
+
+	switch (op_kind) {
+	case EFA_TEST_QUEUED_OP_SEND:
+		EFA_EXPECT_CALL(mock_efa, efa_qp_post_send)
+			.WillOnce(DoAll(SaveArg<5>(&wr_id),
+					SaveArg<7>(&seen_flags), Return(0)));
+		break;
+	case EFA_TEST_QUEUED_OP_READ:
+		EFA_EXPECT_CALL(mock_efa, efa_qp_post_read)
+			.WillOnce(DoAll(SaveArg<5>(&wr_id),
+					SaveArg<6>(&seen_flags), Return(0)));
+		break;
+	case EFA_TEST_QUEUED_OP_WRITE:
+		EFA_EXPECT_CALL(mock_efa, efa_qp_post_write)
+			.WillOnce(DoAll(SaveArg<7>(&wr_id),
+					SaveArg<9>(&seen_flags), Return(0)));
+		break;
+	default:
+		FAIL() << "unknown op kind " << op_kind;
+	}
+
+	EXPECT_EQ(efa_test_process_queued_ope_after_handshake(&qop), 0);
+	EXPECT_FALSE(seen_flags & FI_MORE);
+
+	efa_test_queued_op_cleanup(&qop, wr_id);
+}
+
+INSTANTIATE_TEST_SUITE_P(QueuedOps, EfaRdmOpeQueuedFiMoreTest,
+			 Values(EFA_TEST_QUEUED_OP_SEND,
+				EFA_TEST_QUEUED_OP_READ,
+				EFA_TEST_QUEUED_OP_WRITE),
+			 [](const testing::TestParamInfo<int> &info) {
+				 switch (info.param) {
+				 case EFA_TEST_QUEUED_OP_SEND:
+					 return "send";
+				 case EFA_TEST_QUEUED_OP_READ:
+					 return "read";
+				 default:
+					 return "write";
+				 }
+			 });

--- a/prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.c
@@ -6,6 +6,12 @@
 #include "efa.h"
 #include "efa_av.h"
 #include "rdm/efa_rdm_ep.h"
+#include "rdm/efa_rdm_domain.h"
+#include "rdm/efa_rdm_ope.h"
+#include "rdm/efa_rdm_pke.h"
+#include "rdm/efa_rdm_cq.h"
+#include "rdm/efa_rdm_peer.h"
+#include "rdm/efa_rdm_protocol.h"
 
 int efa_test_drive_rxe_unexp_handle_error(struct fid_ep *ep, void *op_context,
 					  int err, int *prov_errno_out)
@@ -41,4 +47,139 @@ int efa_test_drive_rxe_unexp_handle_error(struct fid_ep *ep, void *op_context,
 		*prov_errno_out = prov_errno;
 
 	return 0;
+}
+
+int efa_test_queue_op_with_fi_more(struct fid_ep *ep_fid, struct fid_av *av_fid,
+				   struct fid_domain *domain_fid, int op_kind,
+				   struct efa_test_queued_op *qop)
+{
+	struct efa_rdm_ep *ep = container_of(ep_fid, struct efa_rdm_ep,
+					     base_ep.util_ep.ep_fid);
+	struct efa_rdm_domain *rdm_domain = efa_rdm_ep_rdm_domain(ep);
+	struct efa_ep_addr raw_addr = {0};
+	size_t raw_addr_len = sizeof(raw_addr);
+	fi_addr_t peer_addr = FI_ADDR_NOTAVAIL;
+	void *desc;
+	struct iovec iov;
+	int ret;
+
+	memset(qop, 0, sizeof(*qop));
+	qop->ep = ep_fid;
+
+	/* Own GID with a different QPN: AH creation succeeds against the
+	 * real device, but the peer is not self, so handshake is enforced. */
+	ret = fi_getname(&ep_fid->fid, &raw_addr, &raw_addr_len);
+	if (ret)
+		return ret;
+	raw_addr.qpn = 1;
+	raw_addr.qkey = 0x1234;
+	if (fi_av_insert(av_fid, &raw_addr, 1, &peer_addr, 0, NULL) != 1)
+		return -FI_EINVAL;
+
+	qop->peer = efa_rdm_ep_get_peer(ep, peer_addr);
+	if (!qop->peer)
+		return -FI_EINVAL;
+	/* REQ already sent, so enforce_handshake queues instead of posting a
+	 * handshake REQ; no handshake received yet. */
+	qop->peer->flags = EFA_RDM_PEER_REQ_SENT;
+	qop->peer->conn->shm_fi_addr = FI_ADDR_NOTAVAIL;
+
+	ret = fi_mr_reg(domain_fid, qop->buf, sizeof(qop->buf),
+			FI_SEND | FI_RECV | FI_READ | FI_WRITE, 0, 0, 0,
+			&qop->mr, NULL);
+	if (ret)
+		return ret;
+	desc = fi_mr_desc(qop->mr);
+
+	iov.iov_base = qop->buf;
+	iov.iov_len = sizeof(qop->buf);
+
+	if (op_kind == EFA_TEST_QUEUED_OP_SEND) {
+		/* Force the send path's handshake enforcement */
+		ep->peer_may_have_zcpy_rx = true;
+
+		struct fi_msg msg = {
+			.msg_iov = &iov,
+			.desc = &desc,
+			.iov_count = 1,
+			.addr = peer_addr,
+			.context = NULL,
+			.data = 0,
+		};
+		ret = fi_sendmsg(ep_fid, &msg, FI_MORE);
+	} else {
+		struct fi_rma_iov rma_iov = {
+			.addr = (uint64_t) qop->buf,
+			.len = sizeof(qop->buf),
+			.key = 0x1234,
+		};
+		struct fi_msg_rma msg = {
+			.msg_iov = &iov,
+			.desc = &desc,
+			.iov_count = 1,
+			.addr = peer_addr,
+			.rma_iov = &rma_iov,
+			.rma_iov_count = 1,
+			.context = NULL,
+			.data = 0,
+		};
+		if (op_kind == EFA_TEST_QUEUED_OP_READ)
+			ret = fi_readmsg(ep_fid, &msg, FI_MORE);
+		else
+			ret = fi_writemsg(ep_fid, &msg, FI_MORE);
+	}
+	if (ret)
+		return ret;
+
+	if (dlist_empty(&rdm_domain->ope_queued_list))
+		return -FI_EINVAL;
+	qop->txe = container_of(rdm_domain->ope_queued_list.next,
+				struct efa_rdm_ope, queued_entry);
+	if (!(qop->txe->internal_flags & EFA_RDM_OPE_QUEUED_BEFORE_HANDSHAKE))
+		return -FI_EINVAL;
+
+	qop->fi_more_was_set = !!(qop->txe->fi_flags & FI_MORE);
+	return 0;
+}
+
+int efa_test_process_queued_ope_after_handshake(struct efa_test_queued_op *qop)
+{
+	struct efa_rdm_ep *ep = container_of(qop->ep, struct efa_rdm_ep,
+					     base_ep.util_ep.ep_fid);
+
+	/* Simulate the handshake landing: peer advertises device RDMA
+	 * read/write and p2p, so the repost takes the device data path. */
+	qop->peer->flags |= EFA_RDM_PEER_HANDSHAKE_RECEIVED;
+	qop->peer->extra_info[0] |= EFA_RDM_EXTRA_FEATURE_RDMA_READ |
+				    EFA_RDM_EXTRA_FEATURE_RDMA_WRITE;
+	qop->peer->p2p_supported = true;
+	/* use_device_rdma defaults off on some platforms, which would route
+	 * the repost through the emulated (send-based) protocols instead of
+	 * efa_qp_post_read/write. The device caps are verified by the test's
+	 * skip gate; force the software toggle so the device path is taken. */
+	ep->use_device_rdma = true;
+
+	return efa_rdm_ope_process_queued_ope(qop->txe,
+					      EFA_RDM_OPE_QUEUED_BEFORE_HANDSHAKE);
+}
+
+void efa_test_queued_op_cleanup(struct efa_test_queued_op *qop, uint64_t wr_id)
+{
+	struct efa_rdm_ep *ep = container_of(qop->ep, struct efa_rdm_ep,
+					     base_ep.util_ep.ep_fid);
+	struct efa_rdm_pke *pkt_entry;
+
+	if (wr_id) {
+		pkt_entry = efa_rdm_cq_get_pke_from_wr_id_solicited(wr_id);
+		if (pkt_entry)
+			efa_rdm_pke_release_tx(pkt_entry);
+	}
+	if (qop->txe)
+		efa_rdm_txe_release(qop->txe);
+	ep->efa_outstanding_tx_ops = 0;
+
+	if (qop->mr) {
+		fi_close(&qop->mr->fid);
+		qop->mr = NULL;
+	}
 }

--- a/prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.h
@@ -14,6 +14,43 @@ extern "C" {
 int efa_test_drive_rxe_unexp_handle_error(struct fid_ep *ep, void *op_context,
 					  int err, int *prov_errno_out);
 
+enum efa_test_queued_op_kind {
+	EFA_TEST_QUEUED_OP_SEND = 0,
+	EFA_TEST_QUEUED_OP_READ = 1,
+	EFA_TEST_QUEUED_OP_WRITE = 2,
+};
+
+struct efa_rdm_ope;
+struct efa_rdm_peer;
+
+struct efa_test_queued_op {
+	struct fid_ep *ep;
+	struct fid_mr *mr;
+	struct efa_rdm_ope *txe;
+	struct efa_rdm_peer *peer;
+	int fi_more_was_set;
+	char buf[16];
+};
+
+/**
+ * @brief Issue a send/read/write with FI_MORE to a peer with no handshake yet,
+ * so the op is queued on the domain's ope_queued_list instead of posted.
+ */
+int efa_test_queue_op_with_fi_more(struct fid_ep *ep, struct fid_av *av,
+				   struct fid_domain *domain, int op_kind,
+				   struct efa_test_queued_op *qop);
+
+/**
+ * @brief Simulate handshake completion (device RDMA + p2p advertised), then
+ * process the queued ope so it reposts to the QP.
+ */
+int efa_test_process_queued_ope_after_handshake(struct efa_test_queued_op *qop);
+
+/**
+ * @brief Release the posted pkt entry (by wr_id) and the txe, and close the MR.
+ */
+void efa_test_queued_op_cleanup(struct efa_test_queued_op *qop, uint64_t wr_id);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
An operation posted with FI_MORE defers the doorbell until a later operation without FI_MORE is posted on the same endpoint. When an operation is instead queued in software (e.g. waiting for the peer handshake in efa_rdm_ep_enforce_handshake_for_txe), its fi_flags are preserved and replayed by the progress engine once the deferral resolves. By that time the application's flushing (non-FI_MORE) operation might have already been posted and doorbelled, so the replayed batch can consist entirely of FI_MORE operations. Their WQEs are then staged in the send queue but the doorbell is never rung, the operations never complete, and the transfer hangs.

Fix by clearing FI_MORE from ope->fi_flags before reposting a queued ope. The batching benefit is already lost for deferred operations, so always flushing is safe.

This bug impacts all queue'ed operations (send/read/write), which get queue'ed for any reason (handshake/RNR/etc..)