### PR TITLE
contrib/aws: Use ami with pre-installed EFA Installer

### DIFF
--- a/contrib/aws/Jenkinsfile
+++ b/contrib/aws/Jenkinsfile
@@ -326,7 +326,7 @@ pipeline {
                     def stages = [:]
                     def timeout = "--timeout 90"
                     def test_suite_pkg = "--test-suite-package subspace_nightly_tests --owner subspace"
-                    def generic_pf = "--cluster-type manual_cluster --test-target libfabric --test-type pr --test-libfabric-pr $env.CHANGE_ID ${test_suite_pkg}"
+                    def generic_pf = "--cluster-type manual_cluster --test-target libfabric --test-type pr --test-libfabric-pr $env.CHANGE_ID ${test_suite_pkg} --use-prebuilt-ami-with-efa-installer true"
                     def unit_tests = "--test-list test_run_efa_unit_tests"
                     def pr_ci_tests = "--test-list test_pr_ci_fabtests test_run_efa_unit_tests"
                     def pr_ci_tests_hpc = "--test-list test_pr_ci_fabtests test_pr_ci_imb test_run_efa_unit_tests"


### PR DESCRIPTION
This will reduce PR CI run time by ~3 min and improve stability.


(cherry picked from commit ace855ecddbcca4d5caf4096c7abfa825b9d6535)