### PR TITLE
[v2.5.x] prov/efa: Strip stale FI_MORE when processing queued opes

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -1976,6 +1976,13 @@ int efa_rdm_ope_process_queued_ope(struct efa_rdm_ope *ope, uint32_t flag)
 	if (!(ope->internal_flags & flag))
 		return 0;
 
+	/*
+	 * Strip stale FI_MORE: the flushing (non-FI_MORE) operation that followed
+	 * this ope may have already been posted while it sat in the queue. Replaying
+	 * FI_MORE now could leave WQEs staged with no later post to ring the doorbell.
+	 */
+	ope->fi_flags &= ~FI_MORE;
+
 	switch (flag) {
 	case EFA_RDM_OPE_QUEUED_BEFORE_HANDSHAKE:
 		ret = efa_rdm_ope_repost_ope_queued_before_handshake(ope);


### PR DESCRIPTION
An operation posted with FI_MORE defers the doorbell until a later operation without FI_MORE is posted on the same endpoint. When an operation is instead queued in software (e.g. waiting for the peer handshake in efa_rdm_ep_enforce_handshake_for_txe), its fi_flags are preserved and replayed by the progress engine once the deferral resolves. By that time the application's flushing (non-FI_MORE) operation might have already been posted and doorbelled, so the replayed batch can consist entirely of FI_MORE operations. Their WQEs are then staged in the send queue but the doorbell is never rung, the operations never complete, and the transfer hangs.

Fix by clearing FI_MORE from ope->fi_flags before reposting a queued ope. The batching benefit is already lost for deferred operations, so always flushing is safe.

This bug impacts all queue'ed operations (send/read/write), which get queue'ed for any reason (handshake/RNR/etc..)

Backport of 3b01e141 from main. The gtest unit tests were dropped as v2.5.x does not have the gtest infrastructure.