### PR TITLE
prov/util: Add dedicated lock for unspec unexpected queues

### DIFF
--- a/include/ofi_util.h
+++ b/include/ofi_util.h
@@ -1356,6 +1356,7 @@ struct util_srx_ctx {
 
 	struct ofi_bufpool	*rx_pool;
 	struct ofi_genlock	*lock;
+	struct ofi_genlock	unspec_lock;
 };
 
 struct util_match_attr {

--- a/prov/efa/test/efa_unit_test_srx.c
+++ b/prov/efa/test/efa_unit_test_srx.c
@@ -196,8 +196,6 @@ void test_efa_srx_foreach_unspec_skips_other_provider(void **state)
 	/* Enable directed receive so foreach_unspec will move resolved entries */
 	srx_ctx->dir_recv = true;
 
-	ofi_genlock_lock(srx_ctx->lock);
-
 	/* Allocate entries for the unspec msg queue */
 	msg_entry_efa = (struct util_rx_entry *) ofi_buf_alloc(srx_ctx->rx_pool);
 	assert_non_null(msg_entry_efa);
@@ -292,8 +290,6 @@ void test_efa_srx_foreach_unspec_skips_other_provider(void **state)
 	efa_peer_ops->discard_tag = test_foreach_unspec_discard_no_op;
 	shm_peer_ops->discard_msg = test_foreach_unspec_discard_no_op;
 	shm_peer_ops->discard_tag = test_foreach_unspec_discard_no_op;
-
-	ofi_genlock_unlock(srx_ctx->lock);
 
 	/* ep close will call util_srx_close which drains remaining entries */
 	fi_close(&resource->ep->fid);

--- a/prov/rxm/src/rxm_domain.c
+++ b/prov/rxm/src/rxm_domain.c
@@ -239,9 +239,7 @@ static void rxm_foreach_ep(struct util_av *av, struct util_ep *ep)
 	rxm_ep = container_of(ep, struct rxm_ep, util_ep);
 	peer_srx = container_of(rxm_ep->srx, struct fid_peer_srx, ep_fid);
 	if (peer_srx) {
-		ofi_genlock_lock(&rxm_ep->util_ep.lock);
 		peer_srx->owner_ops->foreach_unspec_addr(peer_srx, &rxm_get_addr);
-		ofi_genlock_unlock(&rxm_ep->util_ep.lock);
 	}
 }
 

--- a/prov/shm/src/smr_av.c
+++ b/prov/shm/src/smr_av.c
@@ -443,10 +443,8 @@ static int smr_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 			smr_ep->region->max_sar_buf_per_peer =
 				MIN(SMR_BUF_BATCH_MAX,
 				    SMR_MAX_PEERS / smr_av->smr_map.num_peers);
-			ofi_genlock_lock(&util_ep->lock);
 			smr_ep->srx->owner_ops->foreach_unspec_addr(
 						smr_ep->srx, &smr_get_addr);
-			ofi_genlock_unlock(&util_ep->lock);
 		}
 	}
 	ofi_genlock_unlock(&util_av->lock);

--- a/prov/sm2/src/sm2_av.c
+++ b/prov/sm2/src/sm2_av.c
@@ -120,9 +120,7 @@ static int sm2_av_insert(struct fid_av *av_fid, const void *addr, size_t count,
 		util_ep = container_of(av_entry, struct util_ep, av_entry);
 		sm2_ep = container_of(util_ep, struct sm2_ep, util_ep);
 		srx = sm2_get_peer_srx(sm2_ep);
-		ofi_genlock_lock(&sm2_ep->util_ep.lock);
 		srx->owner_ops->foreach_unspec_addr(srx, &sm2_get_addr);
-		ofi_genlock_unlock(&sm2_ep->util_ep.lock);
 	}
 
 	return succ_count;

