### PR TITLE
fabtests/efa: Add multiple endpoints to mr_abort test

### DIFF
--- a/fabtests/prov/efa/src/efa_shared.c
+++ b/fabtests/prov/efa/src/efa_shared.c
@@ -7,6 +7,8 @@
 #include <string.h>
 #include <getopt.h>
 
+#include <rdma/fi_cm.h>
+
 #include <shared.h>
 #include "efa_shared.h"
 
@@ -100,4 +102,66 @@ int efa_calc_peer_distribution(int my_idx, int my_count, int peer_count,
 
 	*num_peers = n;
 	return FI_SUCCESS;
+}
+
+int efa_exchange_addrs_oob(int oob_sock, bool is_initiator,
+			   struct fid_ep **local_eps, int local_n,
+			   struct fid_av *av, fi_addr_t *remote_addrs,
+			   int remote_n)
+{
+	char *local_buf = NULL, *remote_buf = NULL;
+	size_t addrlen;
+	int i, ret;
+
+	local_buf = calloc(local_n, FT_MAX_CTRL_MSG);
+	remote_buf = calloc(remote_n, FT_MAX_CTRL_MSG);
+	if (!local_buf || !remote_buf) {
+		ret = -FI_ENOMEM;
+		goto out;
+	}
+
+	for (i = 0; i < local_n; i++) {
+		addrlen = FT_MAX_CTRL_MSG;
+		ret = fi_getname(&local_eps[i]->fid,
+				 local_buf + (size_t) i * FT_MAX_CTRL_MSG,
+				 &addrlen);
+		if (ret) {
+			FT_PRINTERR("fi_getname", ret);
+			goto out;
+		}
+	}
+
+	if (is_initiator) {
+		ret = ft_sock_send(oob_sock, local_buf,
+				   (size_t) local_n * FT_MAX_CTRL_MSG);
+		if (ret)
+			goto out;
+		ret = ft_sock_recv(oob_sock, remote_buf,
+				   (size_t) remote_n * FT_MAX_CTRL_MSG);
+		if (ret)
+			goto out;
+	} else {
+		ret = ft_sock_recv(oob_sock, remote_buf,
+				   (size_t) remote_n * FT_MAX_CTRL_MSG);
+		if (ret)
+			goto out;
+		ret = ft_sock_send(oob_sock, local_buf,
+				   (size_t) local_n * FT_MAX_CTRL_MSG);
+		if (ret)
+			goto out;
+	}
+
+	for (i = 0; i < remote_n; i++) {
+		ret = ft_av_insert(av,
+				   remote_buf + (size_t) i * FT_MAX_CTRL_MSG,
+				   1, &remote_addrs[i], 0, NULL);
+		if (ret)
+			goto out;
+	}
+
+	ret = FI_SUCCESS;
+out:
+	free(local_buf);
+	free(remote_buf);
+	return ret;
 }

--- a/fabtests/prov/efa/src/efa_shared.h
+++ b/fabtests/prov/efa/src/efa_shared.h
@@ -6,6 +6,7 @@
 #define _EFA_SHARED_H
 
 #include <getopt.h>
+#include <rdma/fabric.h>
 
 #define EFA_FABRIC_NAME	       "efa"
 #define EFA_DIRECT_FABRIC_NAME "efa-direct"
@@ -37,5 +38,10 @@ void efa_longopts_usage(void);
 
 int efa_calc_peer_distribution(int my_idx, int my_count, int peer_count,
 			       int *num_peers, int **peer_ids);
+
+int efa_exchange_addrs_oob(int oob_sock, bool is_initiator,
+			   struct fid_ep **local_eps, int local_n,
+			   struct fid_av *av, fi_addr_t *remote_addrs,
+			   int remote_n);
 
 #endif /* _EFA_SHARED_H */

--- a/fabtests/prov/efa/src/mr_abort.c
+++ b/fabtests/prov/efa/src/mr_abort.c
@@ -421,11 +421,42 @@ static char *slot_op_buf(int op_idx, int mr_idx)
 	return slots[mr_idx].buf + (size_t) op_in_mr * opts.transfer_size;
 }
 
