### PR TITLE
prov/efa: Make efa_av_array concurrent safe

### DIFF
--- a/prov/efa/src/efa_av_array.c
+++ b/prov/efa/src/efa_av_array.c
@@ -11,27 +11,37 @@ int efa_av_array_init_attr(struct efa_av_array **arr_out,
 {
 	struct efa_av_array *arr;
 	unsigned max_idx = attr ? attr->max_idx : 0;
+	unsigned inline_size = (attr && attr->inline_size) ?
+			       attr->inline_size : EFA_AV_ARRAY_INLINE_SIZE;
+	unsigned chunk_size = (attr && attr->chunk_size) ?
+			      attr->chunk_size : EFA_AV_ARRAY_CHUNK_SIZE;
 
 	*arr_out = NULL;
 
-	if (max_idx == 0)
-		max_idx = EFA_AV_ARRAY_DEFAULT_MAX_IDX;
+	if (max_idx == 0) {
+		size_t def = (size_t) inline_size * chunk_size - 1;
+
+		max_idx = def > EFA_AV_ARRAY_MAX_IDX_CEILING ?
+			  EFA_AV_ARRAY_MAX_IDX_CEILING : (unsigned) def;
+	}
 	if (max_idx > EFA_AV_ARRAY_MAX_IDX_CEILING) {
 		EFA_WARN(FI_LOG_AV, "efa_av_array max_idx %u out of range\n",
 			 max_idx);
 		return -FI_EINVAL;
 	}
 
-	arr = calloc(1, sizeof(*arr));
+	arr = calloc(1, sizeof(*arr) +
+		     (size_t) inline_size * sizeof(*arr->inline_entries));
 	if (!arr)
 		return -FI_ENOMEM;
 
 	arr->max_idx = max_idx;
-	if (max_idx >= EFA_AV_ARRAY_FAST_CUTOFF) {
-		size_t span = (size_t) max_idx - EFA_AV_ARRAY_FAST_CUTOFF + 1;
+	arr->inline_size = inline_size;
+	arr->chunk_size = chunk_size;
+	if (max_idx >= inline_size) {
+		size_t span = (size_t) max_idx - inline_size + 1;
 
-		arr->chunk_table_len = (span + EFA_AV_ARRAY_CHUNK_SIZE - 1) /
-				       EFA_AV_ARRAY_CHUNK_SIZE;
+		arr->chunk_table_len = (span + chunk_size - 1) / chunk_size;
 	}
 
 	*arr_out = arr;
@@ -58,49 +68,76 @@ void efa_av_array_destroy(struct efa_av_array *arr)
 	free(arr);
 }
 
-/* This function must be protected by a lock. The lock will guarantee that
- * only 1 writer can insert at a time and will make sure there is a memory
- * barrier before entering and after exiting.
- * This is sufficient because the man pages state that a program must wait
- * for fi_av_insert to return before doing work that requires that AV.
+/*
+ * IMPORTANT: must be called with a lock to serialize writes.
+ *
+ * Publishing model (single writer, any number of lock-free readers):
+ *
+ * All backing memory -- the entry payload and calloc'd chunk/cunk table --
+ * is fully initialized before the single ofi_wmb() so that every pointer
+ * that is published is a valid pointer.
+ *
+ * A reader (efa_av_array_at) issues one ofi_rmb() before walking
+ * chunk_table -> chunk -> entry. Any pointer that is NULL in this chain
+ * just indicates "no entry," which is a valid, safe return for a racing
+ * insert and read call.
+ *
+ * see comments in efa_av_array.h for more context and information.
  */
-int efa_av_array_insert(struct efa_av_array *arr, unsigned index, void *entry)
+int efa_av_array_insert(struct efa_av_array *arr, uint64_t index, void *entry)
 {
-	void **table = NULL;
-	void **chunk = NULL;
-	size_t rel, chunk_idx;
+	void **table;
+	void **chunk;
+	size_t rel, chunk_idx, off;
+	bool new_table = false;
+	bool new_chunk = false;
 
 	if (index > arr->max_idx)
 		return -FI_EINVAL;
 
-	if (index < EFA_AV_ARRAY_FAST_CUTOFF) {
-		arr->fast[index] = entry;
+	if (index < arr->inline_size) {
+		/* Make sure the caller's entry is written before publishing */
+		ofi_wmb();
+		arr->inline_entries[index] = entry;
 		return FI_SUCCESS;
 	}
 
-	if (OFI_UNLIKELY(!arr->chunk_table)) {
+	rel = (size_t) index - arr->inline_size;
+	chunk_idx = rel / arr->chunk_size;
+	off = rel % arr->chunk_size;
+
+	table = arr->chunk_table;
+	if (OFI_UNLIKELY(!table)) {
 		table = calloc(arr->chunk_table_len, sizeof(*table));
 		if (!table)
 			return -FI_ENOMEM;
-
-		arr->chunk_table = table;
+		new_table = true;
 	}
-
-	table = arr->chunk_table;
-
-	rel = (size_t) index - EFA_AV_ARRAY_FAST_CUTOFF;
-	chunk_idx = rel / EFA_AV_ARRAY_CHUNK_SIZE;
 
 	chunk = table[chunk_idx];
 	if (OFI_UNLIKELY(!chunk)) {
-		chunk = calloc(EFA_AV_ARRAY_CHUNK_SIZE, sizeof(*chunk));
-		if (!chunk)
+		chunk = calloc(arr->chunk_size, sizeof(*chunk));
+		if (!chunk) {
+			if (new_table)
+				free(table);
 			return -FI_ENOMEM;
-
-		table[chunk_idx] = chunk;
+		}
+		new_chunk = true;
 	}
 
-	chunk[rel % EFA_AV_ARRAY_CHUNK_SIZE] = entry;
+	/*
+	 * We just need to guarantee that memory is initialized before
+	 * publishing the pointer to it. See function comment for more info
+	 */
+	ofi_wmb();
+	chunk[off] = entry;
+
+	/* avoid re-publishing pointers to avoid cache invalidations */
+	if (OFI_UNLIKELY(new_chunk))
+		table[chunk_idx] = chunk;
+	if (OFI_UNLIKELY(new_table))
+		arr->chunk_table = table;
+
 	return FI_SUCCESS;
 }
 
@@ -110,8 +147,9 @@ void efa_av_array_iter(struct efa_av_array *arr, void *context,
 {
 	size_t i, j;
 
-	for (i = 0; i < EFA_AV_ARRAY_FAST_CUTOFF; i++) {
-		if (arr->fast[i] && fn(arr, arr->fast[i], context))
+	for (i = 0; i < arr->inline_size; i++) {
+		if (arr->inline_entries[i] &&
+		    fn(arr, arr->inline_entries[i], context))
 			return;
 	}
 
@@ -123,7 +161,7 @@ void efa_av_array_iter(struct efa_av_array *arr, void *context,
 
 		if (!chunk)
 			continue;
-		for (j = 0; j < EFA_AV_ARRAY_CHUNK_SIZE; j++) {
+		for (j = 0; j < arr->chunk_size; j++) {
 			if (chunk[j] && fn(arr, chunk[j], context))
 				return;
 		}

--- a/prov/efa/src/efa_av_array.h
+++ b/prov/efa/src/efa_av_array.h
@@ -5,40 +5,54 @@
 #define EFA_AV_ARRAY_H
 
 #include <stddef.h>
+#include <stdbool.h>
+#include <stdint.h>
 #include <ofi_mb.h>
 
-/* Indexes below this are served from the embedded fast array. */
-#define EFA_AV_ARRAY_FAST_CUTOFF 8192
-/* Indexes per chunk for the region at or above the fast array. */
+#define EFA_AV_ARRAY_INLINE_SIZE 8192
 #define EFA_AV_ARRAY_CHUNK_SIZE 8192
 /* Largest max_idx an array may be created with. */
 #define EFA_AV_ARRAY_MAX_IDX_CEILING 1000000000
 /* max_idx applied when the caller passes 0. */
 #define EFA_AV_ARRAY_DEFAULT_MAX_IDX \
-	(EFA_AV_ARRAY_FAST_CUTOFF * EFA_AV_ARRAY_CHUNK_SIZE - 1)
+	(EFA_AV_ARRAY_INLINE_SIZE * EFA_AV_ARRAY_CHUNK_SIZE - 1)
 
 /*
- * A pointer array indexed by an unsigned int in [0, max_idx] for endpoint peer
+ * A pointer array indexed by a uint64_t in [0, max_idx] for endpoint peer
  * lookup by fi_addr. Each slot holds a caller-owned pointer or NULL.
  *
- * Indexes below EFA_AV_ARRAY_FAST_CUTOFF live in the embedded fast array and are
- * reached by direct indexing. Higher indexes live in chunks reached through a
- * chunk table that is sized once at creation and never reallocated; chunks are
- * allocated on first use and are neither freed nor moved before destroy.
+ * Indexes less than inline_size live in the inline array and are reached by direct
+ * indexing. Higher indexes live in chunks reached through a chunk table that is
+ * sized once at creation and never reallocated; chunks are allocated on first
+ * use and are neither freed nor moved before destroy.
  *
- * Note that while this struct is thread-safe, it is not safe for
- * for concurrent writes and reads, only concurrent reads.
+ * insert() publishes each newly reachable pointer after a write barrier and
+ * at() consumes them behind a read barrier, so a single writer may run
+ * concurrently with any number of lock-free readers. This works for both of our
+ * use cases:
+ *   1) the av array itself, which is only written by fi_av_insert() and cannot
+ *      be read until that insert finishes (stated in the man pages)
+ *   2) peer maps, which are added to lazily, so a reader may run concurrently
+ *      with a writer
  */
 struct efa_av_array {
 	void **chunk_table;
 	size_t chunk_table_len;
 	unsigned max_idx;
-	void *fast[EFA_AV_ARRAY_FAST_CUTOFF];
+	unsigned inline_size;
+	unsigned chunk_size;
+	/* Flexible array member allocated with the struct; must stay last. */
+	void *inline_entries[];
 };
+
+_Static_assert(offsetof(struct efa_av_array, inline_entries) % 8 == 0,
+	       "efa_av_array inline_entries must be 8-byte aligned");
 
 struct efa_av_array_attr {
 	/* Largest valid index; 0 selects EFA_AV_ARRAY_DEFAULT_MAX_IDX. */
 	unsigned max_idx;
+	unsigned inline_size;
+	unsigned chunk_size;
 };
 
 /*
@@ -51,7 +65,7 @@ int efa_av_array_init_attr(struct efa_av_array **arr,
 			   const struct efa_av_array_attr *attr);
 void efa_av_array_destroy(struct efa_av_array *arr);
 
-int efa_av_array_insert(struct efa_av_array *arr, unsigned index, void *entry);
+int efa_av_array_insert(struct efa_av_array *arr, uint64_t index, void *entry);
 
 /* Calls fn for each non-NULL entry, stopping early if fn returns non-zero. */
 void efa_av_array_iter(struct efa_av_array *arr, void *context,
@@ -61,40 +75,47 @@ void efa_av_array_iter(struct efa_av_array *arr, void *context,
 /*
  * Returns the pointer stored at index, or NULL if the index is out of range or
  * holds no entry.
+ *
+ * Concurrency: one writer, any number of lock-free readers.
+ * This relies on a structural invariance of the fi_addr_t usage-- once a
+ * a pointer is published, the pointer is good for the life of the array,
+ * meaning that we only need a single rmb() at the beginning of the read
+ * function, as long as we are careful about publishing pointers in the
+ * correct order and after their data is written.
+ *
+ * An observant reader might note that we DO have a remove function, but
+ * The man pages state that a remove CANNOT be called with in-flight
+ * packets though (think: why would a user want this anyways??) so a remove
+ * will not race with a lookup, meaning that the single rmb() guarantees
+ * safety.
  */
-static inline void *efa_av_array_at(const struct efa_av_array *arr, unsigned index)
+static inline void *efa_av_array_at(const struct efa_av_array *arr, uint64_t index)
 {
 	void **table;
 	void *chunk;
-	void *entry;
 	size_t rel;
 
-	/* Single read memory barrier. Since this code is thread safe, but
-	 * non-concurrent, we just need to make sure that we don't have
-	 * stale, cached reads from before the last insert() call was made.
-	 * This can be accomplished with a single rmb here.
+	/* This rmb() is defensive, but possibly not necessary. More
+	 * research would be needed
 	 */
 	ofi_rmb();
 
 	if (index > arr->max_idx)
 		return NULL;
 
-	if (index < EFA_AV_ARRAY_FAST_CUTOFF) {
-		entry = arr->fast[index];
-	} else {
-		table = arr->chunk_table;
-		if (!table)
-			return NULL;
+	if (index < arr->inline_size)
+		return arr->inline_entries[index];
 
-		rel = (size_t) index - EFA_AV_ARRAY_FAST_CUTOFF;
-		chunk = table[rel / EFA_AV_ARRAY_CHUNK_SIZE];
-		if (!chunk)
-			return NULL;
+	table = arr->chunk_table;
+	if (!table)
+		return NULL;
 
-		entry = ((void **) chunk)[rel % EFA_AV_ARRAY_CHUNK_SIZE];
-	}
+	rel = (size_t) index - arr->inline_size;
+	chunk = table[rel / arr->chunk_size];
+	if (!chunk)
+		return NULL;
 
-	return entry;
+	return ((void **) chunk)[rel % arr->chunk_size];
 }
 
 #endif /* EFA_AV_ARRAY_H */

--- a/prov/efa/test/gtest/efa_gtest_av_array.cc
+++ b/prov/efa/test/gtest/efa_gtest_av_array.cc
@@ -31,7 +31,7 @@ class EfaAvArrayTest : public Test
 			efa_test_av_array_destroy(arr);
 	}
 
-	int cutoff() { return efa_test_av_array_fast_cutoff; }
+	int cutoff() { return efa_test_av_array_inline_size; }
 	int chunk() { return efa_test_av_array_chunk_size; }
 };
 
@@ -222,6 +222,33 @@ TEST_F(EfaAvArrayTest, iter_stops_early)
 	EXPECT_EQ(efa_test_av_array_insert(arr, 1, entry_ptr(8)), 0);
 	EXPECT_EQ(efa_test_av_array_insert(arr, cutoff() + 5, entry_ptr(8)), 0);
 	EXPECT_EQ(efa_test_av_array_iter_first_hit(arr, entry_ptr(8)), 1);
+}
+
+/* Custom inline_size/chunk_size stores and reads back across the inline region
+ * and multiple chunks (exercises the barrier paths). */
+TEST_F(EfaAvArrayTest, custom_attr_concurrent_safe_roundtrip)
+{
+	const unsigned inl = 4, chk = 8;
+	struct efa_av_array *a = efa_test_av_array_create_attr(1000, inl, chk);
+	ASSERT_NE(a, nullptr);
+
+	/* Inline region. */
+	EXPECT_EQ(efa_test_av_array_insert(a, inl - 1, entry_ptr(1)), 0);
+	EXPECT_EQ(efa_test_av_array_at(a, inl - 1), entry_ptr(1));
+	EXPECT_EQ(efa_test_av_array_has_chunk_table(a), 0);
+
+	/* First chunk-region index allocates the chunk table. */
+	EXPECT_EQ(efa_test_av_array_insert(a, inl, entry_ptr(2)), 0);
+	EXPECT_EQ(efa_test_av_array_has_chunk_table(a), 1);
+	EXPECT_EQ(efa_test_av_array_at(a, inl), entry_ptr(2));
+
+	/* An index several chunks in reads back and does not disturb the others. */
+	EXPECT_EQ(efa_test_av_array_insert(a, inl + 2 * chk + 1, entry_ptr(3)), 0);
+	EXPECT_EQ(efa_test_av_array_at(a, inl + 2 * chk + 1), entry_ptr(3));
+	EXPECT_EQ(efa_test_av_array_at(a, inl + chk), nullptr);
+	EXPECT_EQ(efa_test_av_array_count(a), 3);
+
+	efa_test_av_array_destroy(a);
 }
 
 /* Destroying a NULL array is a no-op. */

--- a/prov/efa/test/gtest/efa_gtest_av_array_utils.c
+++ b/prov/efa/test/gtest/efa_gtest_av_array_utils.c
@@ -4,7 +4,7 @@
 #include "efa_gtest_av_array_utils.h"
 #include "efa_av_array.h"
 
-const int efa_test_av_array_fast_cutoff = EFA_AV_ARRAY_FAST_CUTOFF;
+const int efa_test_av_array_inline_size = EFA_AV_ARRAY_INLINE_SIZE;
 const int efa_test_av_array_chunk_size = EFA_AV_ARRAY_CHUNK_SIZE;
 const int efa_test_av_array_max_idx_ceiling = EFA_AV_ARRAY_MAX_IDX_CEILING;
 const int efa_test_av_array_default_max_idx = EFA_AV_ARRAY_DEFAULT_MAX_IDX;
@@ -29,18 +29,33 @@ struct efa_av_array *efa_test_av_array_create_max(unsigned max_idx)
 	return arr;
 }
 
+struct efa_av_array *efa_test_av_array_create_attr(unsigned max_idx,
+						   unsigned inline_size,
+						   unsigned chunk_size)
+{
+	struct efa_av_array *arr;
+	struct efa_av_array_attr attr = {0};
+
+	attr.max_idx = max_idx;
+	attr.inline_size = inline_size;
+	attr.chunk_size = chunk_size;
+	if (efa_av_array_init_attr(&arr, &attr))
+		return NULL;
+	return arr;
+}
+
 void efa_test_av_array_destroy(struct efa_av_array *arr)
 {
 	efa_av_array_destroy(arr);
 }
 
-int efa_test_av_array_insert(struct efa_av_array *arr, unsigned index,
+int efa_test_av_array_insert(struct efa_av_array *arr, uint64_t index,
 			     void *entry)
 {
 	return efa_av_array_insert(arr, index, entry);
 }
 
-void *efa_test_av_array_at(struct efa_av_array *arr, unsigned index)
+void *efa_test_av_array_at(struct efa_av_array *arr, uint64_t index)
 {
 	return efa_av_array_at(arr, index);
 }

--- a/prov/efa/test/gtest/efa_gtest_av_array_utils.h
+++ b/prov/efa/test/gtest/efa_gtest_av_array_utils.h
@@ -6,6 +6,8 @@
 #ifndef EFA_GTEST_AV_ARRAY_UTILS_H
 #define EFA_GTEST_AV_ARRAY_UTILS_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -16,11 +18,15 @@ struct efa_av_array;
 struct efa_av_array *efa_test_av_array_create(void);
 /* Create with a custom max_idx; NULL if the value is rejected. */
 struct efa_av_array *efa_test_av_array_create_max(unsigned max_idx);
+/* Create with explicit attr fields; NULL if rejected. 0 selects defaults. */
+struct efa_av_array *efa_test_av_array_create_attr(unsigned max_idx,
+						   unsigned inline_size,
+						   unsigned chunk_size);
 void efa_test_av_array_destroy(struct efa_av_array *arr);
 
-int efa_test_av_array_insert(struct efa_av_array *arr, unsigned index,
+int efa_test_av_array_insert(struct efa_av_array *arr, uint64_t index,
 			     void *entry);
-void *efa_test_av_array_at(struct efa_av_array *arr, unsigned index);
+void *efa_test_av_array_at(struct efa_av_array *arr, uint64_t index);
 
 /* Non-zero once the array has allocated its chunk table. */
 int efa_test_av_array_has_chunk_table(struct efa_av_array *arr);
@@ -29,7 +35,7 @@ int efa_test_av_array_count(struct efa_av_array *arr);
 /* Iterate, stopping at the first entry equal to target; 1 if found, else 0. */
 int efa_test_av_array_iter_first_hit(struct efa_av_array *arr, void *target);
 
-extern const int efa_test_av_array_fast_cutoff;
+extern const int efa_test_av_array_inline_size;
 extern const int efa_test_av_array_chunk_size;
 extern const int efa_test_av_array_max_idx_ceiling;
 extern const int efa_test_av_array_default_max_idx;


### PR DESCRIPTION
    Makes the efa_av_array concurrent safe by adding a write memory barrier
    before pointer publishing. Writes must still be guarded by a lock to
    prevent multiple writers.

    insert() publishes each newly reachable pointer after a write barrier and
    at() consumes them behind a read barrier, so a single writer may run
    concurrently with any number of lock-free readers. This works for both of our
    use cases:
     1) the av array itself, which is only written by fi_av_insert() and cannot
        be read until that insert finishes (stated in the man pages)
     2) peer maps, which are added to lazily, meaning simultaneous writes
        could cause readers to access the list concurrently with writers, since
        we don't have the guarantee that usecase (1) has. This scenario happens
        when 2 threads simultaneous write to a peer that HAS been added to the
        av list, but has not yet been communicated with, causing a race to
        insert/read from the peer map's efa_av_array.

    Also makes inline size and chunk size run time definable attributes.

    changed index from uint to uint64_t