### PR TITLE
prov/efa: add lsan suppression for ofi_reg_dl_prov

### DIFF
--- a/prov/efa/test/lsan.supp
+++ b/prov/efa/test/lsan.supp
@@ -2,3 +2,8 @@
 #
 # benign suppression: persistent glibc allocation
 leak:_dlerror_run
+
+# benign suppression: glibc dlopen bookkeeping from libfabric core's
+# one-time dynamically-loaded provider registration (fi_ini). The DSO is
+# intentionally never dlclose'd; observed on aarch64 (ubuntu2204).
+leak:ofi_reg_dl_prov


### PR DESCRIPTION
The EFA unit tests (efa_gtest) fail with a 24-byte leak reported by LeakSanitizer on the c7g_ubuntu2204 PR-CI container (aarch64). The stack is:

  dlopen <- ofi_reg_dl_prov <- fi_ini

This is the same class of benign glibc/dlopen bookkeeping already suppressed by the existing _dlerror_run rule, but that pattern does not match this particular call path. The DSO is intentionally never dlclose'd.

Add leak:ofi_reg_dl_prov to the existing lsan.supp file.