+/* Each side picks the half of pair p that it owns. */
+static struct fid_ep *local_ep_for_pair(int p)
+{
+	return eps[opts.dst_addr ? p : target_ep_for_pair[p]];
+}
+
+static fi_addr_t peer_addr_for_pair(int p)
+{
+	return remote_ep_addrs[opts.dst_addr ? target_ep_for_pair[p] : p];
+}
+
+/*
+ * Route an MR slot to a pair, round-robin, so a send and its matching recv
+ * land on the same pair.
+ */
+static int pair_idx_for_mr_idx(int mr_idx)
+{
+	return mr_idx % num_initiator_eps;
+}
+
+static struct fid_ep *op_local_ep(int mr_idx)
+{
+	return local_ep_for_pair(pair_idx_for_mr_idx(mr_idx));
+}
+
+static fi_addr_t op_peer_addr(int mr_idx)
+{
+	return peer_addr_for_pair(pair_idx_for_mr_idx(mr_idx));
+}
+
 static ssize_t post_rma_op(int op_idx, int mr_idx)
 {
 	uint64_t flags;
 	struct mr_slot *s = &slots[mr_idx];
 	struct op_ctx *o = &op_arr[op_idx];
+	struct fid_ep *lep = op_local_ep(mr_idx);
 	struct iovec msg_iov = {
 		.iov_base = s->buf,
 		.iov_len = opts.transfer_size,
@@ -439,7 +470,7 @@ static ssize_t post_rma_op(int op_idx, int mr_idx)
 		.msg_iov = &msg_iov,
 		.desc = &s->desc,
 		.iov_count = 1,
-		.addr = remote_fi_addr,
+		.addr = op_peer_addr(mr_idx),
 		.rma_iov = &rma_iov,
 		.rma_iov_count = 1,
 		.context = &o->context,
@@ -456,13 +487,13 @@ static ssize_t post_rma_op(int op_idx, int mr_idx)
 
 	switch (opts.rma_op) {
 	case FT_RMA_WRITE:
-		return fi_writemsg(ep, &msg, flags);
+		return fi_writemsg(lep, &msg, flags);
 	case FT_RMA_WRITEDATA:
 		msg.data = remote_cq_data;
 		flags |= FI_REMOTE_CQ_DATA;
-		return fi_writemsg(ep, &msg, flags);
+		return fi_writemsg(lep, &msg, flags);
 	case FT_RMA_READ:
-		return fi_readmsg(ep, &msg, flags);
+		return fi_readmsg(lep, &msg, flags);
 	default:
 		return -FI_EINVAL;
 	}
@@ -472,32 +503,34 @@ static ssize_t post_send_op(int op_idx, int mr_idx)
 {
 	struct mr_slot *s = &slots[mr_idx];
 	struct op_ctx *o = &op_arr[op_idx];
+	struct fid_ep *lep = op_local_ep(mr_idx);
 	char *buf = slot_op_buf(op_idx, mr_idx);
 
 	o->mr_idx = mr_idx;
 
 	if (test_mode == TEST_TAGGED)
-		return fi_tsend(ep, buf, opts.transfer_size, s->desc,
-				remote_fi_addr, 0xCAFE, &o->context);
+		return fi_tsend(lep, buf, opts.transfer_size, s->desc,
+				op_peer_addr(mr_idx), 0xCAFE, &o->context);
 	else
-		return fi_send(ep, buf, opts.transfer_size, s->desc,
-			       remote_fi_addr, &o->context);
+		return fi_send(lep, buf, opts.transfer_size, s->desc,
+			       op_peer_addr(mr_idx), &o->context);
 }
 
 static ssize_t post_recv_op(int op_idx, int mr_idx)
 {
 	struct mr_slot *s = &slots[mr_idx];
 	struct op_ctx *o = &op_arr[op_idx];
+	struct fid_ep *lep = op_local_ep(mr_idx);
 	char *buf = slot_op_buf(op_idx, mr_idx);
 
 	o->mr_idx = mr_idx;
 
 	if (test_mode == TEST_TAGGED)
-		return fi_trecv(ep, buf, opts.transfer_size, s->desc,
-				remote_fi_addr, 0xCAFE, 0, &o->context);
+		return fi_trecv(lep, buf, opts.transfer_size, s->desc,
+				op_peer_addr(mr_idx), 0xCAFE, 0, &o->context);
 	else
-		return fi_recv(ep, buf, opts.transfer_size, s->desc,
-			       remote_fi_addr, &o->context);
+		return fi_recv(lep, buf, opts.transfer_size, s->desc,
+			       op_peer_addr(mr_idx), &o->context);
 }
 
 static void shuffle(int *arr, int n)
@@ -905,13 +938,20 @@ static int run_fill_abort_initiator(int iter)
 		 *
 		 * Use op_arr[0] as context so drain_cq_counted's container_of
 		 * resolves to a valid op_ctx.
+		 *
+		 * A control message, not a slot op: it borrows this slot's remote
+		 * key because a 0-byte write still needs a valid destination MR.
+		 * Which pair carries it does not matter -- the target closes all
+		 * its MRs on receipt.
 		 */
-		op_arr[0].mr_idx = 0;
-		ret = fi_writedata(ep, NULL, 0, NULL,
+		const int SIGNAL_MR_IDX = 0;
+
+		op_arr[0].mr_idx = SIGNAL_MR_IDX;
+		ret = fi_writedata(op_local_ep(SIGNAL_MR_IDX), NULL, 0, NULL,
 				   (uint64_t) 0xFFFF,
-				   remote_fi_addr,
-				   remote_arr[0].addr,
-				   remote_arr[0].key,
+				   op_peer_addr(SIGNAL_MR_IDX),
+				   remote_arr[SIGNAL_MR_IDX].addr,
+				   remote_arr[SIGNAL_MR_IDX].key,
 				   &op_arr[0].context);
 		if (ret) {
 			FT_PRINTERR("fi_writedata (signal)", ret);

--- a/fabtests/prov/efa/src/mr_abort.c
+++ b/fabtests/prov/efa/src/mr_abort.c
@@ -238,9 +238,9 @@ static int max_ops(void)
 {
 	int n = num_mrs * ops_per_mr;
 
-	/* Partial test always uses 2 ops regardless of num_mrs */
-	if (test_mode == TEST_PARTIAL && n < 2)
-		n = 2;
+	/* The partial test posts 2 ops per slot, all outstanding at once */
+	if (test_mode == TEST_PARTIAL)
+		n = 2 * num_mrs;
 
 	/* Target-close posts an extra signal write before filling the queue */
 	if (close_side == CLOSE_TARGET)
@@ -1136,18 +1136,29 @@ static int run_fill_abort_target(void)
  *
  * Register 2 MRs on the same buffer. Post 1 write with each MR.
  * Close only the first MR. Verify: one op errors, the other completes.
- * Only runs on the initiator side.
+ *
+ * Runs once per slot, and num_mrs == num_initiator_eps here, so every pair is
+ * covered exactly once. Every pair posts and closes before any completion is
+ * reaped, so a close must only abort the ops on its own MR.
  */
-static int run_partial_close_initiator(void)
+
+/*
+ * Post both writes for one slot and close the alias MR. Slot mr_idx owns
+ * op_arr[2 * mr_idx] (op on the surviving slot MR) and op_arr[2 * mr_idx + 1]
+ * (op on the closed alias); max_ops() sizes op_arr to match.
+ */
+static int partial_post_one_slot(int mr_idx)
 {
 	struct mr_slot extra_slot = {0};
 	struct fi_rma_iov local_iov, remote_iov;
-	int i, completed_ok = 0, completed_err = 0, completed;
+	struct op_ctx *surviving = &op_arr[2 * mr_idx];
+	struct op_ctx *closed = &op_arr[2 * mr_idx + 1];
 	int ret;
 
-	/* Use slot 0's buffer for both MRs */
-	extra_slot.buf = slots[0].buf;
-	extra_slot.key = MR_ABORT_KEY_BASE + num_mrs; /* unique key */
+	/* Use this slot's buffer for both MRs */
+	extra_slot.buf = slots[mr_idx].buf;
+	/* Unique key: slot keys occupy [BASE, BASE + num_mrs) */
+	extra_slot.key = MR_ABORT_KEY_BASE + num_mrs + mr_idx;
 
 	ret = ft_reg_mr(fi, extra_slot.buf, opts.transfer_size,
 			ft_info_to_mr_access(fi), extra_slot.key, opts.iface,
@@ -1171,22 +1182,22 @@ static int run_partial_close_initiator(void)
 	if (ret)
 		goto close_extra;
 
-	/* Post write using slot 0's MR (will be closed) */
-	reset_test_state();
-	ret = fi_write(ep, slots[0].buf, opts.transfer_size,
-		       slots[0].desc, remote_fi_addr,
-		       remote_arr[0].addr, remote_arr[0].key,
-		       &op_arr[0].context);
+	/* Post write using this slot's MR (will survive) */
+	surviving->mr_idx = mr_idx;
+	ret = fi_write(op_local_ep(mr_idx), slots[mr_idx].buf,
+		       opts.transfer_size, slots[mr_idx].desc,
+		       op_peer_addr(mr_idx), remote_arr[mr_idx].addr,
+		       remote_arr[mr_idx].key, &surviving->context);
 	if (ret) {
-		FT_PRINTERR("fi_write (slot 0)", ret);
+		FT_PRINTERR("fi_write (slot MR)", ret);
 		goto close_extra;
 	}
 
-	/* Post write using extra MR (will survive) */
-	ret = fi_write(ep, extra_slot.buf, opts.transfer_size,
-		       extra_slot.desc, remote_fi_addr,
-		       remote_iov.addr, remote_iov.key,
-		       &op_arr[1].context);
+	/* Post write using extra MR (will be closed) */
+	closed->mr_idx = mr_idx;
+	ret = fi_write(op_local_ep(mr_idx), extra_slot.buf, opts.transfer_size,
+		       extra_slot.desc, op_peer_addr(mr_idx),
+		       remote_iov.addr, remote_iov.key, &closed->context);
 	if (ret) {
 		FT_PRINTERR("fi_write (extra)", ret);
 		goto close_extra;
@@ -1199,16 +1210,25 @@ static int run_partial_close_initiator(void)
 		goto close_extra;
 	}
 	extra_slot.mr = NULL;
+	return 0;
 
-	/* Drain both completions */
-	ret = drain_cq_counted(txcq, 2, mr_abort_local_close_errs,
-			       ARRAY_SIZE(mr_abort_local_close_errs));
-	if (ret != 0)
-		goto close_extra;
+close_extra:
+	FT_CLOSE_FID(extra_slot.mr);
+	return ret;
+}
+
+/* Verify slot mr_idx's two completions, already reaped by the caller's drain. */
+static int partial_check_one_slot(int mr_idx)
+{
+	struct op_ctx *surviving = &op_arr[2 * mr_idx];
+	struct op_ctx *closed = &op_arr[2 * mr_idx + 1];
+	int i, completed_ok = 0, completed_err = 0, completed;
 
 	for (i = 0; i < 2; i++) {
-		if (op_arr[i].completions) {
-			if (op_arr[i].status == 0)
+		struct op_ctx *o = i ? closed : surviving;
+
+		if (o->completions) {
+			if (o->status == 0)
 				completed_ok++;
 			else
 				completed_err++;
@@ -1217,90 +1237,211 @@ static int run_partial_close_initiator(void)
 	completed = completed_ok + completed_err;
 
 	/*
-	 * op_arr[0] used slots[0].mr (not closed) — must succeed.
-	 * op_arr[1] used extra_slot.mr (closed) — may succeed or fail.
+	 * surviving used slots[mr_idx].mr (not closed) — must succeed.
+	 * closed used extra_slot.mr (closed) — may succeed or fail.
 	 */
-	FT_INFO("Partial close: posted=2 ok=%d err=%d missing=%d "
-	       "surviving_op=%s closed_op=%s ... ",
-	       completed_ok, completed_err, 2 - completed,
-	       op_arr[0].completions == 0 ? "missing" :
-	       op_arr[0].completions > 1  ? "DOUBLE"  :
-		       (op_arr[0].status == 0 ? "ok" : "FAIL"),
-	       op_arr[1].completions == 0 ? "missing" :
-	       op_arr[1].completions > 1  ? "DOUBLE"  :
-		       (op_arr[1].status == 0 ? "ok" : "err"));
+	FT_INFO("Partial close: slot=%d pair=%d posted=2 ok=%d err=%d "
+	       "missing=%d surviving_op=%s closed_op=%s ... ",
+	       mr_idx, pair_idx_for_mr_idx(mr_idx), completed_ok, completed_err,
+	       2 - completed,
+	       surviving->completions == 0 ? "missing" :
+	       surviving->completions > 1  ? "DOUBLE"  :
+		       (surviving->status == 0 ? "ok" : "FAIL"),
+	       closed->completions == 0 ? "missing" :
+	       closed->completions > 1  ? "DOUBLE"  :
+		       (closed->status == 0 ? "ok" : "err"));
 
 	if (completed != 2) {
 		FT_INFO("FAIL (missing completions)\n");
-		ret = -FI_EOTHER;
-	} else if (op_arr[0].status != 0) {
+		return -FI_EOTHER;
+	}
+	if (surviving->status != 0) {
 		FT_INFO("FAIL (surviving MR op must not fail)\n");
-		ret = -FI_EOTHER;
-	} else {
-		FT_INFO("PASS\n");
-		ret = 0;
+		return -FI_EOTHER;
 	}
 
-	/* Sync with target so it can safely close its extra MR */
-	if (!ret)
-		ret = ft_sync();
-
-close_extra:
-	FT_CLOSE_FID(extra_slot.mr);
-	return ret;
+	FT_INFO("PASS\n");
+	return 0;
 }
 
-static int run_partial_close_target(void)
+/*
+ * One loop posts and closes on every pair, then one drain reaps all the
+ * completions at once and a second loop checks each pair's pair of ops.
+ */
+static int run_partial_close_initiator(void)
 {
-	struct mr_slot extra_slot = {0};
+	int mr_idx, ret;
+
+	reset_test_state();
+
+	for (mr_idx = 0; mr_idx < num_mrs; mr_idx++) {
+		ret = partial_post_one_slot(mr_idx);
+		if (ret)
+			return ret;
+	}
+
+	ret = drain_cq_counted(txcq, 2 * num_mrs, mr_abort_local_close_errs,
+			       ARRAY_SIZE(mr_abort_local_close_errs));
+	if (ret)
+		return ret;
+
+	for (mr_idx = 0; mr_idx < num_mrs; mr_idx++) {
+		ret = partial_check_one_slot(mr_idx);
+		if (ret)
+			return ret;
+	}
+
+	/* Sync once the target's extra MRs are safe to close */
+	return ft_sync();
+}
+
+/* Target half of one slot: see partial_post_one_slot(). */
+static int partial_target_one_slot(struct mr_slot *extra_slot, int mr_idx)
+{
 	struct fi_rma_iov local_iov, remote_iov;
 	int ret;
 
 	/* Register an extra MR for the second write target */
-	ret = ft_hmem_alloc(opts.iface, opts.device, (void **) &extra_slot.buf,
+	ret = ft_hmem_alloc(opts.iface, opts.device, (void **) &extra_slot->buf,
 			    opts.transfer_size);
 	if (ret)
 		return ret;
-	extra_slot.key = MR_ABORT_KEY_BASE + num_mrs;
+	extra_slot->key = MR_ABORT_KEY_BASE + num_mrs + mr_idx;
 
-	ret = ft_reg_mr(fi, extra_slot.buf, opts.transfer_size,
-			ft_info_to_mr_access(fi), extra_slot.key, opts.iface,
-			opts.device, &extra_slot.mr, &extra_slot.desc);
+	ret = ft_reg_mr(fi, extra_slot->buf, opts.transfer_size,
+			ft_info_to_mr_access(fi), extra_slot->key, opts.iface,
+			opts.device, &extra_slot->mr, &extra_slot->desc);
 	if (ret) {
 		FT_PRINTERR("ft_reg_mr (extra)", ret);
-		ft_hmem_free(opts.iface, extra_slot.buf);
 		return ret;
 	}
 
 	/* Exchange the extra key with initiator */
-	local_iov.key = fi_mr_key(extra_slot.mr);
+	local_iov.key = fi_mr_key(extra_slot->mr);
 	local_iov.addr = (fi->domain_attr->mr_mode & FI_MR_VIRT_ADDR) ?
-		(uintptr_t) extra_slot.buf : 0;
+		(uintptr_t) extra_slot->buf : 0;
 	local_iov.len = opts.transfer_size;
 
 	ret = ft_sock_recv(oob_sock, &remote_iov, sizeof(remote_iov));
 	if (!ret)
 		ret = ft_sock_send(oob_sock, &local_iov, sizeof(local_iov));
-	if (ret)
-		goto cleanup;
+	return ret;
+}
 
-	/* Wait for initiator to finish the partial close test */
+/*
+ * All the extra MRs must stay alive until the initiator has drained every
+ * completion, so register them all up front and close them after the sync.
+ */
+static int run_partial_close_target(void)
+{
+	struct mr_slot *extra_slots;
+	int mr_idx, ret;
+
+	extra_slots = calloc(num_mrs, sizeof(*extra_slots));
+	if (!extra_slots)
+		return -FI_ENOMEM;
+
+	for (mr_idx = 0; mr_idx < num_mrs; mr_idx++) {
+		ret = partial_target_one_slot(&extra_slots[mr_idx], mr_idx);
+		if (ret)
+			goto cleanup;
+	}
+
+	/* Wait for the initiator to finish posting, closing and draining */
 	ret = ft_sync();
 
 cleanup:
-	FT_CLOSE_FID(extra_slot.mr);
-	ft_hmem_free(opts.iface, extra_slot.buf);
+	for (mr_idx = 0; mr_idx < num_mrs; mr_idx++) {
+		FT_CLOSE_FID(extra_slots[mr_idx].mr);
+		if (extra_slots[mr_idx].buf)
+			ft_hmem_free(opts.iface, extra_slots[mr_idx].buf);
+	}
+	free(extra_slots);
 	return ret;
 }
 
 /*
  * Test 3: Endpoint reuse after abort
  *
- * Re-register MRs, do a normal write + read round-trip.
+ * Re-register MRs, then do a normal write + read round-trip on every pair to
+ * show each local endpoint still works after the abort storm.
  */
-static int reuse_check_initiator(void)
+
+/* Block for one txcq completion; every reuse op must succeed outright. */
+static int reuse_wait_one_comp(const char *what)
+{
+	struct fi_cq_tagged_entry comp;
+	struct fi_cq_err_entry err;
+	int ret;
+
+	do {
+		ret = fi_cq_read(txcq, &comp, 1);
+		if (ret == -FI_EAVAIL) {
+			memset(&err, 0, sizeof(err));
+			fi_cq_readerr(txcq, &err, 0);
+			FT_ERR("Unexpected CQ error during reuse %s:", what);
+			FT_CQ_ERR(txcq, err, NULL, 0);
+			return -err.err;
+		}
+	} while (ret == -FI_EAGAIN);
+	if (ret < 0) {
+		FT_PRINTERR("fi_cq_read (reuse)", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+/*
+ * Write + read round-trip on pair p. The buffer comes from slot p % num_mrs
+ * because -W may leave fewer slots than pairs. Contains one ft_sync(), matched
+ * by reuse_check_target().
+ */
+static int reuse_check_one_pair(int p)
 {
 	struct fi_context2 reuse_ctx;
+	int slot = p % num_mrs;
+	int ret;
+
+	/* Write */
+	ret = ft_hmem_memset(opts.iface, opts.device, slots[slot].buf,
+			     0xAB, opts.transfer_size);
+	if (ret)
+		return ret;
+	ret = fi_write(local_ep_for_pair(p), slots[slot].buf, opts.transfer_size,
+		       slots[slot].desc, peer_addr_for_pair(p),
+		       remote_arr[slot].addr, remote_arr[slot].key, &reuse_ctx);
+	if (ret) {
+		FT_PRINTERR("fi_write (reuse)", ret);
+		return ret;
+	}
+
+	ret = reuse_wait_one_comp("write");
+	if (ret)
+		return ret;
+
+	ret = ft_sync();
+	if (ret)
+		return ret;
+
+	/* Read */
+	ret = ft_hmem_memset(opts.iface, opts.device, slots[slot].buf,
+			     0, opts.transfer_size);
+	if (ret)
+		return ret;
+	ret = fi_read(local_ep_for_pair(p), slots[slot].buf, opts.transfer_size,
+		      slots[slot].desc, peer_addr_for_pair(p),
+		      remote_arr[slot].addr, remote_arr[slot].key, &reuse_ctx);
+	if (ret) {
+		FT_PRINTERR("fi_read (reuse)", ret);
+		return ret;
+	}
+
+	return reuse_wait_one_comp("read");
+}
+
+static int reuse_check_initiator(void)
+{
 	struct fi_cq_tagged_entry comp;
 	struct fi_cq_err_entry err;
 	int i, ret;
@@ -1328,67 +1469,16 @@ static int reuse_check_initiator(void)
 	if (ret)
 		return ret;
 
-	/* Write */
-	ret = ft_hmem_memset(opts.iface, opts.device, slots[0].buf,
-			     0xAB, opts.transfer_size);
-	if (ret)
-		return ret;
-	ret = fi_write(ep, slots[0].buf, opts.transfer_size,
-		       slots[0].desc, remote_fi_addr,
-		       remote_arr[0].addr, remote_arr[0].key, &reuse_ctx);
-	if (ret) {
-		FT_PRINTERR("fi_write (reuse)", ret);
-		return ret;
-	}
-
-	do {
-		ret = fi_cq_read(txcq, &comp, 1);
-		if (ret == -FI_EAVAIL) {
-			memset(&err, 0, sizeof(err));
-			fi_cq_readerr(txcq, &err, 0);
-			FT_ERR("Unexpected CQ error during reuse write:");
-			FT_CQ_ERR(txcq, err, NULL, 0);
-			return -err.err;
+	for (i = 0; i < num_initiator_eps; i++) {
+		ret = reuse_check_one_pair(i);
+		if (ret) {
+			FT_INFO("Reuse: pair %d FAIL\n", i);
+			return ret;
 		}
-	} while (ret == -FI_EAGAIN);
-	if (ret < 0) {
-		FT_PRINTERR("fi_cq_read (reuse write)", ret);
-		return ret;
 	}
 
-	ret = ft_sync();
-	if (ret)
-		return ret;
-
-	/* Read */
-	ret = ft_hmem_memset(opts.iface, opts.device, slots[0].buf,
-			     0, opts.transfer_size);
-	if (ret)
-		return ret;
-	ret = fi_read(ep, slots[0].buf, opts.transfer_size,
-		      slots[0].desc, remote_fi_addr,
-		      remote_arr[0].addr, remote_arr[0].key, &reuse_ctx);
-	if (ret) {
-		FT_PRINTERR("fi_read (reuse)", ret);
-		return ret;
-	}
-
-	do {
-		ret = fi_cq_read(txcq, &comp, 1);
-		if (ret == -FI_EAVAIL) {
-			memset(&err, 0, sizeof(err));
-			fi_cq_readerr(txcq, &err, 0);
-			FT_ERR("Unexpected CQ error during reuse read:");
-			FT_CQ_ERR(txcq, err, NULL, 0);
-			return -err.err;
-		}
-	} while (ret == -FI_EAGAIN);
-	if (ret < 0) {
-		FT_PRINTERR("fi_cq_read (reuse read)", ret);
-		return ret;
-	}
-
-	FT_INFO("Reuse: write ok, read ok ... PASS\n");
+	FT_INFO("Reuse: write ok, read ok on %d pair(s) ... PASS\n",
+		num_initiator_eps);
 	return 0;
 }
 
@@ -1408,12 +1498,13 @@ static int reuse_check_target(void)
 	if (ret)
 		return ret;
 
-	/* Sync after initiator's write */
-	ret = ft_sync();
-	if (ret)
-		return ret;
+	/* One sync per pair, matching reuse_check_one_pair(). */
+	for (i = 0; i < num_initiator_eps; i++) {
+		ret = ft_sync();
+		if (ret)
+			return ret;
+	}
 
-	/* Initiator does read, no sync needed — target just keeps MRs alive */
 	return 0;
 }
 
@@ -2383,9 +2474,9 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-	/* Partial test only uses slot 0 + one extra MR */
+	/* One slot per pair; -W does not apply. */
 	if (test_mode == TEST_PARTIAL)
-		num_mrs = 1;
+		num_mrs = num_initiator_eps;
 
 	hints->caps = FI_MSG;
 	switch (test_mode) {

--- a/fabtests/prov/efa/src/mr_abort.c
+++ b/fabtests/prov/efa/src/mr_abort.c
@@ -73,6 +73,12 @@ enum test_mode {
 	TEST_TAGGED,
 };
 
+/* mr_abort-only long options, above the efa_shared and shared opt ranges. */
+enum {
+	OPT_NUM_TARGET_EPS = 512,
+	OPT_NUM_INITIATOR_EPS,
+};
+
 /*
  * Each MR slot can have ops_per_mr operations posted against it.
  * op_ctx tracks per-operation state; mr_slot tracks per-MR state.
@@ -134,6 +140,27 @@ static int close_ep_first;
 static int set_homogeneous_peers;
 static bool use_high_pps = false;
 static bool sl_low_latency = false;
+
+#define EFA_MR_ABORT_MAX_EPS 64
+
+static int num_target_eps = 1;
+static int num_initiator_eps = 1;
+static bool num_eps_set;
+static bool target_eps_set;
+static bool initiator_eps_set;
+
+static struct fid_ep *eps[EFA_MR_ABORT_MAX_EPS];
+static fi_addr_t *remote_ep_addrs;
+static int n_local_eps = 1;
+static int n_peer_eps = 1;
+
+/*
+ * Endpoint pairing built by build_ep_pairs(). Pairs are numbered by initiator
+ * endpoint: there are num_initiator_eps of them and pair p is (initiator ep p,
+ * target ep target_ep_for_pair[p]). Both sides build the identical array, so a pair
+ * index names the same pair on both ends.
+ */
+static int *target_ep_for_pair;
 
 /*
  * -r <file>: replay a previously dumped close order instead of generating
@@ -1880,6 +1907,96 @@ static int run_mr_abort_test(int is_initiator)
 	return ret;
 }
 
+/*
+ * Enumerate from the initiator's side on both sides: both know the endpoint
+ * counts, so both derive the same array with nothing exchanged over the wire.
+ * Since only 1:1 and incast are allowed (enforced in main()),
+ * efa_calc_peer_distribution() returns exactly one peer per initiator endpoint.
+ */
+static int build_ep_pairs(void)
+{
+	int i, n, ret;
+	int *target_ids;
+
+	target_ep_for_pair = calloc(num_initiator_eps, sizeof(*target_ep_for_pair));
+	if (!target_ep_for_pair)
+		return -FI_ENOMEM;
+
+	for (i = 0; i < num_initiator_eps; i++) {
+		ret = efa_calc_peer_distribution(i, num_initiator_eps,
+						 num_target_eps, &n,
+						 &target_ids);
+		if (ret)
+			return ret;
+
+		assert(n == 1);
+		target_ep_for_pair[i] = target_ids[0];
+		free(target_ids);
+	}
+
+	FT_INFO("endpoint pairing: %d initiator ep(s), %d target ep(s)",
+		num_initiator_eps, num_target_eps);
+	for (i = 0; i < num_initiator_eps; i++)
+		FT_DEBUG("  pair %d: initiator ep %d <-> target ep %d", i, i,
+			 target_ep_for_pair[i]);
+
+	return 0;
+}
+
+static int setup_eps(void)
+{
+	int i, ret;
+
+	n_local_eps = opts.dst_addr ? num_initiator_eps : num_target_eps;
+	n_peer_eps = opts.dst_addr ? num_target_eps : num_initiator_eps;
+
+	ret = build_ep_pairs();
+	if (ret)
+		return ret;
+
+	remote_ep_addrs = calloc(n_peer_eps, sizeof(*remote_ep_addrs));
+	if (!remote_ep_addrs)
+		return -FI_ENOMEM;
+
+	eps[0] = ep;
+	for (i = 1; i < n_local_eps; i++) {
+		ret = fi_endpoint(domain, fi, &eps[i], NULL);
+		if (ret) {
+			FT_PRINTERR("fi_endpoint", ret);
+			return ret;
+		}
+		ret = ft_enable_ep(eps[i], eq, av, txcq, rxcq,
+				   txcntr, rxcntr, rma_cntr);
+		if (ret)
+			return ret;
+	}
+
+	ret = efa_exchange_addrs_oob(oob_sock, opts.dst_addr != NULL,
+				     eps, n_local_eps, av, remote_ep_addrs,
+				     n_peer_eps);
+	if (ret)
+		return ret;
+
+	remote_fi_addr = remote_ep_addrs[0];
+	return 0;
+}
+
+static void teardown_eps(void)
+{
+	int i;
+
+	for (i = 1; i < n_local_eps; i++) {
+		if (eps[i]) {
+			fi_close(&eps[i]->fid);
+			eps[i] = NULL;
+		}
+	}
+	free(remote_ep_addrs);
+	remote_ep_addrs = NULL;
+	free(target_ep_for_pair);
+	target_ep_for_pair = NULL;
+}
+
 static int run(void)
 {
 	int ret;
@@ -1888,12 +2005,19 @@ static int run(void)
 	if (close_side == CLOSE_TARGET || opts.rma_op == FT_RMA_WRITEDATA)
 		cq_attr.format = FI_CQ_FORMAT_DATA;
 
+	opts.options |= FT_OPT_SKIP_ADDR_EXCH;
+
 	ret = ft_init_fabric();
+	if (ret)
+		return ret;
+
+	ret = setup_eps();
 	if (ret)
 		return ret;
 
 	if (set_homogeneous_peers) {
 		bool homogeneous = true;
+		int i;
 		/*
 		 * Tell the EP all peers are homogeneous so it skips the
 		 * handshake requirement before using an extra-feature,
@@ -1902,6 +2026,10 @@ static int run(void)
 		 * send, so the target is reliably owed -- and can enforce via
 		 * -X -- exactly one completion per op.
 		 *
+		 * Set on every local endpoint: the option is per-EP, so an EP
+		 * left without it would still handshake and make the -X contract
+		 * depend on which endpoint an op was routed to.
+		 *
 		 * Normally this option is set before fi_enable(), but
 		 * ft_init_fabric() has already enabled the EP. Setting it here
 		 * is still correct: EFA's setopt handler has no enable-state
@@ -1909,12 +2037,14 @@ static int run(void)
 		 * (efa_rdm_msg_post_rtm), not at enable. No send has been posted
 		 * yet at this point, so the value is in effect for every op.
 		 */
-		ret = fi_setopt(&ep->fid, FI_OPT_ENDPOINT,
-				FI_OPT_EFA_HOMOGENEOUS_PEERS,
-				&homogeneous, sizeof(homogeneous));
-		if (ret) {
-			FT_PRINTERR("fi_setopt(HOMOGENEOUS_PEERS)", ret);
-			return ret;
+		for (i = 0; i < n_local_eps; i++) {
+			ret = fi_setopt(&eps[i]->fid, FI_OPT_ENDPOINT,
+					FI_OPT_EFA_HOMOGENEOUS_PEERS,
+					&homogeneous, sizeof(homogeneous));
+			if (ret) {
+				FT_PRINTERR("fi_setopt(HOMOGENEOUS_PEERS)", ret);
+				return ret;
+			}
 		}
 	}
 
@@ -1927,10 +2057,20 @@ static int run(void)
 	/*
 	 * Target teardown order: EFA requires the endpoint to be closed
 	 * before recv buffer MRs can be deregistered. Use -A ep_first
-	 * to close the EP before freeing test MRs.
+	 * to close the EP before freeing test MRs. eps[0] == ep is closed
+	 * by ft_free_res(); the extra EPs are closed here.
 	 */
-	if (close_ep_first && !opts.dst_addr)
+	if (close_ep_first && !opts.dst_addr) {
+		int i;
+
+		for (i = 1; i < n_local_eps; i++) {
+			if (eps[i]) {
+				FT_CLOSE_FID(eps[i]);
+				eps[i] = NULL;
+			}
+		}
 		FT_CLOSE_FID(ep);
+	}
 
 	if (!ret)
 		ret = free_test_res();
@@ -1940,7 +2080,40 @@ static int run(void)
 	if (!ret)
 		ft_finalize();
 
+	teardown_eps();
+
 	return ret;
+}
+
+/* mr_abort-only options appended to the shared efa_long_opts table. */
+static struct option mr_abort_extra_opts[] = {
+	{"num-target-eps", required_argument, NULL, OPT_NUM_TARGET_EPS},
+	{"num-initiator-eps", required_argument, NULL, OPT_NUM_INITIATOR_EPS},
+	{0, 0, 0, 0}
+};
+
+static struct option *mr_abort_long_opts;
+
+static int build_mr_abort_long_opts(void)
+{
+	int efa_cnt, extra_cnt, i;
+
+	build_efa_long_opts();
+
+	for (efa_cnt = 0; efa_long_opts[efa_cnt].name; efa_cnt++)
+		;
+	extra_cnt = sizeof(mr_abort_extra_opts) / sizeof(mr_abort_extra_opts[0]) - 1;
+
+	mr_abort_long_opts = calloc(efa_cnt + extra_cnt + 1, sizeof(struct option));
+	if (!mr_abort_long_opts)
+		return -FI_ENOMEM;
+
+	for (i = 0; i < extra_cnt; i++)
+		mr_abort_long_opts[i] = mr_abort_extra_opts[i];
+	for (i = 0; i < efa_cnt; i++)
+		mr_abort_long_opts[extra_cnt + i] = efa_long_opts[i];
+
+	return 0;
 }
 
 int main(int argc, char **argv)
@@ -1952,7 +2125,8 @@ int main(int argc, char **argv)
 	opts.transfer_size = 4096; /* 4KB default — override with -S */
 	opts.iterations = 10;
 	opts.cqdata_op = 0;
-	build_efa_long_opts();
+	if (build_mr_abort_long_opts())
+		return EXIT_FAILURE;
 
 	hints = fi_allocinfo();
 	if (!hints)
@@ -1962,13 +2136,25 @@ int main(int argc, char **argv)
 
 	while ((op = getopt_long(argc, argv,
 				 "W:N:C:R:T:A:r:XHh" CS_OPTS INFO_OPTS API_OPTS,
-				 efa_long_opts, &lopt_idx)) != -1) {
+				 mr_abort_long_opts, &lopt_idx)) != -1) {
 		switch (op) {
 		case OPT_HIGH_PPS:
 			use_high_pps = true;
 			break;
 		case OPT_SL_LOW_LATENCY:
 			sl_low_latency = true;
+			break;
+		case OPT_NUM_EPS:
+			num_target_eps = num_initiator_eps = atoi(optarg);
+			num_eps_set = true;
+			break;
+		case OPT_NUM_TARGET_EPS:
+			num_target_eps = atoi(optarg);
+			target_eps_set = true;
+			break;
+		case OPT_NUM_INITIATOR_EPS:
+			num_initiator_eps = atoi(optarg);
+			initiator_eps_set = true;
 			break;
 		case 'W':
 			num_mrs = atoi(optarg);
@@ -2069,6 +2255,11 @@ int main(int argc, char **argv)
 				"Aborted send/tagged ops are owed a target "
 				"recv completion (LONGCTS/LONGREAD); only "
 				"valid with -T send|tagged");
+			FT_PRINT_OPTS_USAGE("--num-target-eps <n>",
+				"Number of endpoints on the target side");
+			FT_PRINT_OPTS_USAGE("--num-initiator-eps <n>",
+				"Number of endpoints on the initiator side "
+				"(>= --num-target-eps; incast)");
 			efa_longopts_usage();
 			return EXIT_FAILURE;
 		}
@@ -2079,6 +2270,29 @@ int main(int argc, char **argv)
 
 	if (num_mrs <= 0 || ops_per_mr <= 0) {
 		FT_ERR("-W and -N must be positive");
+		return EXIT_FAILURE;
+	}
+
+	if (num_eps_set && (target_eps_set || initiator_eps_set)) {
+		FT_ERR("use --num-eps OR --num-target-eps/--num-initiator-eps, "
+		       "not both");
+		return EXIT_FAILURE;
+	}
+
+	if (num_target_eps < 1 || num_target_eps > EFA_MR_ABORT_MAX_EPS ||
+	    num_initiator_eps < 1 || num_initiator_eps > EFA_MR_ABORT_MAX_EPS) {
+		FT_ERR("endpoint counts must be 1-%d", EFA_MR_ABORT_MAX_EPS);
+		return EXIT_FAILURE;
+	}
+
+	/*
+	 * Outcast would give an initiator endpoint more than one peer, so a pair
+	 * index would no longer name one pair. build_ep_pairs() relies on that.
+	 */
+	if (num_initiator_eps < num_target_eps) {
+		FT_ERR("outcast is not supported: --num-initiator-eps (%d) must be "
+		       ">= --num-target-eps (%d)", num_initiator_eps,
+		       num_target_eps);
 		return EXIT_FAILURE;
 	}
 


### PR DESCRIPTION
This PR has a series of commits that introduce multiple initiator and target endpoints for all of the variants of the mr_abort test.

Support is added only for symmetric tests (number of initiator endpoints = number of target endpoints) and incast style tests (number of initiator endpoints > number of target endpoints). Outcast style tests are not supported.

For abort style tests, each endpoint pair operates independently. For partial tests, all of the writes and MR closes for all endpoint pairs happen first. The completions for all endpoint pairs are drained later.

The final commit adds parametrizations to test_mr_abort.py with 16 initiator and target endpoints (symmetric) and 16 initiator endpoints with a single target endpoint (incast).

All of the endpoints are on the same domain. Tests that open endpoints on multiple domains will be added in the future.

This PR does not add any tests to `test_mr_abort.py` that use multiple endpoints. That will also be done in future PRs.