### PR TITLE
fabtests/efa: Update MR Abort Test Cases

### DIFF
--- a/fabtests/pytest/efa/test_mr_abort.py
+++ b/fabtests/pytest/efa/test_mr_abort.py
@@ -48,6 +48,10 @@ def combined_msg_size_params():
 
             for high_pps_val in high_pps_vals:
                 for sl_low_latency_val in sl_low_latency_vals:
+                    # high_pps and sl_low_latency are mutually exclusive:
+                    # do not generate test cases with both enabled
+                    if high_pps_val and sl_low_latency_val:
+                        continue
 
                     id = f"{rma_op}-{size}"
 

--- a/fabtests/pytest/efa/test_mr_abort.py
+++ b/fabtests/pytest/efa/test_mr_abort.py
@@ -40,18 +40,18 @@ def combined_msg_size_params():
     for rma_op in ["write", "read", "writedata"]:
         for size in BASE_MESSAGE_SIZES:
 
-            high_pps_vals = [None]
-            sl_low_latency_vals = [None]
+            use_high_pps_vals = [None]
+            use_sl_low_latency_vals = [None]
 
             if (rma_op == "write" or rma_op == "writedata"):
                 # High PPS parametrization is only applicable for RDMA writes
                 # up to 64KB
                 if size <= HIGH_PPS_MAX_WRITE_SIZE:
-                    high_pps_vals = [True, False]
+                    use_high_pps_vals = [True, False]
 
                 # Low latency SL is only applicable for RDMA writes up to 8 KiB
                 if size <= SL_LOW_LATENCY_MAX_WRITE_SIZE:
-                    sl_low_latency_vals = [True, False]
+                    use_sl_low_latency_vals = [True, False]
 
             marks = []
             if size == 10485760:
@@ -60,28 +60,28 @@ def combined_msg_size_params():
                 # parallel workers
                 marks = [pytest.mark.serial]
 
-            for high_pps_val in high_pps_vals:
-                for sl_low_latency_val in sl_low_latency_vals:
+            for use_high_pps in use_high_pps_vals:
+                for use_sl_low_latency in use_sl_low_latency_vals:
                     # high_pps and sl_low_latency are mutually exclusive:
                     # do not generate test cases with both enabled
-                    if high_pps_val and sl_low_latency_val:
+                    if use_high_pps and use_sl_low_latency:
                         continue
 
                     # 128B exists only to pin the low latency SL firmware
                     # boundary; skip every other combination at that size
-                    if size == 128 and not sl_low_latency_val:
+                    if size == 128 and not use_sl_low_latency:
                         continue
 
                     id = f"{rma_op}-{size}"
 
-                    if high_pps_val is not None:
-                        id += f"-high_pps-{high_pps_val}"
+                    if use_high_pps is not None:
+                        id += f"-high_pps-{use_high_pps}"
 
-                    if sl_low_latency_val is not None:
-                        id += f"-sl_low_lat-{sl_low_latency_val}"
+                    if use_sl_low_latency is not None:
+                        id += f"-sl_low_lat-{use_sl_low_latency}"
 
-                    yield pytest.param(size, rma_op, high_pps_val,
-                                       sl_low_latency_val, marks=marks, id=id)
+                    yield pytest.param(size, rma_op, use_high_pps,
+                                       use_sl_low_latency, marks=marks, id=id)
 
 
 # --- Test: abort (RMA) ---

--- a/fabtests/pytest/efa/test_mr_abort.py
+++ b/fabtests/pytest/efa/test_mr_abort.py
@@ -21,7 +21,10 @@ BASE_MESSAGE_SIZES = [
     10485760,
 ]
 
-SL_LOW_LATENCY_MAX_WRITE_SIZE = 128
+# The low latency service level only accelerates write WQEs <= 128 bytes,
+# but request it for writes up to 8 KiB so a single run mixes the
+# accelerated (<= 128B) and non-accelerated flows.
+SL_LOW_LATENCY_MAX_WRITE_SIZE = 8192
 
 
 def combined_msg_size_params():
@@ -35,8 +38,8 @@ def combined_msg_size_params():
                 # High PPS parametrization is only applicable for RDMA writes
                 high_pps_vals = [True, False]
 
