### PR TITLE
[v2.6.x]fabtests/pytest: Complete pr_ci coverage for the shm, sm2 and…

### DIFF
--- a/fabtests/pytest/default/test_av.py
+++ b/fabtests/pytest/default/test_av.py
@@ -1,11 +1,13 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_av(cmdline_args, server_address, good_address):
     from common import UnitTest
     test = UnitTest(cmdline_args, "fi_av_test -g " + good_address + " -n 1 -s " + server_address)
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 @pytest.mark.parametrize("endpoint_type", ["rdm", "dgram"])
 def test_av_xfer(cmdline_args, endpoint_type):

--- a/fabtests/pytest/default/test_cm.py
+++ b/fabtests/pytest/default/test_cm.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_cm_data(cmdline_args):
     from common import ClientServerTest

--- a/fabtests/pytest/default/test_dgram.py
+++ b/fabtests/pytest/default/test_dgram.py
@@ -1,11 +1,13 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_dgram_g00n13s(cmdline_args):
     from common import UnitTest
     test = UnitTest(cmdline_args, "fi_dgram g00n13s", is_negative=True)
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_dgram(cmdline_args):
     from common import ClientServerTest

--- a/fabtests/pytest/default/test_inject_test.py
+++ b/fabtests/pytest/default/test_inject_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 @pytest.mark.parametrize("api_type", ["sendmsg", "post_tx"])
 @pytest.mark.parametrize("flag", ["inject", "inj_complete"])

--- a/fabtests/pytest/default/test_mr.py
+++ b/fabtests/pytest/default/test_mr.py
@@ -7,6 +7,7 @@ def test_mr(cmdline_args):
     test = UnitTest(cmdline_args, "fi_mr_test")
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 @pytest.mark.parametrize("endpoint_type", ["msg", "rdm"])
 def test_multi_mr(cmdline_args, endpoint_type):

--- a/fabtests/pytest/default/test_msg.py
+++ b/fabtests/pytest/default/test_msg.py
@@ -1,23 +1,27 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_msg_g00n13s(cmdline_args):
     from common import UnitTest
     test = UnitTest(cmdline_args, "fi_msg g00n13s", is_negative=True)
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_msg(cmdline_args):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, "fi_msg")
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_msg_epoll(cmdline_args):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, "fi_msg_epoll")
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_msg_sockets(cmdline_args):
     from common import ClientServerTest
@@ -27,6 +31,7 @@ def test_msg_sockets(cmdline_args):
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_msg_pingpong(cmdline_args, iteration_type, prefix_type, datacheck_type):
     from common import ClientServerTest
     command = "fi_msg_pingpong"
@@ -37,6 +42,7 @@ def test_msg_pingpong(cmdline_args, iteration_type, prefix_type, datacheck_type)
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_msg_bw(cmdline_args, iteration_type, datacheck_type):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, "fi_msg_bw", iteration_type,

--- a/fabtests/pytest/default/test_rdm.py
+++ b/fabtests/pytest/default/test_rdm.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.unit
 def test_rdm_g00n13s(cmdline_args):
     from common import UnitTest
@@ -13,12 +14,14 @@ def test_rdm(cmdline_args, completion_semantic):
     test = ClientServerTest(cmdline_args, "fi_rdm", completion_semantic=completion_semantic)
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_rdm_rma_event(cmdline_args):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, "fi_rdm_rma_event")
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_rdm_rma_trigger(cmdline_args):
     from common import ClientServerTest
@@ -32,6 +35,7 @@ def test_rdm_tagged_peek(cmdline_args):
     test = ClientServerTest(cmdline_args, "fi_rdm_tagged_peek")
     test.run()
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_rdm_shared_av(cmdline_args):
     from common import ClientServerTest
