### PR TITLE
fabtests: Add --randomize-test-order to run tests in a random order

### DIFF
--- a/fabtests/pytest/conftest.py
+++ b/fabtests/pytest/conftest.py
@@ -40,6 +40,19 @@ def pytest_addoption(parser):
                              help=option_helpmsg, default=option_default)
 
 
+@pytest.hookimpl(trylast=True)
+def pytest_collection_modifyitems(session, config, items):
+    '''
+        Establish the final test order for every provider. Implements the
+        logic to run tests that marked with the run_last marker to run
+        at the end of the session.
+    '''
+    run_last = [item for item in items if item.get_closest_marker("run_last")]
+    if run_last:
+        items[:] = [item for item in items
+                    if not item.get_closest_marker("run_last")] + run_last
+
+
 class CmdlineArgs:
 
     def __init__(self, request):

--- a/fabtests/pytest/conftest.py
+++ b/fabtests/pytest/conftest.py
@@ -1,5 +1,6 @@
 import builtins
 import os
+import random
 import re
 import shlex
 
@@ -40,13 +41,62 @@ def pytest_addoption(parser):
                              help=option_helpmsg, default=option_default)
 
 
+randomize_seed_key = pytest.StashKey[int]()
+
+def get_randomize_seed(config):
+    '''
+        the seed used to randomize the test order, or None when the test order
+        is not randomized
+    '''
+    return config.stash.get(randomize_seed_key, None)
+
+def pytest_configure(config):
+    if not config.getoption("--randomize-test-order"):
+        return
+
+    if hasattr(config, "workerinput"):
+        # xdist worker: use the seed the controller generated. Every worker
+        # collects the tests independently, so they must all shuffle the same
+        # way or xdist fails the run with "Different tests were collected".
+        seed = int(config.workerinput["randomize_seed"])
+    else:
+        seed = config.getoption("--randomize-seed")
+        if seed is None:
+            seed = random.Random().randrange(2 ** 31)
+
+    config.stash[randomize_seed_key] = seed
+
+def pytest_configure_node(node):
+    '''
+        xdist hook, called on the controller for each worker it starts. Not
+        called at all in a serial run.
+    '''
+    seed = get_randomize_seed(node.config)
+    if seed is not None:
+        node.workerinput["randomize_seed"] = seed
+
+def pytest_report_header(config):
+    seed = get_randomize_seed(config)
+    if seed is None:
+        return None
+
+    return "randomized test order, seed {} (reproduce with " \
+           "--randomize-test-order --randomize-seed={})".format(seed, seed)
+
 @pytest.hookimpl(trylast=True)
 def pytest_collection_modifyitems(session, config, items):
     '''
         Establish the final test order for every provider. Implements the
         logic to run tests that marked with the run_last marker to run
         at the end of the session.
+
+        If --randomize-test-order is set, the collected tests are shuffled
+        first so that tests marked with run_last still run at the end.
     '''
+    seed = get_randomize_seed(config)
+    if seed is not None:
+        random.Random(seed).shuffle(items)
+
     run_last = [item for item in items if item.get_closest_marker("run_last")]
     if run_last:
         items[:] = [item for item in items

--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -283,9 +283,10 @@ def device_has_hw_cntr(host_id):
     return False
 
 
-@pytest.hookimpl(hookwrapper=True)
 def pytest_collection_modifyitems(session, config, items):
-    # Called after collection has been performed, may filter or re-order the items in-place
+    # Called after collection has been performed, deselects tests whose
+    # required binary or device support is missing. Test ordering is handled
+    # by the shared hook in the parent conftest.
     binpath = config.getoption("--binpath", default="") or ""
     server_id = config.getoption("--server-id", default="")
     client_id = config.getoption("--client-id", default="")
@@ -316,16 +317,6 @@ def pytest_collection_modifyitems(session, config, items):
     if deselected:
         config.hook.pytest_deselected(items=deselected)
         items[:] = remaining
-
-    # We use this hook to always run the MR exhaustion test at the end
-    mr_exhaustion_tests, other_tests = [], []
-    for item in items:
-        if "mr_exhaustion" in item.name:
-            mr_exhaustion_tests.append(item)
-        else:
-            other_tests.append(item)
-
-    yield other_tests + mr_exhaustion_tests
 
 
 @pytest.fixture(scope="function")

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -194,6 +194,7 @@ def test_rdm_pingpong_sread(cmdline_args, completion_semantic, memory_type_bi_di
 # do memory registrations on behalf of the application
 @pytest.mark.functional
 @pytest.mark.serial
+@pytest.mark.run_last
 def test_mr_exhaustion_rdm_pingpong(cmdline_args, completion_semantic):
     import os
     binpath = cmdline_args.binpath or ""

--- a/fabtests/pytest/options.yaml
+++ b/fabtests/pytest/options.yaml
@@ -96,3 +96,9 @@ do_dmabuf_reg_for_hmem:
   type: boolean
   help: "Register hmem memory via dmabuf"
   longform: --do-dmabuf-reg-for-hmem
+randomize_test_order:
+  type: boolean
+  help: "Run the tests in a random order. Default: no"
+randomize_seed:
+  type: int
+  help: "Seed used to randomize the test order. Only meaningful together with\n--randomize-test-order. Defaults to a randomly generated seed, which is\nreported in the pytest header so a run can be reproduced."

--- a/fabtests/pytest/pytest.ini
+++ b/fabtests/pytest/pytest.ini
@@ -19,6 +19,7 @@ markers =
     hw_cntr: test requires fi_efa_hw_cntr binary (built with efadv_create_comp_cntr)
     gda: test requires fi_efa_gda binary (built with --enable-efagda)
     pre_release: test requires pre-release firmware, skip unless explicitly requested
+    run_last: test must run at the end of the session
 junit_suite_name = fabtests
 junit_logging = all
 junit_log_passing_tests = true


### PR DESCRIPTION
Running the tests in a fixed order hides bugs that only appear in a
particular sequence, and hides tests that only pass because an earlier test
left useful state behind. Add an option to shuffle the collected tests.

Randomization is off by default to not affect current tests. It can be
turned on by default in the future.