--- a/prov/util/src/util_srx.c
+++ b/prov/util/src/util_srx.c
@@ -347,8 +347,10 @@ static int util_queue_msg(struct fi_peer_rx_entry *rx_entry)
 	util_entry = container_of(rx_entry, struct util_rx_entry, peer_entry);
 	assert(util_entry->status == RX_ENTRY_UNEXP);
 	if (!srx_ctx->dir_recv || rx_entry->addr == FI_ADDR_UNSPEC) {
+		ofi_genlock_lock(&srx_ctx->unspec_lock);
 		dlist_insert_tail(&util_entry->d_entry,
 				  &srx_ctx->unspec_unexp_msg_queue);
+		ofi_genlock_unlock(&srx_ctx->unspec_lock);
 	} else {
 		unexp_peer = ofi_array_at(&srx_ctx->src_unexp_peers,
 					  rx_entry->addr);
@@ -372,8 +374,10 @@ static int util_queue_tag(struct fi_peer_rx_entry *rx_entry)
 	util_entry = container_of(rx_entry, struct util_rx_entry, peer_entry);
 	assert(util_entry->status == RX_ENTRY_UNEXP);
 	if (!srx_ctx->dir_recv || rx_entry->addr == FI_ADDR_UNSPEC) {
+		ofi_genlock_lock(&srx_ctx->unspec_lock);
 		dlist_insert_tail(&util_entry->d_entry,
 				  &srx_ctx->unspec_unexp_tag_queue);
+		ofi_genlock_unlock(&srx_ctx->unspec_lock);
 	} else {
 		unexp_peer = ofi_array_at(&srx_ctx->src_unexp_peers,
 					  rx_entry->addr);
@@ -450,7 +454,7 @@ static void util_foreach_unspec(struct fid_peer_srx *srx,
 
 	srx_ctx = srx->ep_fid.fid.context;
 
-	assert(ofi_genlock_held(srx_ctx->lock));
+	ofi_genlock_lock(&srx_ctx->unspec_lock);
 	dlist_foreach_container_safe(&srx_ctx->unspec_unexp_msg_queue,
 				     struct util_rx_entry, rx_entry, d_entry,
 				     tmp) {
@@ -490,6 +494,7 @@ static void util_foreach_unspec(struct fid_peer_srx *srx,
 			dlist_insert_tail(&unexp_peer->entry,
 					  &srx_ctx->unexp_peers);
 	}
+	ofi_genlock_unlock(&srx_ctx->unspec_lock);
 }
 
 static struct fi_ops_srx_owner util_srx_owner_ops = {
@@ -525,10 +530,12 @@ static struct util_rx_entry *util_search_unexp_msg(struct util_srx_ctx *srx,
 	struct util_unexp_peer *unexp_peer;
 
 	if (addr == FI_ADDR_UNSPEC) {
+		ofi_genlock_lock(&srx->unspec_lock);
 		if (!dlist_empty(&srx->unspec_unexp_msg_queue)) {
 			dlist_pop_front(&srx->unspec_unexp_msg_queue,
 					struct util_rx_entry, rx_entry,
 					d_entry);
+			ofi_genlock_unlock(&srx->unspec_lock);
 			return rx_entry;
 		}
 
@@ -536,9 +543,12 @@ static struct util_rx_entry *util_search_unexp_msg(struct util_srx_ctx *srx,
 					struct util_unexp_peer, unexp_peer,
 					entry) {
 			rx_entry = util_search_peer_msg(unexp_peer);
-			if (rx_entry)
+			if (rx_entry) {
+				ofi_genlock_unlock(&srx->unspec_lock);
 				return rx_entry;
+			}
 		}
+		ofi_genlock_unlock(&srx->unspec_lock);
 		return NULL;
 	}
 
@@ -652,6 +662,7 @@ static struct util_rx_entry *util_search_unexp_tag(struct util_srx_ctx *srx,
 	struct util_unexp_peer *unexp_peer;
 
 	if (addr == FI_ADDR_UNSPEC) {
+		ofi_genlock_lock(&srx->unspec_lock);
 		dlist_foreach_container(&srx->unspec_unexp_tag_queue,
 					struct util_rx_entry, rx_entry,
 					d_entry) {
@@ -662,6 +673,7 @@ static struct util_rx_entry *util_search_unexp_tag(struct util_srx_ctx *srx,
 			if (remove)
 				dlist_remove(&rx_entry->d_entry);
 
+			ofi_genlock_unlock(&srx->unspec_lock);
 			return rx_entry;
 		}
 
@@ -669,9 +681,12 @@ static struct util_rx_entry *util_search_unexp_tag(struct util_srx_ctx *srx,
 				struct util_unexp_peer, unexp_peer, entry) {
 			rx_entry = util_search_peer_tag(unexp_peer, tag,
 							ignore, remove);
-			if (rx_entry)
+			if (rx_entry) {
+				ofi_genlock_unlock(&srx->unspec_lock);
 				return rx_entry;
+			}
 		}
+		ofi_genlock_unlock(&srx->unspec_lock);
 		return NULL;
 	}
 
@@ -1058,6 +1073,7 @@ int util_srx_close(struct fid *fid)
 	ofi_bufpool_destroy(srx->rx_pool);
 
 	ofi_genlock_unlock(srx->lock);
+	ofi_genlock_destroy(&srx->unspec_lock);
 	free(srx);
 
 	return FI_SUCCESS;
@@ -1222,6 +1238,14 @@ int util_ep_srx_context(struct util_domain *domain, size_t rx_size,
 	dlist_init(&srx->unspec_unexp_tag_queue);
 	dlist_init(&srx->unexp_peers);
 
+	ret = ofi_genlock_init(&srx->unspec_lock,
+			       domain->threading == FI_THREAD_DOMAIN ?
+			       OFI_LOCK_NOOP : OFI_LOCK_MUTEX);
+	if (ret) {
+		free(srx);
+		return ret;
+	}
+
 	ofi_array_init(&srx->src_recv_queues, sizeof(struct slist),
 		       util_srx_init_slist);
 	ofi_array_init(&srx->src_trecv_queues, sizeof(struct slist),
@@ -1242,6 +1266,7 @@ int util_ep_srx_context(struct util_domain *domain, size_t rx_size,
 	pool_attr.context = srx;
 	ret = ofi_bufpool_create_attr(&pool_attr, &srx->rx_pool);
 	if (ret) {
+		ofi_genlock_destroy(&srx->unspec_lock);
 		free(srx);
 		return ret;
 	}


### PR DESCRIPTION
Under FI_THREAD_COMPLETION, providers could set SRX context lock as a
NOOP on the data path. However, AV insert (foreach_unspec_addr)
and CQ progress (queue_msg/queue_tag) can race on the unspec unexpected
queues.

Add a dedicated unspec_lock to util_srx_ctx. It is NOOP only under
FI_THREAD_DOMAIN (where the app serializes all domain calls) and a
real mutex for all other threading levels. Acquire it where unspec
queues are modified.

This keeps the fast path lock-free under FI_THREAD_COMPLETION while
correctly protecting the only queues where AV and progress threads actually race.