@@ -57,6 +61,7 @@ def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic):
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_cntr_pingpong(cmdline_args, iteration_type):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, "fi_rdm_cntr_pingpong", iteration_type)
@@ -87,6 +92,7 @@ def test_rdm_tagged_pingpong(cmdline_args, iteration_type,
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_tagged_bw(cmdline_args, iteration_type, datacheck_type, completion_semantic):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, "fi_rdm_tagged_bw", iteration_type,
@@ -96,6 +102,7 @@ def test_rdm_tagged_bw(cmdline_args, iteration_type, datacheck_type, completion_
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_bw_mt(cmdline_args, iteration_type, datacheck_type, completion_semantic):
     from common import ClientServerTest
     test = ClientServerTest(cmdline_args, "fi_rdm_bw_mt -n 4", iteration_type,

--- a/fabtests/pytest/default/test_scalable_ep.py
+++ b/fabtests/pytest/default/test_scalable_ep.py
@@ -1,5 +1,6 @@
 import pytest
 
+@pytest.mark.pr_ci
 @pytest.mark.functional
 def test_scalable_ep(cmdline_args):
     from common import ClientServerTest

--- a/fabtests/pytest/default/test_ubertest.py
+++ b/fabtests/pytest/default/test_ubertest.py
@@ -1,7 +1,7 @@
 import pytest
 
 @pytest.mark.parametrize("ubertest_test_type",
-                         [pytest.param("quick", marks=pytest.mark.ubertest_quick),
+                         [pytest.param("quick", marks=[pytest.mark.ubertest_quick, pytest.mark.pr_ci]),
                           pytest.param("all", marks=pytest.mark.ubertest_all),
                           pytest.param("verify", marks=pytest.mark.ubertest_verify)])
 def test_ubertest(cmdline_args, ubertest_test_type):

--- a/fabtests/pytest/shm/test_av.py
+++ b/fabtests/pytest/shm/test_av.py
@@ -1,6 +1,7 @@
 import pytest
 
 # shm only supports RDM EPs
+@pytest.mark.pr_ci
 @pytest.mark.functional
 @pytest.mark.parametrize("endpoint_type", ["rdm"])
 def test_av_xfer(cmdline_args, endpoint_type):

--- a/fabtests/pytest/sm2/test_av.py
+++ b/fabtests/pytest/sm2/test_av.py
@@ -1,6 +1,7 @@
 import pytest
 
 # sm2 only supports RDM EPs
+@pytest.mark.pr_ci
 @pytest.mark.functional
 @pytest.mark.parametrize("endpoint_type", ["rdm"])
 def test_av_xfer(cmdline_args, endpoint_type):

--- a/fabtests/pytest/sm2/test_rdm.py
+++ b/fabtests/pytest/sm2/test_rdm.py
@@ -5,6 +5,7 @@ from sm2.sm2_common import sm2_run_client_server_test
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type):
     sm2_run_client_server_test(cmdline_args, "fi_rdm_pingpong", iteration_type,
                                completion_semantic, memory_type, completion_type=completion_type)
@@ -13,6 +14,7 @@ def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic, memory_
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type):
     sm2_run_client_server_test(cmdline_args, "fi_rdm_tagged_pingpong", iteration_type,
                                completion_semantic, memory_type, completion_type=completion_type)
@@ -21,6 +23,7 @@ def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, 
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.pr_ci
 def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type):
     sm2_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw", iteration_type,
                                completion_semantic, memory_type, completion_type=completion_type)


### PR DESCRIPTION
… default suites

A provider cannot be selected with '-m pr_ci and not standard' while any test its suite runs carries no pr_ci marker, because asking for the pr_ci set then drops that test rather than narrowing the matrix. Mark the tests still missing it in shm/, sm2/ and default/.

The markers describe what PR CI already runs today. default/ is the suite used by the providers without a directory of their own, tcp and sockets, and is also re-exported by efa/, shm/ and sm2/.

test_ubertest is marked on its quick parametrization rather than on the function, which would also pull in the ubertest_all and ubertest_verify configs that no provider runs in PR CI.


(cherry picked from commit cc36feac5b96de60d168375eebed3bc759b216f5)