### PR TITLE
prov/efa: Remove srx lock from AV operations and EP enable 

### DIFF
--- a/prov/efa/src/efa_ah.c
+++ b/prov/efa/src/efa_ah.c
@@ -9,8 +9,6 @@
 #include "rdm/efa_rdm_domain.h"
 #include <infiniband/efadv.h>
 
-void efa_ah_destroy_ah(struct efa_domain *domain, struct efa_ah *ah);
-
 /**
  * @brief Move the AH to the end of the LRU list to indicate that it is the
  * most recently used entry
@@ -25,6 +23,7 @@ void efa_ah_destroy_ah(struct efa_domain *domain, struct efa_ah *ah);
  */
 void efa_ah_implicit_av_lru_ah_move(struct efa_domain *domain,
 					struct efa_ah *ah)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
 {
 	struct efa_rdm_domain *rdm_domain;
 
@@ -51,6 +50,7 @@ static inline int efa_ah_implicit_av_evict_ah(struct efa_domain *domain,
 	struct efa_rdm_domain *rdm_domain;
 
 	assert(domain->info_type == EFA_INFO_RDM);
+	assert(ofi_genlock_held(&domain->util_domain.lock));
 	rdm_domain = (struct efa_rdm_domain *) domain;
 
 	dlist_foreach_container (&rdm_domain->ah_lru_list, struct efa_ah, ah_tmp,
@@ -128,6 +128,7 @@ static void efa_ah_warn_create_einval(struct efa_domain *domain, const uint8_t *
  */
 struct efa_ah *efa_ah_alloc(struct efa_domain *domain, const uint8_t *gid,
 			    bool insert_implicit_av)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
 {
 	struct ibv_pd *ibv_pd = domain->ibv_pd;
 	struct efa_ah *efa_ah;
@@ -227,6 +228,7 @@ err_free_efa_ah:
 }
 
 void efa_ah_destroy_ah(struct efa_domain *domain, struct efa_ah *ah)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
 {
 	int err;
 
@@ -251,6 +253,7 @@ void efa_ah_destroy_ah(struct efa_domain *domain, struct efa_ah *ah)
  */
 void efa_ah_release(struct efa_domain *domain, struct efa_ah *ah,
 		    bool release_from_implicit_av)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
 {
 #if ENABLE_DEBUG
 	struct efa_ah *tmp;

--- a/prov/efa/src/efa_ah.c
+++ b/prov/efa/src/efa_ah.c
@@ -29,6 +29,7 @@ void efa_ah_implicit_av_lru_ah_move(struct efa_domain *domain,
 	struct efa_rdm_domain *rdm_domain;
 
 	assert(domain->info_type == EFA_INFO_RDM);
+	assert(ofi_genlock_held(&domain->util_domain.lock));
 
 	rdm_domain = (struct efa_rdm_domain *) domain;
 	assert(ah->implicit_refcnt > 0 || ah->explicit_refcnt > 0);
@@ -138,13 +139,11 @@ struct efa_ah *efa_ah_alloc(struct efa_domain *domain, const uint8_t *gid,
 
 	efa_ah = NULL;
 
-	ofi_genlock_lock(&domain->util_domain.lock);
 	HASH_FIND(hh, domain->ah_map, gid, EFA_GID_LEN, efa_ah);
 	if (efa_ah) {
 		insert_implicit_av ? efa_ah->implicit_refcnt++ : efa_ah->explicit_refcnt++;
 		if (domain->info_type == EFA_INFO_RDM)
 			efa_ah_implicit_av_lru_ah_move(domain, efa_ah);
-		ofi_genlock_unlock(&domain->util_domain.lock);
 		return efa_ah;
 	}
 
@@ -152,7 +151,6 @@ struct efa_ah *efa_ah_alloc(struct efa_domain *domain, const uint8_t *gid,
 	if (!efa_ah) {
 		errno = FI_ENOMEM;
 		EFA_WARN(FI_LOG_AV, "cannot allocate memory for efa_ah\n");
-		ofi_genlock_unlock(&domain->util_domain.lock);
 		return NULL;
 	}
 
@@ -219,14 +217,12 @@ struct efa_ah *efa_ah_alloc(struct efa_domain *domain, const uint8_t *gid,
 	efa_ah->ahn = efa_ah_attr.ahn;
 	memcpy(efa_ah->gid, gid, EFA_GID_LEN);
 	HASH_ADD(hh, domain->ah_map, gid, EFA_GID_LEN, efa_ah);
-	ofi_genlock_unlock(&domain->util_domain.lock);
 	return efa_ah;
 
 err_destroy_ibv_ah:
 	ibv_destroy_ah(efa_ah->ibv_ah);
 err_free_efa_ah:
 	free(efa_ah);
-	ofi_genlock_unlock(&domain->util_domain.lock);
 	return NULL;
 }
 
@@ -256,13 +252,13 @@ void efa_ah_destroy_ah(struct efa_domain *domain, struct efa_ah *ah)
 void efa_ah_release(struct efa_domain *domain, struct efa_ah *ah,
 		    bool release_from_implicit_av)
 {
-	ofi_genlock_lock(&domain->util_domain.lock);
 #if ENABLE_DEBUG
 	struct efa_ah *tmp;
 
 	HASH_FIND(hh, domain->ah_map, ah->gid, EFA_GID_LEN, tmp);
 	assert(tmp == ah);
 #endif
+	assert(ofi_genlock_held(&domain->util_domain.lock));
 	assert((release_from_implicit_av && ah->implicit_refcnt > 0) ||
 	       (!release_from_implicit_av && ah->explicit_refcnt > 0));
 
@@ -272,5 +268,4 @@ void efa_ah_release(struct efa_domain *domain, struct efa_ah *ah,
 	if (ah->implicit_refcnt == 0 && ah->explicit_refcnt == 0) {
 		efa_ah_destroy_ah(domain, ah);
 	}
-	ofi_genlock_unlock(&domain->util_domain.lock);
 }

--- a/prov/efa/src/efa_ah.h
+++ b/prov/efa/src/efa_ah.h
@@ -14,26 +14,29 @@ struct efa_ah {
 	struct ibv_ah	*ibv_ah; /* created by ibv_create_ah() using GID */
 	uint16_t	ahn; /* adress handle number */
 	/* Number of explicit AV entries associated with this AH */
-	int explicit_refcnt;
+	int explicit_refcnt OFI_TSA_GUARDED_BY(efa_util_domain_lock_sym);
 	/* Number of implicit AV entries associated with this AH */
-	int implicit_refcnt;
+	int implicit_refcnt OFI_TSA_GUARDED_BY(efa_util_domain_lock_sym);
 	/* dlist of all implicit AV entries associated with this AH entry */
-	struct dlist_entry implicit_conn_list;
+	struct dlist_entry implicit_conn_list OFI_TSA_GUARDED_BY(efa_util_domain_lock_sym);
 	/* dlist entry in domain's LRU AH list */
-	struct dlist_entry domain_lru_ah_list_entry;
+	struct dlist_entry domain_lru_ah_list_entry OFI_TSA_GUARDED_BY(efa_util_domain_lock_sym);
 	UT_hash_handle	hh; /* hash map handle, link all efa_ah with efa_ep->ah_map */
 };
 
+void efa_ah_destroy_ah(struct efa_domain *domain, struct efa_ah *ah)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym);
+
 void efa_ah_implicit_av_lru_ah_move(struct efa_domain *domain,
-					struct efa_ah *ah);
+					struct efa_ah *ah)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym);
 
 struct efa_ah *efa_ah_alloc(struct efa_domain *domain, const uint8_t *gid,
-			    bool insert_implicit_av);
+			    bool insert_implicit_av)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym);
 
 void efa_ah_release(struct efa_domain *domain, struct efa_ah *ah,
-		    bool release_from_implicit_av);
-
-void efa_ah_release_unsafe(struct efa_domain *domain, struct efa_ah *ah,
-			   bool release_from_implicit_av);
+		    bool release_from_implicit_av)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym);
 
 #endif

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -69,6 +69,7 @@ struct efa_conn *efa_av_addr_to_conn_implicit(struct efa_av *av, fi_addr_t fi_ad
  * 		If no such peer exist, return FI_ADDR_NOTAVAIL
  */
 fi_addr_t efa_av_reverse_lookup(struct efa_av *av, uint16_t ahn, uint16_t qpn)
+	OFI_TSA_NO_ANALYSIS // DGRAM uses FI_THREAD_DOMAIN, efa direct doesn't acquire the lock
 {
 	struct efa_cur_reverse_av *cur_entry;
 	struct efa_cur_reverse_av_key cur_key;
@@ -153,14 +154,15 @@ fi_addr_t efa_av_reverse_lookup_rdm(struct efa_av *av, uint16_t ahn,
 				    uint16_t qpn, struct efa_rdm_pke *pkt_entry)
 {
 	struct efa_conn *conn;
+	fi_addr_t fi_addr;
 
+	EFA_GENLOCK_LOCK(&av->util_av.lock, efa_util_av_lock_sym);
 	conn = efa_av_reverse_lookup_rdm_conn(
 		&av->cur_reverse_av, &av->prv_reverse_av, ahn, qpn, pkt_entry);
+	fi_addr = (OFI_LIKELY(!!conn)) ? conn->fi_addr : FI_ADDR_NOTAVAIL;
+	EFA_GENLOCK_UNLOCK(&av->util_av.lock, efa_util_av_lock_sym);
 
-	if (OFI_LIKELY(!!conn))
-		return conn->fi_addr;
-
-	return FI_ADDR_NOTAVAIL;
+	return fi_addr;
 }
 
 /**
@@ -351,6 +353,7 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 					 struct efa_ep_addr *raw_addr,
 					 fi_addr_t implicit_fi_addr,
 					 fi_addr_t *fi_addr)
+	OFI_TSA_REQUIRES(efa_util_av_lock_sym)
 	OFI_TSA_REQUIRES(efa_implicit_av_lock_sym)
 	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
 {
@@ -369,7 +372,7 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 		 " to explicit AV\n",
 		 implicit_fi_addr);
 
-	assert(ofi_genlock_held(&av->util_av.lock));
+	assert(EFA_GENLOCK_HELD(&av->util_av.lock, efa_util_av_lock_sym));
 	assert(EFA_GENLOCK_HELD(&av->util_av_implicit.lock, efa_implicit_av_lock_sym));
 
 	/* Get implicit util AV entry and conn */
@@ -535,7 +538,7 @@ int efa_av_insert_one_explicit(struct efa_av *av,
 		 "Inserting address GID[%s] QP[%u] QKEY[%u] to explicit AV\n",
 		 raw_gid_str, addr->qpn, addr->qkey);
 
-	ofi_genlock_lock(&av->util_av.lock);
+	EFA_GENLOCK_LOCK(&av->util_av.lock, efa_util_av_lock_sym);
 
 	/* Check if this address already exists in the explicit AV */
 	efa_fiaddr = ofi_av_lookup_fi_addr_unsafe(&av->util_av, addr);
@@ -545,7 +548,7 @@ int efa_av_insert_one_explicit(struct efa_av *av,
 			 "address! fi_addr: %" PRId64 "\n",
 			 efa_fiaddr);
 		*fi_addr = efa_fiaddr;
-		ofi_genlock_unlock(&av->util_av.lock);
+		EFA_GENLOCK_UNLOCK(&av->util_av.lock, efa_util_av_lock_sym);
 		return 0;
 	}
 
@@ -564,7 +567,7 @@ int efa_av_insert_one_explicit(struct efa_av *av,
 			*fi_addr = FI_ADDR_NOTAVAIL;
 
 		EFA_GENLOCK_UNLOCK(&av->util_av_implicit.lock, efa_implicit_av_lock_sym);
-		ofi_genlock_unlock(&av->util_av.lock);
+		EFA_GENLOCK_UNLOCK(&av->util_av.lock, efa_util_av_lock_sym);
 		return ret;
 	}
 	EFA_GENLOCK_UNLOCK(&av->util_av_implicit.lock, efa_implicit_av_lock_sym);
@@ -573,12 +576,12 @@ int efa_av_insert_one_explicit(struct efa_av *av,
 	conn = efa_conn_alloc_explicit(av, addr, flags, context, insert_shm_av);
 	if (!conn) {
 		*fi_addr = FI_ADDR_NOTAVAIL;
-		ofi_genlock_unlock(&av->util_av.lock);
+		EFA_GENLOCK_UNLOCK(&av->util_av.lock, efa_util_av_lock_sym);
 		return -FI_EADDRNOTAVAIL;
 	}
 
 	*fi_addr = conn->fi_addr;
-	ofi_genlock_unlock(&av->util_av.lock);
+	EFA_GENLOCK_UNLOCK(&av->util_av.lock, efa_util_av_lock_sym);
 
 	EFA_INFO(FI_LOG_AV,
 		 "Successfully inserted address GID[%s] QP[%u] "
@@ -624,18 +627,18 @@ int efa_av_insert_one_implicit(struct efa_av *av,
 		 raw_gid_str, addr->qpn, addr->qkey);
 
 	/* Check if this address already exists in the explicit AV */
-	ofi_genlock_lock(&av->util_av.lock);
+	EFA_GENLOCK_LOCK(&av->util_av.lock, efa_util_av_lock_sym);
 	efa_fiaddr = ofi_av_lookup_fi_addr_unsafe(&av->util_av, addr);
 	if (efa_fiaddr != FI_ADDR_NOTAVAIL) {
 		*fi_addr = efa_fiaddr;
-		ofi_genlock_unlock(&av->util_av.lock);
+		EFA_GENLOCK_UNLOCK(&av->util_av.lock, efa_util_av_lock_sym);
 		EFA_INFO(FI_LOG_AV,
 			 "Found existing AV entry pointing to this "
 			 "address! fi_addr: %" PRId64 "\n",
 			 efa_fiaddr);
 		return 0;
 	}
-	ofi_genlock_unlock(&av->util_av.lock);
+	EFA_GENLOCK_UNLOCK(&av->util_av.lock, efa_util_av_lock_sym);
 
 	/* Check if address already exists in the implicit AV */
 	EFA_GENLOCK_LOCK(&av->util_av_implicit.lock, efa_implicit_av_lock_sym);
@@ -744,15 +747,15 @@ static int efa_av_lookup(struct fid_av *av_fid, fi_addr_t fi_addr,
 	if (fi_addr == FI_ADDR_NOTAVAIL)
 		return -FI_EINVAL;
 
-	ofi_genlock_lock(&av->util_av.lock);
+	EFA_GENLOCK_LOCK(&av->util_av.lock, efa_util_av_lock_sym);
 	conn = efa_av_addr_to_conn(av, fi_addr);
 	if (!conn) {
-		ofi_genlock_unlock(&av->util_av.lock);
+		EFA_GENLOCK_UNLOCK(&av->util_av.lock, efa_util_av_lock_sym);
 		return -FI_EINVAL;
 	}
 
 	memcpy(addr, (void *)conn->ep_addr, MIN(EFA_EP_ADDR_LEN, *addrlen));
-	ofi_genlock_unlock(&av->util_av.lock);
+	EFA_GENLOCK_UNLOCK(&av->util_av.lock, efa_util_av_lock_sym);
 	if (*addrlen > EFA_EP_ADDR_LEN)
 		*addrlen = EFA_EP_ADDR_LEN;
 	return 0;
@@ -802,7 +805,7 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 	 * util_domain.lock -> util_av.lock -> util_av_implicit.lock
 	 * in the AV insertion, removal and CQ read paths to prevent deadlocks */
 	EFA_GENLOCK_LOCK(&av->domain->util_domain.lock, efa_util_domain_lock_sym);
-	ofi_genlock_lock(&av->util_av.lock);
+	EFA_GENLOCK_LOCK(&av->util_av.lock, efa_util_av_lock_sym);
 	for (i = 0; i < count; i++) {
 		conn = efa_av_addr_to_conn(av, fi_addr[i]);
 		if (!conn) {
@@ -818,7 +821,7 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 		assert(err);
 	}
 
-	ofi_genlock_unlock(&av->util_av.lock);
+	EFA_GENLOCK_UNLOCK(&av->util_av.lock, efa_util_av_lock_sym);
 	EFA_GENLOCK_UNLOCK(&av->domain->util_domain.lock, efa_util_domain_lock_sym);
 	return err;
 }
@@ -849,7 +852,7 @@ static void efa_av_close_reverse_av(struct efa_av *av)
 	 * in the AV insertion, removal and CQ read paths to prevent deadlocks */
 	EFA_GENLOCK_LOCK(&av->domain->util_domain.lock, efa_util_domain_lock_sym);
 
-	ofi_genlock_lock(&av->util_av.lock);
+	EFA_GENLOCK_LOCK(&av->util_av.lock, efa_util_av_lock_sym);
 	HASH_ITER(hh, av->cur_reverse_av, cur_entry, curtmp) {
 		efa_conn_release_explicit(av, cur_entry->conn);
 	}
@@ -857,7 +860,7 @@ static void efa_av_close_reverse_av(struct efa_av *av)
 	HASH_ITER(hh, av->prv_reverse_av, prv_entry, prvtmp) {
 		efa_conn_release_explicit(av, prv_entry->conn);
 	}
-	ofi_genlock_unlock(&av->util_av.lock);
+	EFA_GENLOCK_UNLOCK(&av->util_av.lock, efa_util_av_lock_sym);
 
 	EFA_GENLOCK_LOCK(&av->util_av_implicit.lock, efa_implicit_av_lock_sym);
 	HASH_ITER(hh, av->cur_reverse_av_implicit, cur_entry, curtmp) {

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -810,7 +810,7 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 			break;
 		}
 
-		efa_conn_release(av, conn, false);
+		efa_conn_release_explicit(av, conn);
 	}
 
 	if (i < count) {
@@ -851,21 +851,21 @@ static void efa_av_close_reverse_av(struct efa_av *av)
 
 	ofi_genlock_lock(&av->util_av.lock);
 	HASH_ITER(hh, av->cur_reverse_av, cur_entry, curtmp) {
-		efa_conn_release(av, cur_entry->conn, false);
+		efa_conn_release_explicit(av, cur_entry->conn);
 	}
 
 	HASH_ITER(hh, av->prv_reverse_av, prv_entry, prvtmp) {
-		efa_conn_release(av, prv_entry->conn, false);
+		efa_conn_release_explicit(av, prv_entry->conn);
 	}
 	ofi_genlock_unlock(&av->util_av.lock);
 
 	EFA_GENLOCK_LOCK(&av->util_av_implicit.lock, efa_implicit_av_lock_sym);
 	HASH_ITER(hh, av->cur_reverse_av_implicit, cur_entry, curtmp) {
-		efa_conn_release(av, cur_entry->conn, true);
+		efa_conn_release_implicit(av, cur_entry->conn);
 	}
 
 	HASH_ITER(hh, av->prv_reverse_av_implicit, prv_entry, prvtmp) {
-		efa_conn_release(av, prv_entry->conn, true);
+		efa_conn_release_implicit(av, prv_entry->conn);
 	}
 	EFA_GENLOCK_UNLOCK(&av->util_av_implicit.lock, efa_implicit_av_lock_sym);
 

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -213,6 +213,7 @@ static inline int efa_av_is_valid_address(struct efa_ep_addr *addr)
 void efa_av_implicit_av_lru_conn_move(struct efa_av *av,
 					struct efa_conn *conn)
 	OFI_TSA_REQUIRES(efa_implicit_av_lock_sym)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
 {
 	assert(EFA_GENLOCK_HELD(&av->util_av_implicit.lock, efa_implicit_av_lock_sym));
 	assert(av->implicit_av_size == 0 ||
@@ -351,6 +352,7 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 					 fi_addr_t implicit_fi_addr,
 					 fi_addr_t *fi_addr)
 	OFI_TSA_REQUIRES(efa_implicit_av_lock_sym)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
 {
 	int err;
 	struct efa_ah *ah;
@@ -433,6 +435,7 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 		return err;
 
 	/* Handle AH LRU list and refcnt */
+	assert(ofi_genlock_held(&av->domain->util_domain.lock));
 	assert(!dlist_empty(&ah->implicit_conn_list));
 	dlist_remove(&implicit_conn->ah_implicit_conn_list_entry);
 	efa_ah_implicit_av_lru_ah_move(av->domain, ah);
@@ -516,6 +519,7 @@ int efa_av_insert_one_explicit(struct efa_av *av,
 			       struct efa_ep_addr *addr,
 			       fi_addr_t *fi_addr, uint64_t flags,
 			       void *context, bool insert_shm_av)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
 {
 	char raw_gid_str[INET6_ADDRSTRLEN];
 	struct efa_conn *conn;
@@ -603,6 +607,7 @@ int efa_av_insert_one_implicit(struct efa_av *av,
 			       struct efa_ep_addr *addr,
 			       fi_addr_t *fi_addr, uint64_t flags,
 			       void *context)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
 {
 	char raw_gid_str[INET6_ADDRSTRLEN];
 	struct efa_conn *conn;
@@ -699,7 +704,7 @@ int efa_av_insert(struct fid_av *av_fid, const void *addr,
 	 * The order in which the util domain and av locks are acquired must be 
 	 * util_domain.lock -> util_av.lock -> util_av_implicit.lock
 	 * in the AV insertion, removal and CQ read paths to prevent deadlocks */
-	ofi_genlock_lock(&av->domain->util_domain.lock);
+	EFA_GENLOCK_LOCK(&av->domain->util_domain.lock, efa_util_domain_lock_sym);
 
 	for (i = 0; i < count; i++) {
 		addr_i = (struct efa_ep_addr *) ((uint8_t *)addr + i * EFA_EP_ADDR_LEN);
@@ -716,7 +721,7 @@ int efa_av_insert(struct fid_av *av_fid, const void *addr,
 		success_cnt++;
 	}
 
-	ofi_genlock_unlock(&av->domain->util_domain.lock);
+	EFA_GENLOCK_UNLOCK(&av->domain->util_domain.lock, efa_util_domain_lock_sym);
 
 	/* cancel remaining request and log to event queue */
 	for (; i < count ; i++) {
@@ -796,7 +801,7 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 	/* The order in which the util domain and av locks are acquired must be 
 	 * util_domain.lock -> util_av.lock -> util_av_implicit.lock
 	 * in the AV insertion, removal and CQ read paths to prevent deadlocks */
-	ofi_genlock_lock(&av->domain->util_domain.lock);
+	EFA_GENLOCK_LOCK(&av->domain->util_domain.lock, efa_util_domain_lock_sym);
 	ofi_genlock_lock(&av->util_av.lock);
 	for (i = 0; i < count; i++) {
 		conn = efa_av_addr_to_conn(av, fi_addr[i]);
@@ -814,7 +819,7 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 	}
 
 	ofi_genlock_unlock(&av->util_av.lock);
-	ofi_genlock_unlock(&av->domain->util_domain.lock);
+	EFA_GENLOCK_UNLOCK(&av->domain->util_domain.lock, efa_util_domain_lock_sym);
 	return err;
 }
 
@@ -842,7 +847,7 @@ static void efa_av_close_reverse_av(struct efa_av *av)
 	/* The order in which the util domain and av locks are acquired must be 
 	 * util_domain.lock -> util_av.lock -> util_av_implicit.lock
 	 * in the AV insertion, removal and CQ read paths to prevent deadlocks */
-	ofi_genlock_lock(&av->domain->util_domain.lock);
+	EFA_GENLOCK_LOCK(&av->domain->util_domain.lock, efa_util_domain_lock_sym);
 
 	ofi_genlock_lock(&av->util_av.lock);
 	HASH_ITER(hh, av->cur_reverse_av, cur_entry, curtmp) {
@@ -864,7 +869,7 @@ static void efa_av_close_reverse_av(struct efa_av *av)
 	}
 	EFA_GENLOCK_UNLOCK(&av->util_av_implicit.lock, efa_implicit_av_lock_sym);
 
-	ofi_genlock_unlock(&av->domain->util_domain.lock);
+	EFA_GENLOCK_UNLOCK(&av->domain->util_domain.lock, efa_util_domain_lock_sym);
 }
 
 static int efa_av_close(struct fid *fid)
@@ -899,11 +904,10 @@ static int efa_av_close(struct fid *fid)
 					 fi_strerror(err));
 			}
 		}
-	}
-
-	HASH_ITER(hh, av->evicted_peers_hashset, ep_addr_hashable, tmp) {
-		HASH_DEL(av->evicted_peers_hashset, ep_addr_hashable);
-		free(ep_addr_hashable);
+		HASH_ITER(hh, av->evicted_peers_hashset, ep_addr_hashable, tmp) {
+			HASH_DEL(av->evicted_peers_hashset, ep_addr_hashable);
+			free(ep_addr_hashable);
+		}
 	}
 
 	free(av);

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -180,6 +180,7 @@ fi_addr_t efa_av_reverse_lookup_rdm_implicit(struct efa_av *av, uint16_t ahn,
 	struct efa_conn *conn;
 	fi_addr_t implicit_fi_addr = FI_ADDR_NOTAVAIL;
 
+	ofi_genlock_lock(&av->domain->util_domain.lock);
 	EFA_GENLOCK_LOCK(&av->util_av_implicit.lock, efa_implicit_av_lock_sym);
 	conn = efa_av_reverse_lookup_rdm_conn(&av->cur_reverse_av_implicit,
 					      &av->prv_reverse_av_implicit, ahn,
@@ -190,6 +191,7 @@ fi_addr_t efa_av_reverse_lookup_rdm_implicit(struct efa_av *av, uint16_t ahn,
 		implicit_fi_addr = conn->implicit_fi_addr;
 	}
 	EFA_GENLOCK_UNLOCK(&av->util_av_implicit.lock, efa_implicit_av_lock_sym);
+	ofi_genlock_unlock(&av->domain->util_domain.lock);
 
 	return implicit_fi_addr;
 }
@@ -222,6 +224,7 @@ void efa_av_implicit_av_lru_conn_move(struct efa_av *av,
 	dlist_insert_tail(&conn->implicit_av_lru_entry,
 			  &av->implicit_av_lru_list);
 
+	assert(ofi_genlock_held(&av->domain->util_domain.lock));
 	efa_ah_implicit_av_lru_ah_move(av->domain, conn->ah);
 }
 
@@ -484,9 +487,6 @@ static inline int efa_av_insert_one_validate(struct efa_av *av,
 	if (av->domain->info_type == EFA_INFO_DGRAM)
 		addr->qkey = EFA_DGRAM_CONNID;
 
-	if (av->domain->info_type == EFA_INFO_RDM)
-		assert(ofi_genlock_held(&((struct efa_rdm_domain *) av->domain)->srx_lock));
-
 	memset(raw_gid_str, 0, INET6_ADDRSTRLEN);
 	if (!inet_ntop(AF_INET6, addr->raw, raw_gid_str, INET6_ADDRSTRLEN)) {
 		EFA_WARN(FI_LOG_AV, "cannot convert address to string. errno: %d\n", errno);
@@ -693,10 +693,13 @@ int efa_av_insert(struct fid_av *av_fid, const void *addr,
 	if (flags)
 		return -FI_ENOSYS;
 
-	/* The order in which the util AV and SRX locks are acquired must match
+	/* 
+	 * Acquire domain lock because AH is a domain-level resource whose fields
+	 * are modified during av insert.
+	 * The order in which the util domain and av locks are acquired must be 
+	 * util_domain.lock -> util_av.lock -> util_av_implicit.lock
 	 * in the AV insertion, removal and CQ read paths to prevent deadlocks */
-	if (av->domain->info_type == EFA_INFO_RDM)
-		ofi_genlock_lock(&((struct efa_rdm_domain *) av->domain)->srx_lock);
+	ofi_genlock_lock(&av->domain->util_domain.lock);
 
 	for (i = 0; i < count; i++) {
 		addr_i = (struct efa_ep_addr *) ((uint8_t *)addr + i * EFA_EP_ADDR_LEN);
@@ -713,8 +716,7 @@ int efa_av_insert(struct fid_av *av_fid, const void *addr,
 		success_cnt++;
 	}
 
-	if (av->domain->info_type == EFA_INFO_RDM)
-		ofi_genlock_unlock(&((struct efa_rdm_domain *) av->domain)->srx_lock);
+	ofi_genlock_unlock(&av->domain->util_domain.lock);
 
 	/* cancel remaining request and log to event queue */
 	for (; i < count ; i++) {
@@ -791,10 +793,10 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 	if (av->type != FI_AV_TABLE)
 		return -FI_EINVAL;
 
-	/* The order in which the util AV and SRX locks are acquired must match
-	 in the AV insertion, removal and CQ read paths to prevent deadlocks */
-	if (av->domain->info_type == EFA_INFO_RDM)
-		ofi_genlock_lock(&((struct efa_rdm_domain *) av->domain)->srx_lock);
+	/* The order in which the util domain and av locks are acquired must be 
+	 * util_domain.lock -> util_av.lock -> util_av_implicit.lock
+	 * in the AV insertion, removal and CQ read paths to prevent deadlocks */
+	ofi_genlock_lock(&av->domain->util_domain.lock);
 	ofi_genlock_lock(&av->util_av.lock);
 	for (i = 0; i < count; i++) {
 		conn = efa_av_addr_to_conn(av, fi_addr[i]);
@@ -812,8 +814,7 @@ static int efa_av_remove(struct fid_av *av_fid, fi_addr_t *fi_addr,
 	}
 
 	ofi_genlock_unlock(&av->util_av.lock);
-	if (av->domain->info_type == EFA_INFO_RDM)
-		ofi_genlock_unlock(&((struct efa_rdm_domain *) av->domain)->srx_lock);
+	ofi_genlock_unlock(&av->domain->util_domain.lock);
 	return err;
 }
 
@@ -838,13 +839,12 @@ static void efa_av_close_reverse_av(struct efa_av *av)
 	struct efa_cur_reverse_av *cur_entry, *curtmp;
 	struct efa_prv_reverse_av *prv_entry, *prvtmp;
 
-	/* The order in which the util AV and SRX locks are acquired must match
-	 in the AV insertion, removal and CQ read paths to prevent deadlocks */
-	if (av->domain->info_type == EFA_INFO_RDM)
-		ofi_genlock_lock(&((struct efa_rdm_domain *) av->domain)->srx_lock);
+	/* The order in which the util domain and av locks are acquired must be 
+	 * util_domain.lock -> util_av.lock -> util_av_implicit.lock
+	 * in the AV insertion, removal and CQ read paths to prevent deadlocks */
+	ofi_genlock_lock(&av->domain->util_domain.lock);
 
 	ofi_genlock_lock(&av->util_av.lock);
-
 	HASH_ITER(hh, av->cur_reverse_av, cur_entry, curtmp) {
 		efa_conn_release(av, cur_entry->conn, false);
 	}
@@ -852,11 +852,9 @@ static void efa_av_close_reverse_av(struct efa_av *av)
 	HASH_ITER(hh, av->prv_reverse_av, prv_entry, prvtmp) {
 		efa_conn_release(av, prv_entry->conn, false);
 	}
-
 	ofi_genlock_unlock(&av->util_av.lock);
 
 	EFA_GENLOCK_LOCK(&av->util_av_implicit.lock, efa_implicit_av_lock_sym);
-
 	HASH_ITER(hh, av->cur_reverse_av_implicit, cur_entry, curtmp) {
 		efa_conn_release(av, cur_entry->conn, true);
 	}
@@ -864,11 +862,9 @@ static void efa_av_close_reverse_av(struct efa_av *av)
 	HASH_ITER(hh, av->prv_reverse_av_implicit, prv_entry, prvtmp) {
 		efa_conn_release(av, prv_entry->conn, true);
 	}
-
 	EFA_GENLOCK_UNLOCK(&av->util_av_implicit.lock, efa_implicit_av_lock_sym);
 
-	if (av->domain->info_type == EFA_INFO_RDM)
-		ofi_genlock_unlock(&((struct efa_rdm_domain *) av->domain)->srx_lock);
+	ofi_genlock_unlock(&av->domain->util_domain.lock);
 }
 
 static int efa_av_close(struct fid *fid)

--- a/prov/efa/src/efa_av.h
+++ b/prov/efa/src/efa_av.h
@@ -89,11 +89,13 @@ int efa_av_open(struct fid_domain *domain_fid, struct fi_av_attr *attr,
 
 int efa_av_insert_one_explicit(struct efa_av *av, struct efa_ep_addr *addr,
 			       fi_addr_t *fi_addr, uint64_t flags,
-			       void *context, bool insert_shm_av);
+			       void *context, bool insert_shm_av)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym);
 
 int efa_av_insert_one_implicit(struct efa_av *av, struct efa_ep_addr *addr,
 			       fi_addr_t *fi_addr, uint64_t flags,
-			       void *context);
+			       void *context)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym);
 
 struct efa_conn *efa_av_addr_to_conn(struct efa_av *av, fi_addr_t fi_addr);
 struct efa_conn *efa_av_addr_to_conn_implicit(struct efa_av *av,

--- a/prov/efa/src/efa_av.h
+++ b/prov/efa/src/efa_av.h
@@ -68,8 +68,8 @@ struct efa_av {
 	 * prv_reverse_av is a map from (ahn + qpn + connid) to all previous efa_conns.
 	 * cur_reverse_av is faster to search because its key size is smaller
 	 */
-	struct efa_cur_reverse_av *cur_reverse_av;
-	struct efa_prv_reverse_av *prv_reverse_av;
+	struct efa_cur_reverse_av *cur_reverse_av OFI_TSA_GUARDED_BY(efa_util_av_lock_sym);
+	struct efa_prv_reverse_av *prv_reverse_av OFI_TSA_GUARDED_BY(efa_util_av_lock_sym);
 	struct util_av util_av;
 
 	/* implicit AV is used when receiving messages from peers not explicity

--- a/prov/efa/src/efa_conn.c
+++ b/prov/efa/src/efa_conn.c
@@ -235,6 +235,7 @@ void efa_conn_rdm_deinit(struct efa_av *av, struct efa_conn *conn)
  */
 struct efa_conn *efa_conn_alloc_explicit(struct efa_av *av, struct efa_ep_addr *raw_addr,
 					 uint64_t flags, void *context, bool insert_shm_av)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
 {
 	struct util_av *util_av;
 	struct efa_cur_reverse_av **cur_reverse_av;
@@ -329,6 +330,7 @@ err_release:
 struct efa_conn *efa_conn_alloc_implicit(struct efa_av *av, struct efa_ep_addr *raw_addr,
 					 uint64_t flags, void *context)
 	OFI_TSA_REQUIRES(efa_implicit_av_lock_sym)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
 {
 	struct util_av *util_av_implicit;
 	struct util_av_entry *util_av_entry = NULL;
@@ -495,6 +497,7 @@ void efa_conn_release(struct efa_av *av, struct efa_conn *conn,
  */
 void efa_conn_release_implicit_ah_unsafe(struct efa_av *av, struct efa_conn *conn)
 	OFI_TSA_REQUIRES(efa_implicit_av_lock_sym)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
 {
 	assert(EFA_GENLOCK_HELD(&av->util_av_implicit.lock, efa_implicit_av_lock_sym));
 	efa_conn_release_reverse_av(av, conn, true);

--- a/prov/efa/src/efa_conn.c
+++ b/prov/efa/src/efa_conn.c
@@ -161,16 +161,12 @@ int efa_conn_rdm_insert_shm_av(struct efa_av *av, struct efa_conn *conn)
 }
 
 /**
- * @brief release the rdm related resources of an efa_conn object. This function
- * requires the caller to take the SRX lock because this function modifies the
- * peer map and destroys peers which are accessed and modified in the CQ read
- * path.
+ * @brief release the rdm related resources of an efa_conn object.
  *
- * this function release the shm av entry and rdm peer;
+ * This function releases the shm av entry and rdm peer.
  *
  * @param[in]	av	address vector
  * @param[in]	conn	efa_conn object
- * peer
  */
 void efa_conn_rdm_deinit(struct efa_av *av, struct efa_conn *conn)
 {
@@ -299,10 +295,8 @@ struct efa_conn *efa_conn_alloc_explicit(struct efa_av *av, struct efa_ep_addr *
 
 	err = efa_av_reverse_av_add(av, cur_reverse_av, prv_reverse_av, conn);
 	if (err) {
-		if (av->domain->info_type == EFA_INFO_RDM) {
-			assert(ofi_genlock_held(&((struct efa_rdm_domain *) av->domain)->srx_lock));
+		if (av->domain->info_type == EFA_INFO_RDM)
 			efa_conn_rdm_deinit(av, conn);
-		}
 		goto err_release;
 	}
 
@@ -393,7 +387,6 @@ struct efa_conn *efa_conn_alloc_implicit(struct efa_av *av, struct efa_ep_addr *
 
 	err = efa_av_reverse_av_add(av, &av->cur_reverse_av_implicit, &av->prv_reverse_av_implicit, conn);
 	if (err) {
-		assert(ofi_genlock_held(&((struct efa_rdm_domain *) av->domain)->srx_lock));
 		efa_conn_rdm_deinit(av, conn);
 		goto err_release;
 	}
@@ -469,22 +462,16 @@ void efa_conn_release_util_av(struct efa_av *av, struct efa_conn *conn,
 /**
  * @brief release an efa conn object
  * Caller of this function must obtain av->util_av.lock or
- * av->util_av_implicit.lock. This function obtains the SRX lock and is called
- * from the AV removal path.
+ * av->util_av_implicit.lock.
  *
  * @param[in]	av	address vector
  * @param[in]	conn	efa_conn object pointer
  * @param[in]	release_from_implicit_av		whether to release conn
  * from implicit AV
- * @param[in]	grab_srx_lock		whether to get the SRX lock before
- * destroying the peer struct
  */
 void efa_conn_release(struct efa_av *av, struct efa_conn *conn,
 		      bool release_from_implicit_av)
 {
-	assert(av->domain->info_type != EFA_INFO_RDM ||
-	       ofi_genlock_held(&((struct efa_rdm_domain *) av->domain)->srx_lock));
-
 	efa_conn_release_reverse_av(av, conn, release_from_implicit_av);
 	if (av->domain->info_type == EFA_INFO_RDM)
 		efa_conn_rdm_deinit(av, conn);
@@ -499,9 +486,9 @@ void efa_conn_release(struct efa_av *av, struct efa_conn *conn,
 
 /**
  * @brief release an efa conn object from the implicit AV
- * Caller of this function must obtain av->util_av_implicit.lock, the
- * util_domain lock, and the SRX lock. This function is called when
- * evicting an AH entry in the CQ read path.
+ * Caller of this function must obtain av->util_av_implicit.lock and the
+ * util_domain lock. This function is called when evicting an AH entry
+ * in the CQ read path.
  *
  * @param[in]	av	address vector
  * @param[in]	conn	efa_conn object pointer
@@ -512,7 +499,6 @@ void efa_conn_release_implicit_ah_unsafe(struct efa_av *av, struct efa_conn *con
 	assert(EFA_GENLOCK_HELD(&av->util_av_implicit.lock, efa_implicit_av_lock_sym));
 	efa_conn_release_reverse_av(av, conn, true);
 
-	assert(ofi_genlock_held(&((struct efa_rdm_domain *) av->domain)->srx_lock));
 	efa_conn_rdm_deinit(av, conn);
 
 	assert(ofi_genlock_held(&av->domain->util_domain.lock));

--- a/prov/efa/src/efa_conn.c
+++ b/prov/efa/src/efa_conn.c
@@ -46,6 +46,7 @@ static bool efa_is_local_peer(struct efa_av *av, const void *addr)
 static inline int efa_av_implicit_av_lru_insert(struct efa_av *av,
 						 struct efa_conn *conn)
 	OFI_TSA_REQUIRES(efa_implicit_av_lock_sym)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
 {
 	size_t cur_size;
 	struct efa_ep_addr_hashable *ep_addr_hashable;
@@ -80,7 +81,7 @@ static inline int efa_av_implicit_av_lru_insert(struct efa_av *av,
 	memcpy(ep_addr_hashable, conn->ep_addr, sizeof(struct efa_ep_addr));
 	HASH_ADD(hh, av->evicted_peers_hashset, addr, sizeof(struct efa_ep_addr), ep_addr_hashable);
 
-	efa_conn_release(av, conn_to_release, true);
+	efa_conn_release_implicit(av, conn_to_release);
 
 	assert(HASH_CNT(hh, av->util_av_implicit.hash) == av->implicit_av_size);
 
@@ -410,39 +411,13 @@ err_release:
 	return NULL;
 }
 
-void efa_conn_release_reverse_av(struct efa_av *av, struct efa_conn *conn,
-				 bool release_from_implicit_av)
+static void efa_conn_release_util_av(struct util_av *util_av,
+					    struct efa_conn *conn, fi_addr_t fi_addr)
 {
-	if (release_from_implicit_av) {
-		assert(EFA_GENLOCK_HELD(&av->util_av_implicit.lock, efa_implicit_av_lock_sym));
-		efa_av_reverse_av_remove(&av->cur_reverse_av_implicit,
-					 &av->prv_reverse_av_implicit, conn);
-	} else {
-		assert(ofi_genlock_held(&av->util_av.lock));
-		efa_av_reverse_av_remove(&av->cur_reverse_av,
-					 &av->prv_reverse_av, conn);
-	}
-}
-
-void efa_conn_release_util_av(struct efa_av *av, struct efa_conn *conn,
-			      bool release_from_implicit_av)
-{
-	struct util_av *util_av;
 	struct util_av_entry *util_av_entry;
 	struct efa_av_entry *efa_av_entry;
 	char gidstr[INET6_ADDRSTRLEN];
-	fi_addr_t fi_addr;
 	int err;
-
-	if (release_from_implicit_av) {
-		assert(EFA_GENLOCK_HELD(&av->util_av_implicit.lock, efa_implicit_av_lock_sym));
-		util_av = &av->util_av_implicit;
-		fi_addr = conn->implicit_fi_addr;
-	} else {
-		assert(ofi_genlock_held(&av->util_av.lock));
-		util_av = &av->util_av;
-		fi_addr = conn->fi_addr;
-	}
 
 	util_av_entry = ofi_bufpool_get_ibuf(util_av->av_entry_pool, fi_addr);
 	assert(util_av_entry);
@@ -462,28 +437,49 @@ void efa_conn_release_util_av(struct efa_av *av, struct efa_conn *conn,
 }
 
 /**
- * @brief release an efa conn object
- * Caller of this function must obtain av->util_av.lock or
- * av->util_av_implicit.lock.
+ * @brief release an efa conn object from the explicit AV
+ *
+ * Caller must hold util_domain.lock and util_av.lock.
  *
  * @param[in]	av	address vector
  * @param[in]	conn	efa_conn object pointer
- * @param[in]	release_from_implicit_av		whether to release conn
- * from implicit AV
  */
-void efa_conn_release(struct efa_av *av, struct efa_conn *conn,
-		      bool release_from_implicit_av)
+void efa_conn_release_explicit(struct efa_av *av, struct efa_conn *conn)
+	OFI_TSA_REQUIRES(efa_util_av_lock_sym)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
 {
-	efa_conn_release_reverse_av(av, conn, release_from_implicit_av);
+	assert(ofi_genlock_held(&av->util_av.lock));
+	efa_av_reverse_av_remove(&av->cur_reverse_av, &av->prv_reverse_av,
+				 conn);
+
 	if (av->domain->info_type == EFA_INFO_RDM)
 		efa_conn_rdm_deinit(av, conn);
 
-	if (release_from_implicit_av)
-		dlist_remove(&conn->ah_implicit_conn_list_entry);
+	efa_ah_release(av->domain, conn->ah, false);
+	efa_conn_release_util_av(&av->util_av, conn, conn->fi_addr);
+}
 
-	efa_ah_release(av->domain, conn->ah, release_from_implicit_av);
+/**
+ * @brief release an efa conn object from the implicit AV
+ *
+ * Caller must hold util_domain.lock and util_av_implicit.lock.
+ *
+ * @param[in]	av	address vector
+ * @param[in]	conn	efa_conn object pointer
+ */
+void efa_conn_release_implicit(struct efa_av *av, struct efa_conn *conn)
+	OFI_TSA_REQUIRES(efa_implicit_av_lock_sym)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
+{
+	assert(EFA_GENLOCK_HELD(&av->util_av_implicit.lock, efa_implicit_av_lock_sym));
+	efa_av_reverse_av_remove(&av->cur_reverse_av_implicit,
+				 &av->prv_reverse_av_implicit, conn);
 
-	efa_conn_release_util_av(av, conn, release_from_implicit_av);
+	efa_conn_rdm_deinit(av, conn);
+
+	dlist_remove(&conn->ah_implicit_conn_list_entry);
+	efa_ah_release(av->domain, conn->ah, true);
+	efa_conn_release_util_av(&av->util_av_implicit, conn, conn->implicit_fi_addr);
 }
 
 /**
@@ -500,12 +496,14 @@ void efa_conn_release_implicit_ah_unsafe(struct efa_av *av, struct efa_conn *con
 	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
 {
 	assert(EFA_GENLOCK_HELD(&av->util_av_implicit.lock, efa_implicit_av_lock_sym));
-	efa_conn_release_reverse_av(av, conn, true);
+	efa_av_reverse_av_remove(&av->cur_reverse_av_implicit,
+				 &av->prv_reverse_av_implicit, conn);
 
 	efa_conn_rdm_deinit(av, conn);
 
 	assert(ofi_genlock_held(&av->domain->util_domain.lock));
 	dlist_remove(&conn->ah_implicit_conn_list_entry);
-	efa_conn_release_util_av(av, conn, true);
+
+	efa_conn_release_util_av(&av->util_av_implicit, conn, conn->implicit_fi_addr);
 	conn->ah->implicit_refcnt--;
 }

--- a/prov/efa/src/efa_conn.h
+++ b/prov/efa/src/efa_conn.h
@@ -16,7 +16,7 @@ struct efa_conn {
 	fi_addr_t		fi_addr;
 	fi_addr_t		shm_fi_addr;
 	struct dlist_entry	implicit_av_lru_entry;
-	struct dlist_entry ah_implicit_conn_list_entry;
+	struct dlist_entry ah_implicit_conn_list_entry OFI_TSA_GUARDED_BY(efa_util_domain_lock_sym);
 };
 
 int efa_conn_rdm_insert_shm_av(struct efa_av *av, struct efa_conn *conn);
@@ -24,11 +24,13 @@ int efa_conn_rdm_insert_shm_av(struct efa_av *av, struct efa_conn *conn);
 void efa_conn_rdm_deinit(struct efa_av *av, struct efa_conn *conn);
 
 struct efa_conn *efa_conn_alloc_explicit(struct efa_av *av, struct efa_ep_addr *raw_addr,
-					uint64_t flags, void *context, bool insert_shm_av);
+					uint64_t flags, void *context, bool insert_shm_av)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym);
 
 struct efa_conn *efa_conn_alloc_implicit(struct efa_av *av, struct efa_ep_addr *raw_addr,
 					 uint64_t flags, void *context)
-	OFI_TSA_REQUIRES(efa_implicit_av_lock_sym);
+	OFI_TSA_REQUIRES(efa_implicit_av_lock_sym)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym);
 
 void efa_conn_release_reverse_av(struct efa_av *av, struct efa_conn *conn,
 				 bool release_from_implicit_av);
@@ -40,6 +42,7 @@ void efa_conn_release(struct efa_av *av, struct efa_conn *conn,
 		      bool release_from_implicit_av);
 
 void efa_conn_release_implicit_ah_unsafe(struct efa_av *av, struct efa_conn *conn)
-	OFI_TSA_REQUIRES(efa_implicit_av_lock_sym);
+	OFI_TSA_REQUIRES(efa_implicit_av_lock_sym)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym);
 
 #endif

--- a/prov/efa/src/efa_conn.h
+++ b/prov/efa/src/efa_conn.h
@@ -32,14 +32,13 @@ struct efa_conn *efa_conn_alloc_implicit(struct efa_av *av, struct efa_ep_addr *
 	OFI_TSA_REQUIRES(efa_implicit_av_lock_sym)
 	OFI_TSA_REQUIRES(efa_util_domain_lock_sym);
 
-void efa_conn_release_reverse_av(struct efa_av *av, struct efa_conn *conn,
-				 bool release_from_implicit_av);
+void efa_conn_release_explicit(struct efa_av *av, struct efa_conn *conn)
+	OFI_TSA_REQUIRES(efa_util_av_lock_sym)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym);
 
-void efa_conn_release_util_av(struct efa_av *av, struct efa_conn *conn,
-			      bool release_from_implicit_av);
-
-void efa_conn_release(struct efa_av *av, struct efa_conn *conn,
-		      bool release_from_implicit_av);
+void efa_conn_release_implicit(struct efa_av *av, struct efa_conn *conn)
+	OFI_TSA_REQUIRES(efa_implicit_av_lock_sym)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym);
 
 void efa_conn_release_implicit_ah_unsafe(struct efa_av *av, struct efa_conn *conn)
 	OFI_TSA_REQUIRES(efa_implicit_av_lock_sym)

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -27,7 +27,7 @@ struct efa_domain {
 	struct efa_fabric	*fabric;
 	bool 			mr_local;
 	struct dlist_entry	list_entry; /* linked to g_efa_domain_list */
-	struct efa_ah		*ah_map;
+	struct efa_ah		*ah_map OFI_TSA_GUARDED_BY(efa_util_domain_lock_sym);
 	/* Total count of ibv memory registrations */
 	ofi_atomic64_t ibv_mr_reg_ct;
 	/* Total size of memory registrations (in bytes) */

--- a/prov/efa/src/efa_domain_util.c
+++ b/prov/efa/src/efa_domain_util.c
@@ -53,6 +53,7 @@ int efa_domain_init_base(struct efa_domain *efa_domain,
 			 struct fid_fabric *fabric_fid,
 			 struct fi_info *info,
 			 void *context)
+	OFI_TSA_NO_ANALYSIS
 {
 	int err;
 
@@ -152,7 +153,7 @@ void efa_domain_cleanup_ah_map(struct efa_domain *efa_domain)
 	struct efa_ah *ah_entry, *tmp;
 	int ret;
 
-	ofi_genlock_lock(&efa_domain->util_domain.lock);
+	EFA_GENLOCK_LOCK(&efa_domain->util_domain.lock, efa_util_domain_lock_sym);
 	if (efa_domain->ah_map) {
 		EFA_WARN(FI_LOG_DOMAIN, "AH map not empty during domain close! Cleaning up ...\n");
 		HASH_ITER(hh, efa_domain->ah_map, ah_entry, tmp) {
@@ -163,7 +164,7 @@ void efa_domain_cleanup_ah_map(struct efa_domain *efa_domain)
 			free(ah_entry);
 		}
 	}
-	ofi_genlock_unlock(&efa_domain->util_domain.lock);
+	EFA_GENLOCK_UNLOCK(&efa_domain->util_domain.lock, efa_util_domain_lock_sym);
 }
 
 void efa_domain_destruct(struct efa_domain *efa_domain)

--- a/prov/efa/src/efa_thread_annotations.c
+++ b/prov/efa/src/efa_thread_annotations.c
@@ -6,3 +6,4 @@
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_qp_table_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_implicit_av_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_util_ep_lock_sym);
+OFI_TSA_LOCK_SYMBOL_DEFINE(efa_util_domain_lock_sym);

--- a/prov/efa/src/efa_thread_annotations.c
+++ b/prov/efa/src/efa_thread_annotations.c
@@ -6,4 +6,5 @@
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_qp_table_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_implicit_av_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_util_ep_lock_sym);
+OFI_TSA_LOCK_SYMBOL_DEFINE(efa_util_av_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_util_domain_lock_sym);

--- a/prov/efa/src/efa_thread_annotations.h
+++ b/prov/efa/src/efa_thread_annotations.h
@@ -95,6 +95,7 @@ efa_genlock_held(struct ofi_genlock *lock, struct ofi_tsa_lock_symbol *sym)
 OFI_TSA_LOCK_SYMBOL_DECLARE(efa_qp_table_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DECLARE(efa_implicit_av_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DECLARE(efa_util_ep_lock_sym);
+OFI_TSA_LOCK_SYMBOL_DECLARE(efa_util_av_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DECLARE(efa_util_domain_lock_sym);
 
 #endif /* EFA_THREAD_ANNOTATIONS_H */

--- a/prov/efa/src/efa_thread_annotations.h
+++ b/prov/efa/src/efa_thread_annotations.h
@@ -95,5 +95,6 @@ efa_genlock_held(struct ofi_genlock *lock, struct ofi_tsa_lock_symbol *sym)
 OFI_TSA_LOCK_SYMBOL_DECLARE(efa_qp_table_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DECLARE(efa_implicit_av_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DECLARE(efa_util_ep_lock_sym);
+OFI_TSA_LOCK_SYMBOL_DECLARE(efa_util_domain_lock_sym);
 
 #endif /* EFA_THREAD_ANNOTATIONS_H */

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -463,9 +463,14 @@ efa_rdm_cq_get_peer_for_pkt_entry(struct efa_rdm_ep *ep,
 	 * The message is from a peer through efa device, which means peer is
 	 * not local or shm is disabled for transmission. We shouldn't insert
 	 * in to shm av in this case.
+	 *
+	 * Acquire domain lock because AH is a domain-level resource whose fields
+	 * are modified during av insert.
 	 */
+	ofi_genlock_lock(&ep->base_ep.domain->util_domain.lock);
 	ret = efa_av_insert_one_implicit(ep->base_ep.av, &efa_ep_addr, &implicit_fi_addr,
 				0, NULL);
+	ofi_genlock_unlock(&ep->base_ep.domain->util_domain.lock);
 	if (OFI_UNLIKELY(ret != 0)) {
 		efa_base_ep_write_eq_error(&ep->base_ep, ret,
 					   FI_EFA_ERR_AV_INSERT);

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -467,10 +467,10 @@ efa_rdm_cq_get_peer_for_pkt_entry(struct efa_rdm_ep *ep,
 	 * Acquire domain lock because AH is a domain-level resource whose fields
 	 * are modified during av insert.
 	 */
-	ofi_genlock_lock(&ep->base_ep.domain->util_domain.lock);
+	EFA_GENLOCK_LOCK(&ep->base_ep.domain->util_domain.lock, efa_util_domain_lock_sym);
 	ret = efa_av_insert_one_implicit(ep->base_ep.av, &efa_ep_addr, &implicit_fi_addr,
 				0, NULL);
-	ofi_genlock_unlock(&ep->base_ep.domain->util_domain.lock);
+	EFA_GENLOCK_UNLOCK(&ep->base_ep.domain->util_domain.lock, efa_util_domain_lock_sym);
 	if (OFI_UNLIKELY(ret != 0)) {
 		efa_base_ep_write_eq_error(&ep->base_ep, ret,
 					   FI_EFA_ERR_AV_INSERT);

--- a/prov/efa/src/rdm/efa_rdm_domain.h
+++ b/prov/efa/src/rdm/efa_rdm_domain.h
@@ -28,7 +28,7 @@ struct efa_rdm_domain {
 	/* list of #efa_rdm_peer that will retry posting handshake pkt */
 	struct dlist_entry handshake_queued_peer_list;
 	/* LRU list of AH entries in this domain */
-	struct dlist_entry ah_lru_list;
+	struct dlist_entry ah_lru_list OFI_TSA_GUARDED_BY(efa_util_domain_lock_sym);
 };
 
 _Static_assert(offsetof(struct efa_rdm_domain, efa_domain) == 0,

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -1112,9 +1112,9 @@ static int efa_rdm_ep_close(struct fid *fid)
 	 * modified in the CQ read path by implicit-to-explicit AV entry conversion
 	 */
 	if (efa_rdm_ep->self_ah) {
-		ofi_genlock_lock(&domain->util_domain.lock);
+		EFA_GENLOCK_LOCK(&domain->util_domain.lock, efa_util_domain_lock_sym);
 		efa_ah_release(domain, efa_rdm_ep->self_ah, false);
-		ofi_genlock_unlock(&domain->util_domain.lock);
+		EFA_GENLOCK_UNLOCK(&domain->util_domain.lock, efa_util_domain_lock_sym);
 	}
 
 	efa_rdm_ep_deregister_ibv_cqs(efa_rdm_ep);
@@ -1394,6 +1394,7 @@ int efa_rdm_ep_register_ibv_cqs(struct efa_rdm_ep *ep)
  */
 static inline
 int efa_rdm_ep_create_self_ah(struct efa_rdm_ep *rdm_ep)
+	OFI_TSA_REQUIRES(efa_util_domain_lock_sym)
 {
 
 	rdm_ep->self_ah = efa_ah_alloc(rdm_ep->base_ep.domain, rdm_ep->base_ep.src_addr.raw, false);
@@ -1439,9 +1440,9 @@ static int efa_rdm_ep_ctrl(struct fid *fid, int command, void *arg)
 		 * Creating the self AH modifies the AH refcnts which can also
 		 * modified in the CQ read path by implicit-to-explicit AV entry
 		 * conversion */
-		ofi_genlock_lock(&ep->base_ep.domain->util_domain.lock);                          
+		EFA_GENLOCK_LOCK(&ep->base_ep.domain->util_domain.lock, efa_util_domain_lock_sym);              
 		ret = efa_rdm_ep_create_self_ah(ep);
-		ofi_genlock_unlock(&ep->base_ep.domain->util_domain.lock);                          
+		EFA_GENLOCK_UNLOCK(&ep->base_ep.domain->util_domain.lock, efa_util_domain_lock_sym);            
 		if (ret) {
 			EFA_WARN(FI_LOG_EP_CTRL,
 			 "EFA RDM endpoint cannot create ah for its own address\n");

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -1097,9 +1097,6 @@ static int efa_rdm_ep_close(struct fid *fid)
 	 * otherwise there can be race condition that efa_rdm_domain_progress_peers_and_queues
 	 * (part of fi_cq_read) can access entries that are from a closed QP.
 	 *
-	 * Destroying the self AH also requires the SRX lock
-	 * Destroying the self AH modifies the AH refcnts which can also
-	 * modified in the CQ read path by implicit-to-explicit AV entry conversion
 	 */
 	ofi_genlock_lock(&((struct efa_rdm_domain *) domain)->srx_lock);
 
@@ -1109,8 +1106,16 @@ static int efa_rdm_ep_close(struct fid *fid)
 
 	efa_rdm_ep_remove_cntr_ibv_cq_poll_list(&efa_rdm_ep->base_ep);
 
-	if (efa_rdm_ep->self_ah)
-		efa_ah_release(efa_rdm_ep->base_ep.domain, efa_rdm_ep->self_ah, false);
+	/*
+	 * Destroying the self AH also requires the util_domain.lock, 
+	 * because it modifies the AH refcnts which can also be
+	 * modified in the CQ read path by implicit-to-explicit AV entry conversion
+	 */
+	if (efa_rdm_ep->self_ah) {
+		ofi_genlock_lock(&domain->util_domain.lock);
+		efa_ah_release(domain, efa_rdm_ep->self_ah, false);
+		ofi_genlock_unlock(&domain->util_domain.lock);
+	}
 
 	efa_rdm_ep_deregister_ibv_cqs(efa_rdm_ep);
 
@@ -1430,13 +1435,13 @@ static int efa_rdm_ep_ctrl(struct fid *fid, int command, void *arg)
 		if (ret)
 			return ret;
 
-		/* Acquire the SRX lock before creating self AH
+		/* Acquire the util_domain.lock before creating self AH
 		 * Creating the self AH modifies the AH refcnts which can also
 		 * modified in the CQ read path by implicit-to-explicit AV entry
 		 * conversion */
-		ofi_genlock_lock(&efa_rdm_ep_rdm_domain(ep)->srx_lock);
+		ofi_genlock_lock(&ep->base_ep.domain->util_domain.lock);                          
 		ret = efa_rdm_ep_create_self_ah(ep);
-		ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(ep)->srx_lock);
+		ofi_genlock_unlock(&ep->base_ep.domain->util_domain.lock);                          
 		if (ret) {
 			EFA_WARN(FI_LOG_EP_CTRL,
 			 "EFA RDM endpoint cannot create ah for its own address\n");

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -154,6 +154,8 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer_implicit(struct efa_rdm_ep *ep, fi_addr
 		return NULL;
 
 	/*
+	 * The util_domain.lock is required for efa_av_implicit_av_lru_conn_move, 
+	 * which modifies domain->ah_lru_list.
 	 * The endpoint lock protects the peer map; the implicit-AV lock
 	 * protects peer->conn and its implicit-LRU entry (touched by the LRU
 	 * move below).
@@ -163,8 +165,9 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer_implicit(struct efa_rdm_ep *ep, fi_addr
 	 * the same time. Otherwise, the promotion could free the implicit conn
 	 * and cause the LRU move to operate on a now-bad pointer.
 	 *
-	 * Follows locking order: implicit-AV -> endpoint.
+	 * Follows locking order: util_domain -> implicit-AV -> endpoint.
 	 */
+	ofi_genlock_lock(&ep->base_ep.domain->util_domain.lock);
 	EFA_GENLOCK_LOCK(&ep->base_ep.av->util_av_implicit.lock, efa_implicit_av_lock_sym);
 	EFA_GENLOCK_LOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
 
@@ -207,6 +210,7 @@ unlock_ep:
 		efa_av_implicit_av_lru_conn_move(ep->base_ep.av, peer->conn);
 
 	EFA_GENLOCK_UNLOCK(&ep->base_ep.av->util_av_implicit.lock, efa_implicit_av_lock_sym);
+	ofi_genlock_unlock(&ep->base_ep.domain->util_domain.lock);
 	return peer;
 }
 

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -167,7 +167,7 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer_implicit(struct efa_rdm_ep *ep, fi_addr
 	 *
 	 * Follows locking order: util_domain -> implicit-AV -> endpoint.
 	 */
-	ofi_genlock_lock(&ep->base_ep.domain->util_domain.lock);
+	EFA_GENLOCK_LOCK(&ep->base_ep.domain->util_domain.lock, efa_util_domain_lock_sym);
 	EFA_GENLOCK_LOCK(&ep->base_ep.av->util_av_implicit.lock, efa_implicit_av_lock_sym);
 	EFA_GENLOCK_LOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
 
@@ -210,7 +210,7 @@ unlock_ep:
 		efa_av_implicit_av_lru_conn_move(ep->base_ep.av, peer->conn);
 
 	EFA_GENLOCK_UNLOCK(&ep->base_ep.av->util_av_implicit.lock, efa_implicit_av_lock_sym);
-	ofi_genlock_unlock(&ep->base_ep.domain->util_domain.lock);
+	EFA_GENLOCK_UNLOCK(&ep->base_ep.domain->util_domain.lock, efa_util_domain_lock_sym);
 	return peer;
 }
 

--- a/prov/efa/test/efa_unit_test_av.c
+++ b/prov/efa/test/efa_unit_test_av.c
@@ -434,9 +434,9 @@ static struct efa_rdm_peer *test_av_get_peer_from_implicit_av(struct efa_resourc
 	ahn = efa_rdm_ep->self_ah->ahn;
 
 	/* Manually insert into implicit AV */
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
-
+	ofi_genlock_lock(&av->domain->util_domain.lock);
 	err = efa_av_insert_one_implicit(av, &raw_addr, &implicit_fi_addr, 0, NULL);
+	ofi_genlock_unlock(&av->domain->util_domain.lock);
 
 	peer = efa_rdm_ep_get_peer_implicit(efa_rdm_ep, implicit_fi_addr);
 
@@ -447,7 +447,6 @@ static struct efa_rdm_peer *test_av_get_peer_from_implicit_av(struct efa_resourc
 	test_addr = efa_av_reverse_lookup_rdm_implicit(av, ahn, raw_addr.qpn, NULL);
 	assert_int_equal(test_addr, implicit_fi_addr);
 
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 
 	return peer;
 }
@@ -592,10 +591,8 @@ void test_av_implicit_av_lru_insertion(void **state)
 
 	/* Access peer0 through the CQ read path */
 	ahn = efa_rdm_ep->self_ah->ahn;
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	implicit_fi_addr = efa_av_reverse_lookup_rdm_implicit(
 		av, ahn, peer0->conn->ep_addr->qpn, NULL);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	assert_int_equal(implicit_fi_addr, 0);
 
 	/* Expected LRU list: HEAD->peer1->peer2->peer0 */
@@ -603,10 +600,8 @@ void test_av_implicit_av_lru_insertion(void **state)
 
 	/* Access peer2 through the CQ read path */
 	ahn = efa_rdm_ep->self_ah->ahn;
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	implicit_fi_addr = efa_av_reverse_lookup_rdm_implicit(
 		av, ahn, peer2->conn->ep_addr->qpn, NULL);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	assert_int_equal(implicit_fi_addr, 2);
 
 	/* Expected LRU list: HEAD->peer1->peer0->peer2 */
@@ -614,9 +609,9 @@ void test_av_implicit_av_lru_insertion(void **state)
 
 
 	/* Access peer1 through repeated AV insertion path */
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	ofi_genlock_lock(&av->domain->util_domain.lock);
 	err = efa_av_insert_one_implicit(av, peer1->conn->ep_addr, &implicit_fi_addr, 0, NULL);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	ofi_genlock_unlock(&av->domain->util_domain.lock);
 	assert_int_equal(err, 0);
 	assert_int_equal(implicit_fi_addr, 1);
 	test_av_verify_av_hash_cnt(av, 0, 0, 3, 0);
@@ -625,9 +620,9 @@ void test_av_implicit_av_lru_insertion(void **state)
 	test_av_implicit_av_verify_lru_list_first_last_elements(av, peer0->conn, peer1->conn);
 
 	/* Access peer2 through repeated AV insertion path */
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	ofi_genlock_lock(&av->domain->util_domain.lock);
 	err = efa_av_insert_one_implicit(av, peer2->conn->ep_addr, &implicit_fi_addr, 0, NULL);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	ofi_genlock_unlock(&av->domain->util_domain.lock);
 	assert_int_equal(err, 0);
 	assert_int_equal(implicit_fi_addr, 2);
 	test_av_verify_av_hash_cnt(av, 0, 0, 3, 0);
@@ -676,10 +671,8 @@ void test_av_implicit_av_lru_eviction(void **state)
 
 	/* Access peer0 through the CQ read path */
 	ahn = efa_rdm_ep->self_ah->ahn;
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	implicit_fi_addr = efa_av_reverse_lookup_rdm_implicit(
 		av, ahn, peer0->conn->ep_addr->qpn, NULL);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	assert_int_equal(implicit_fi_addr, 0);
 
 	/* Expected LRU list: HEAD->peer1->peer0 */
@@ -702,9 +695,9 @@ void test_av_implicit_av_lru_eviction(void **state)
 			 1);
 
 	/* Access peer0 through repeated AV insertion path */
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	ofi_genlock_lock(&av->domain->util_domain.lock);
 	err = efa_av_insert_one_implicit(av, peer0->conn->ep_addr, &implicit_fi_addr, 0, NULL);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	ofi_genlock_unlock(&av->domain->util_domain.lock);
 	assert_int_equal(err, 0);
 	assert_int_equal(implicit_fi_addr, 0);
 	test_av_verify_av_hash_cnt(av, 0, 0, 2, 0);
@@ -771,10 +764,11 @@ void test_ah_refcnt(void **state)
 	assert_int_equal(HASH_CNT(hh, efa_domain->ah_map), 0);
 
 	/* Manually insert into implicit AV */
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	ofi_genlock_lock(&av->domain->util_domain.lock);
 	err = efa_av_insert_one_implicit(av, &raw_addr, &fi_addr, 0, NULL);
+	ofi_genlock_unlock(&av->domain->util_domain.lock);
+
 	peer = efa_rdm_ep_get_peer_implicit(efa_rdm_ep, fi_addr);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 
 	efa_ah = peer->conn->ah;
 
@@ -894,10 +888,11 @@ void test_ah_lru_eviction_impl(bool explicit)
 	assert_int_equal(HASH_CNT(hh, efa_domain[0]->ah_map), 0);
 
 	/* Manually insert into implicit AV in first domain */
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep[0])->srx_lock);
+	ofi_genlock_lock(&efa_domain[0]->util_domain.lock);
 	err = efa_av_insert_one_implicit(efa_av[0], &raw_addr[0], &fi_addr, 0, NULL);
+	ofi_genlock_unlock(&efa_domain[0]->util_domain.lock);
+
 	peer = efa_rdm_ep_get_peer_implicit(efa_rdm_ep[0], fi_addr);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep[0])->srx_lock);
 
 	assert_int_equal(HASH_CNT(hh, efa_domain[0]->ah_map), 1);
 	efa_ah = peer->conn->ah;
@@ -909,10 +904,10 @@ void test_ah_lru_eviction_impl(bool explicit)
 		assert_int_equal(err, 1);
 		peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep[0], fi_addr);
 	} else {
-		ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep[0])->srx_lock);
+		ofi_genlock_lock(&efa_domain[0]->util_domain.lock);
 		err = efa_av_insert_one_implicit(efa_av[0], &raw_addr[1], &fi_addr, 0, NULL);
+		ofi_genlock_unlock(&efa_domain[0]->util_domain.lock);
 		peer = efa_rdm_ep_get_peer_implicit(efa_rdm_ep[0], fi_addr);
-		ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep[0])->srx_lock);
 	}
 
 	assert_int_equal(HASH_CNT(hh, efa_domain[0]->ah_map), 1);

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.c
@@ -51,21 +51,18 @@ int efa_test_av_insert_self(struct fid_ep *ep, struct fid_av *av,
 
 fi_addr_t efa_test_av_insert_new_ah(struct fid_ep *ep, struct fid_av *av)
 {
-	struct efa_rdm_ep *efa_rdm_ep;
 	struct efa_av *efa_av;
 	struct efa_ep_addr raw_addr;
 	fi_addr_t fi_addr = FI_ADDR_NOTAVAIL;
 	int err;
 
-	efa_rdm_ep =
-		container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
 	efa_av = container_of(av, struct efa_av, util_av.av_fid);
 
 	efa_test_fabricate_addr(ep, &raw_addr);
 
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	ofi_genlock_lock(&efa_av->domain->util_domain.lock);
 	err = efa_av_insert_one_implicit(efa_av, &raw_addr, &fi_addr, 0, NULL);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	ofi_genlock_unlock(&efa_av->domain->util_domain.lock);
 
 	if (err)
 		return FI_ADDR_NOTAVAIL;


### PR DESCRIPTION
SRX lock should not be used to protect race condition with AV.
Acquire util_domain.lock around AV insertion to protect AH refcnt, implicit_conn_list, ah_lru_list, and ensure the consistent
locking order util_domain.lock -> util_av.lock -> util_av_implicit.lock.
