### PR TITLE
fabtests/pytest: Fix orphaned server process on setup failure

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -440,6 +440,26 @@ def _wait_for_oob_port_free(host_id, port):
         sleep(OOB_POLL_INTERVAL_SEC)
 
 
+def _kill_oob_listener(host_id, port):
+    output = _run_ssh_probe(host_id, "ss -ltnp")
+    suffix = ":{}".format(port)
+    listener_found = False
+    pids = set()
+    for line in output.splitlines():
+        fields = line.split()
+        if len(fields) >= 4 and fields[3].endswith(suffix):
+            listener_found = True
+            pids.update(re.findall(r"pid=(\d+)", line))
+
+    if not listener_found:
+        return
+
+    if pids:
+        print("killing OOB listener PID(s) {} on {} port {}".format(", ".join(sorted(pids)), host_id, port))
+        _run_ssh_probe(host_id, "kill -KILL {}".format(" ".join(sorted(pids))))
+
+    _wait_for_oob_port_free(host_id, port)
+
 def _wait_for_server_listening(host_id, port, server_process,
                                server_log_path=None):
     """
@@ -716,7 +736,7 @@ class ClientServerTest:
                              _is_linux_host(self._cmdline_args.server_id))
 
         if use_oob_readiness:
-            _wait_for_oob_port_free(self._cmdline_args.server_id, oob_port)
+            _kill_oob_listener(self._cmdline_args.server_id, oob_port)
 
         with open(server_log_path, "w") as server_log_file:
             server_process = Popen(
@@ -727,76 +747,89 @@ class ClientServerTest:
                 universal_newlines=True,
             )
 
-        if use_oob_readiness:
-            _wait_for_server_listening(self._cmdline_args.server_id, oob_port,
-                                       server_process,
-                                       server_log_path=server_log_path)
-        else:
-            sleep(1)
-
-        client_returncode = -1
+        run_completed = False
         try:
-            # Start client
-            # Retry on SSH connection error until server timeout
-            client_returncode = retry(
-                retry_on_exception=is_ssh_connection_error,
-                stop_max_delay=self._timeout * 1000,  # Convert to milliseconds
-                wait_fixed=CLIENT_RETRY_INTERVAL_MS,
-            )(self._run_client_command)(server_process, self._client_command, client_log_path).returncode
-        except Exception as e:
-            print("Client error: {}".format(e))
-            # Clean up server if client is terminated unexpectedly
-            server_process.terminate()
+            if use_oob_readiness:
+                _wait_for_server_listening(self._cmdline_args.server_id, oob_port,
+                                        server_process,
+                                        server_log_path=server_log_path)
+            else:
+                sleep(1)
 
-        server_timed_out = False
-        try:
-            server_process.wait(
-                timeout=self._timeout + SERVER_RESTART_DELAY_MS/1000)
-        except TimeoutExpired:
-            server_timed_out = True
-            server_process.terminate()
+            client_returncode = -1
             try:
-                server_process.wait(timeout=SERVER_RESTART_DELAY_MS/1000)
+                # Start client
+                # Retry on SSH connection error until server timeout
+                client_returncode = retry(
+                    retry_on_exception=is_ssh_connection_error,
+                    stop_max_delay=self._timeout * 1000,  # Convert to milliseconds
+                    wait_fixed=CLIENT_RETRY_INTERVAL_MS,
+                )(self._run_client_command)(server_process, self._client_command, client_log_path).returncode
+            except Exception as e:
+                print("Client error: {}".format(e))
+                # Clean up server if client is terminated unexpectedly
+                server_process.terminate()
+
+            server_timed_out = False
+            try:
+                server_process.wait(
+                    timeout=self._timeout + SERVER_RESTART_DELAY_MS/1000)
             except TimeoutExpired:
+                server_timed_out = True
+                server_process.terminate()
+                try:
+                    server_process.wait(timeout=SERVER_RESTART_DELAY_MS/1000)
+                except TimeoutExpired:
+                    server_process.kill()
+                    server_process.wait()
+
+            print("server_stdout:")
+            ssh_connection_error = False
+            output_ends_with_newline = True
+            with open(server_log_path, errors="replace") as server_log_file:
+                for line in server_log_file:
+                    print(line, end="")
+                    output_ends_with_newline = line.endswith("\n")
+                    if has_ssh_connection_err_msg(line):
+                        ssh_connection_error = True
+            if not output_ends_with_newline:
+                print("")
+
+            if ssh_connection_error:
+                print("encountered ssh connection issue!")
+                raise SshConnectionError()
+
+            print(f"server returncode: {server_process.returncode}")
+
+            if server_timed_out:
+                raise RuntimeError("Server timed out\n" + log_msg)
+
+            list_to_check_return_code = []
+            if not self._server_parameters['might_fail']:
+                list_to_check_return_code.append(server_process.returncode)
+            if not self._client_parameters['might_fail']:
+                list_to_check_return_code.append(client_returncode)
+
+            strict = self._cmdline_args.strict_fabtests_mode
+            has_failure = any(
+                check_returncode(returncode, strict)[0] == FAIL
+                for returncode in list_to_check_return_code)
+            if not has_failure:
+                remove_test_logs(server_log_path, client_log_path)
+
+            check_returncode_list(list_to_check_return_code, strict,
+                                extra_fail_message=log_msg)
+            run_completed = True
+        finally:
+            # The spawned server must not outlive the test on any exit path.
+            if server_process.poll() is None:
                 server_process.kill()
                 server_process.wait()
-
-        print("server_stdout:")
-        ssh_connection_error = False
-        output_ends_with_newline = True
-        with open(server_log_path, errors="replace") as server_log_file:
-            for line in server_log_file:
-                print(line, end="")
-                output_ends_with_newline = line.endswith("\n")
-                if has_ssh_connection_err_msg(line):
-                    ssh_connection_error = True
-        if not output_ends_with_newline:
-            print("")
-
-        if ssh_connection_error:
-            print("encountered ssh connection issue!")
-            raise SshConnectionError()
-
-        print(f"server returncode: {server_process.returncode}")
-
-        if server_timed_out:
-            raise RuntimeError("Server timed out\n" + log_msg)
-
-        list_to_check_return_code = []
-        if not self._server_parameters['might_fail']:
-            list_to_check_return_code.append(server_process.returncode)
-        if not self._client_parameters['might_fail']:
-            list_to_check_return_code.append(client_returncode)
-
-        strict = self._cmdline_args.strict_fabtests_mode
-        has_failure = any(
-            check_returncode(returncode, strict)[0] == FAIL
-            for returncode in list_to_check_return_code)
-        if not has_failure:
-            remove_test_logs(server_log_path, client_log_path)
-
-        check_returncode_list(list_to_check_return_code, strict,
-                              extra_fail_message=log_msg)
+            if use_oob_readiness and not run_completed:
+                try:
+                    _kill_oob_listener(self._cmdline_args.server_id, oob_port)
+                except Exception as e:
+                    print("server cleanup failed: {}".format(e))
 
 
 class MultinodeTest(ClientServerTest):


### PR DESCRIPTION
Kill remote processes holding worker OOB ports after abnormal server exits.
Skip remote cleanup probes after successful tests to avoid CI slowdown.