-                # Low latency SL is only applicable for small RDMA writes
-                if size < SL_LOW_LATENCY_MAX_WRITE_SIZE:
+                # Low latency SL is only applicable for RDMA writes up to 8 KiB
+                if size <= SL_LOW_LATENCY_MAX_WRITE_SIZE:
                     sl_low_latency_vals = [True, False]
 
             marks = []
@@ -91,7 +94,7 @@ def test_mr_abort(cmdline_args, rma_fabric, rma_op, cancel_order, close_side, op
 
     if sl_low_latency:
         assert(rma_op != "read")
-        assert(message_size < 128)
+        assert(message_size <= SL_LOW_LATENCY_MAX_WRITE_SIZE)
         command += " --sl-low-latency"
 
     test = ClientServerTest(cmdline_args, command, timeout=300, fabric=rma_fabric, memory_type=memory_type)
@@ -117,7 +120,7 @@ def test_mr_abort_partial(cmdline_args, rma_fabric, rma_op, high_pps,
 
     if sl_low_latency:
         assert(rma_op != "read")
-        assert(message_size < 128)
+        assert(message_size <= SL_LOW_LATENCY_MAX_WRITE_SIZE)
         command += " --sl-low-latency"
 
     test = ClientServerTest(cmdline_args, command, timeout=300, fabric=rma_fabric, memory_type=memory_type)

--- a/fabtests/pytest/efa/test_mr_abort.py
+++ b/fabtests/pytest/efa/test_mr_abort.py
@@ -24,6 +24,12 @@ BASE_MESSAGE_SIZES = [
     10485760,
 ]
 
+# The high PPS WQE hint only accelerates writes <= 8KB, but writes up to
+# 64KB marked high-pps exercise special handling that routes them back to
+# the default processing path. Request high PPS for writes up to 64KB to
+# utilize both paths; larger sizes add no new coverage.
+HIGH_PPS_MAX_WRITE_SIZE = 65536
+
 # The low latency service level only accelerates write WQEs <= 128 bytes,
 # but request it for writes up to 8 KiB so a single run mixes the
 # accelerated (<= 128B) and non-accelerated flows.
@@ -39,7 +45,9 @@ def combined_msg_size_params():
 
             if (rma_op == "write" or rma_op == "writedata"):
                 # High PPS parametrization is only applicable for RDMA writes
-                high_pps_vals = [True, False]
+                # up to 64KB
+                if size <= HIGH_PPS_MAX_WRITE_SIZE:
+                    high_pps_vals = [True, False]
 
                 # Low latency SL is only applicable for RDMA writes up to 8 KiB
                 if size <= SL_LOW_LATENCY_MAX_WRITE_SIZE:

--- a/fabtests/pytest/efa/test_mr_abort.py
+++ b/fabtests/pytest/efa/test_mr_abort.py
@@ -15,6 +15,9 @@ MR_ABORT_NUM_MRS = 2046
 
 BASE_MESSAGE_SIZES = [
     64,
+    # 128B is the largest write WQE the low latency service level
+    # accelerates; only low-latency cases are generated at this size
+    128,
     4096,
     65536,
     1048576,
@@ -54,6 +57,11 @@ def combined_msg_size_params():
                     # high_pps and sl_low_latency are mutually exclusive:
                     # do not generate test cases with both enabled
                     if high_pps_val and sl_low_latency_val:
+                        continue
+
+                    # 128B exists only to pin the low latency SL firmware
+                    # boundary; skip every other combination at that size
+                    if size == 128 and not sl_low_latency_val:
                         continue
 
                     id = f"{rma_op}-{size}"


### PR DESCRIPTION
* ebe6c760 (HEAD -> do-not-run-highpps-and-lowlat-at-same-time, szegel/do-not-run-highpps-and-lowlat-at-same-time) fabtests/efa: Rename MR abort parametrization variables for clarity
* 65f766b9 fabtests/efa: Cap high PPS MR abort writes at 64KB
* 320ef644 fabtests/efa: Add 128B low latency case to MR abort fabtest
* 8d2ac635 fabtests/efa: Request low latency SL for MR abort writes up to 8KB
* f4ec3f8e fabtests/efa: Do not combine high PPS and low latency SL in MR abort test