### PR TITLE
fabtests/efa: Run MR abort tests with 4 EP's per Domain

### DIFF
--- a/fabtests/prov/efa/src/mr_abort.c
+++ b/fabtests/prov/efa/src/mr_abort.c
@@ -77,6 +77,7 @@ enum test_mode {
 enum {
 	OPT_NUM_TARGET_EPS = 512,
 	OPT_NUM_INITIATOR_EPS,
+	OPT_PARTIAL_SPLIT_EPS,
 };
 
 /*
@@ -140,6 +141,15 @@ static int close_ep_first;
 static int set_homogeneous_peers;
 static bool use_high_pps = false;
 static bool sl_low_latency = false;
+
+/*
+ * -T partial only: post each slot's two aliased-MR writes from two different
+ * initiator endpoints -- the surviving op from the slot's own pair endpoint,
+ * the to-be-canceled op from the next pair's endpoint. Verifies that closing
+ * an MR only aborts that MR's op even when the two ops entered the device
+ * through different QPs. Requires --num-initiator-eps >= 2.
+ */
+static bool partial_split_eps = false;
 
 #define EFA_MR_ABORT_MAX_EPS 64
 
@@ -1247,12 +1257,25 @@ static int run_fill_abort_target(void)
  * Runs once per slot, and num_mrs == num_initiator_eps here, so every pair is
  * covered exactly once. Every pair posts and closes before any completion is
  * reaped, so a close must only abort the ops on its own MR.
+ *
+ * --partial-split-eps additionally posts each slot's two ops through two
+ * different initiator endpoints (see partial_post_one_slot), so the
+ * close-only-aborts-its-own-MR property is also checked across QPs.
  */
 
 /*
  * Post both writes for one slot and close the alias MR. Slot mr_idx owns
  * op_arr[2 * mr_idx] (op on the surviving slot MR) and op_arr[2 * mr_idx + 1]
  * (op on the closed alias); max_ops() sizes op_arr to match.
+ *
+ * With --partial-split-eps the two writes enter the device through different
+ * QPs: the surviving op from the slot's own pair endpoint, the to-be-canceled
+ * op from the next pair's endpoint. Both still target the same remote
+ * endpoint -- pair mr_idx's target EP -- because the remote MRs live on that
+ * EP's domain, so its rkeys are only valid there. The alias MR is registered
+ * on the split endpoint's domain so the split endpoint can send from it, and
+ * the target address is resolved through the split endpoint's domain's AV
+ * (an fi_addr_t is only valid against the AV that produced it).
  */
 static int partial_post_one_slot(int mr_idx)
 {
@@ -1260,14 +1283,30 @@ static int partial_post_one_slot(int mr_idx)
 	struct fi_rma_iov local_iov, remote_iov;
 	struct op_ctx *surviving = &op_arr[2 * mr_idx];
 	struct op_ctx *closed = &op_arr[2 * mr_idx + 1];
+	struct fid_ep *closed_ep;
+	struct fid_domain *closed_dom;
+	fi_addr_t closed_peer_addr;
 	int ret;
+
+	if (partial_split_eps) {
+		int split_ep_idx = (mr_idx + 1) % num_initiator_eps;
+
+		closed_ep = eps[split_ep_idx];
+		closed_dom = doms[dom_of(split_ep_idx)].domain;
+		closed_peer_addr = doms[dom_of(split_ep_idx)]
+				.peer_addrs[target_ep_for_pair[mr_idx]];
+	} else {
+		closed_ep = op_local_ep(mr_idx);
+		closed_dom = op_dom(mr_idx)->domain;
+		closed_peer_addr = op_peer_addr(mr_idx);
+	}
 
 	/* Use this slot's buffer for both MRs */
 	extra_slot.buf = slots[mr_idx].buf;
 	/* Unique key: slot keys occupy [BASE, BASE + num_mrs) */
 	extra_slot.key = MR_ABORT_KEY_BASE + num_mrs + mr_idx;
 
-	ret = ft_reg_mr_dom(op_dom(mr_idx)->domain, op_local_ep(mr_idx), fi,
+	ret = ft_reg_mr_dom(closed_dom, closed_ep, fi,
 			    extra_slot.buf, opts.transfer_size,
 			    ft_info_to_mr_access(fi), extra_slot.key, opts.iface,
 			    opts.device, &extra_slot.mr, &extra_slot.desc);
@@ -1303,8 +1342,8 @@ static int partial_post_one_slot(int mr_idx)
 
 	/* Post write using extra MR (will be closed) */
 	closed->mr_idx = mr_idx;
-	ret = fi_write(op_local_ep(mr_idx), extra_slot.buf, opts.transfer_size,
-		       extra_slot.desc, op_peer_addr(mr_idx),
+	ret = fi_write(closed_ep, extra_slot.buf, opts.transfer_size,
+		       extra_slot.desc, closed_peer_addr,
 		       remote_iov.addr, remote_iov.key, &closed->context);
 	if (ret) {
 		FT_PRINTERR("fi_write (extra)", ret);
@@ -2562,6 +2601,7 @@ static int run(void)
 static struct option mr_abort_extra_opts[] = {
 	{"num-target-eps", required_argument, NULL, OPT_NUM_TARGET_EPS},
 	{"num-initiator-eps", required_argument, NULL, OPT_NUM_INITIATOR_EPS},
+	{"partial-split-eps", no_argument, NULL, OPT_PARTIAL_SPLIT_EPS},
 	{0, 0, 0, 0}
 };
 
@@ -2628,6 +2668,9 @@ int main(int argc, char **argv)
 		case OPT_NUM_INITIATOR_EPS:
 			num_initiator_eps = atoi(optarg);
 			initiator_eps_set = true;
+			break;
+		case OPT_PARTIAL_SPLIT_EPS:
+			partial_split_eps = true;
 			break;
 		case OPT_EPS_PER_DOMAIN:
 			eps_per_domain = atoi(optarg);
@@ -2751,6 +2794,11 @@ int main(int argc, char **argv)
 			FT_PRINT_OPTS_USAGE("--num-initiator-eps <n>",
 				"Number of endpoints on the initiator side "
 				"(>= --num-target-eps; incast)");
+			FT_PRINT_OPTS_USAGE("--partial-split-eps",
+				"-T partial only: post the surviving and "
+				"to-be-canceled ops from two different "
+				"initiator endpoints (requires >= 2 "
+				"initiator endpoints)");
 			efa_longopts_usage();
 			return EXIT_FAILURE;
 		}
@@ -2837,6 +2885,17 @@ int main(int argc, char **argv)
 		FT_ERR("Target-close (-R target) is not supported for "
 		       "the partial test (-T partial): it only closes a "
 		       "local MR on the initiator");
+		return EXIT_FAILURE;
+	}
+
+	if (partial_split_eps && test_mode != TEST_PARTIAL) {
+		FT_ERR("--partial-split-eps is only valid with -T partial");
+		return EXIT_FAILURE;
+	}
+
+	if (partial_split_eps && num_initiator_eps < 2) {
+		FT_ERR("--partial-split-eps requires at least 2 initiator "
+		       "endpoints (have %d)", num_initiator_eps);
 		return EXIT_FAILURE;
 	}
 

--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -331,7 +331,7 @@ class UnitTest:
             failing_warn_msgs = [failing_warn_msgs]
 
         if failing_warn_msgs:
-            self._cmdline_args = copy.copy(cmdline_args)
+            self._cmdline_args = copy.deepcopy(cmdline_args)
             self._cmdline_args.append_environ("FI_LOG_LEVEL=warn")
         else:
             self._cmdline_args = cmdline_args
@@ -811,7 +811,7 @@ class MultinodeTest(ClientServerTest):
         self._server_base_command = cmdline_args.populate_command(server_base_command, "server", self._timeout)
         self._client_base_command_list = []
         for client_hostname in client_hostname_list:
-            cmdline_args_copy = copy.copy(cmdline_args)
+            cmdline_args_copy = copy.deepcopy(cmdline_args)
             cmdline_args_copy.client_id = client_hostname
             self._client_base_command_list.append(cmdline_args_copy.populate_command(client_base_command, "client", self._timeout))
         self._run_client_asynchronously = run_client_asynchronously

--- a/fabtests/pytest/conftest.py
+++ b/fabtests/pytest/conftest.py
@@ -286,7 +286,7 @@ class CmdlineArgs:
 
         return command
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def cmdline_args(request):
     return CmdlineArgs(request)
 

--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -16,6 +16,7 @@ from efa_common import (
     support_cq_interrupts,
     CudaMemorySupport,
     get_cuda_memory_support,
+    get_efa_device_names,
     memory_type_list_bi_dir,
 )
 
@@ -372,3 +373,25 @@ def support_sread(cmdline_args):
             support_cq_interrupts(cmdline_args.client_id))
 
 
+@pytest.fixture(scope="session")
+def num_domains(cmdline_args):
+    """
+    Number of EFA domains (NICs) a test can spread endpoints across.
+
+    This is the smaller of the two hosts' device counts: each peer opens
+    domains from its own device list, so a heterogeneous pair can only spread
+    as far as the host with fewer devices.
+
+    Session-scoped so the device lookup runs once per xdist worker instead of
+    once per test; cmdline_args is session-scoped too, so it can be used here.
+    """
+    server_id = cmdline_args.server_id
+    client_id = cmdline_args.client_id
+
+    counts = [len(get_efa_device_names(host_id))
+              for host_id in dict.fromkeys(filter(None, (server_id, client_id)))]
+
+    if not counts or not min(counts):
+        pytest.skip("could not determine the EFA device count on both hosts")
+
+    return min(counts)

--- a/fabtests/pytest/efa/test_dgram.py
+++ b/fabtests/pytest/efa/test_dgram.py
@@ -15,7 +15,7 @@ def test_dgram_pingpong(cmdline_args, iteration_type, message_sizes):
     # dgram is unreliable, therefore it is expected that receiver does not always get all the messages
     # when that happened, the test will return -FI_ENODATA
     # Disable the strict mode to mark such return code as pass
-    cmdline_args_copy = copy.copy(cmdline_args)
+    cmdline_args_copy = copy.deepcopy(cmdline_args)
     cmdline_args_copy.strict_fabtests_mode = False
 
     client_tx_bytes_before_test = efa_retrieve_hw_counter_value(cmdline_args.client_id, "tx_bytes")

--- a/fabtests/pytest/efa/test_efa_device_selection.py
+++ b/fabtests/pytest/efa/test_efa_device_selection.py
@@ -48,7 +48,7 @@ def test_efa_device_selection(cmdline_args, fabric, selection_approach):
             server_domain_name = server_device_name + "-" + suffix
             client_domain_name = client_device_name + "-" + suffix
 
-            cmdline_args_copy = copy.copy(cmdline_args)
+            cmdline_args_copy = copy.deepcopy(cmdline_args)
             if selection_approach == "domain name":
                 cmdline_args_copy.additional_server_arguments = "-d " + server_domain_name
                 cmdline_args_copy.additional_client_arguments = "-d " + client_domain_name

--- a/fabtests/pytest/efa/test_efa_protocol_selection.py
+++ b/fabtests/pytest/efa/test_efa_protocol_selection.py
@@ -36,7 +36,7 @@ def test_transfer_with_read_protocol_cuda(cmdline_args, fabtest_name, cntrl_env_
 
     message_size = 1024
 
-    cmdline_args_copy = copy.copy(cmdline_args)
+    cmdline_args_copy = copy.deepcopy(cmdline_args)
     cmdline_args_copy.append_environ("FI_EFA_USE_DEVICE_RDMA=1")
     cmdline_args_copy.append_environ(f"{cntrl_env_var}=1000")
     cmdline_args_copy.append_environ("FI_EFA_RUNT_SIZE=0")

--- a/fabtests/pytest/efa/test_fork_support.py
+++ b/fabtests/pytest/efa/test_fork_support.py
@@ -7,7 +7,7 @@ import pytest
 def test_fork_support(cmdline_args, completion_semantic, environment_variable, fabric):
     from common import ClientServerTest
     import copy
-    cmdline_args_copy = copy.copy(cmdline_args)
+    cmdline_args_copy = copy.deepcopy(cmdline_args)
 
     cmdline_args_copy.append_environ("{}=1".format(environment_variable))
     test = ClientServerTest(cmdline_args_copy, "fi_rdm_bw -K",

--- a/fabtests/pytest/efa/test_mr.py
+++ b/fabtests/pytest/efa/test_mr.py
@@ -21,7 +21,7 @@ def test_mr_hmem(cmdline_args, hmem_type, fabric):
     if hmem_type == "neuron" and not has_neuron(cmdline_args.server_id):
         pytest.skip("no neuron device")
 
-    cmdline_args_copy = copy.copy(cmdline_args)
+    cmdline_args_copy = copy.deepcopy(cmdline_args)
 
     test_command = f"fi_mr_test -D {hmem_type} -f {fabric}"
 
@@ -47,7 +47,7 @@ def test_efa_mr_hmem(cmdline_args, hmem_type, fabric):
     if not cmdline_args.do_dmabuf_reg_for_hmem:
         pytest.skip("This test tests neuron get_dmabuf_fd_vX and needs dmabuf to be enabled and working to test these apis")
 
-    cmdline_args_copy = copy.copy(cmdline_args)
+    cmdline_args_copy = copy.deepcopy(cmdline_args)
 
     test_command = f"fi_efa_mr_test -D neuron -f {fabric}"
 

--- a/fabtests/pytest/efa/test_mr_abort.py
+++ b/fabtests/pytest/efa/test_mr_abort.py
@@ -152,15 +152,35 @@ def test_mr_abort(cmdline_args, rma_fabric, rma_op, cancel_order, close_side, op
 @pytest.mark.functional
 @pytest.mark.fabric(params=["efa-direct"]) # TODO add test for efa fabric
 @pytest.mark.memory_type(memory_type_list_symm, prefer_accelerator=True)  # TODO run both system + hmem memory cases on the efa fabric
+@pytest.mark.parametrize("split_eps", [False, True],
+                         ids=["same_ep", "split_eps"])
 @pytest.mark.parametrize("message_size, rma_op, high_pps, sl_low_latency",
                          list(rma_case_params()))
 def test_mr_abort_partial(cmdline_args, rma_fabric, rma_op, high_pps,
-                          sl_low_latency, message_size, memory_type):
+                          sl_low_latency, message_size, memory_type,
+                          split_eps):
     if rma_fabric == "efa" and cmdline_args.server_id == cmdline_args.client_id:
         pytest.skip("fi_mr_abort not supported with efa with SHM")
 
     command = (f"fi_mr_abort -T partial -o {rma_op} -S {message_size}"
                f"{MR_ABORT_EP_ARGS}")
+
+    if split_eps:
+        # Post each slot's surviving and to-be-canceled ops from two
+        # different initiator endpoints, so an MR close must not disturb
+        # in-flight ops on another QP.
+        if MR_ABORT_NUM_EPS < 2:
+            # No second endpoint to split across; fi_mr_abort rejects it.
+            pytest.skip("--partial-split-eps requires at least 2 "
+                        "initiator endpoints")
+        if MR_ABORT_EPS_PER_DOMAIN < MR_ABORT_NUM_EPS:
+            # With more than one domain the wrap-around split pair
+            # (last endpoint -> endpoint 0) always crosses domains, so
+            # the test would exercise cross-NIC rather than
+            # cross-QP-same-NIC behavior.
+            pytest.skip("--partial-split-eps needs all endpoints on one "
+                        "domain so every split op pair shares a domain")
+        command += " --partial-split-eps"
 
     if high_pps:
         assert(rma_op != "read")

--- a/fabtests/pytest/efa/test_mr_abort.py
+++ b/fabtests/pytest/efa/test_mr_abort.py
@@ -11,20 +11,21 @@ pytestmark = pytest.mark.pre_release
 # means more NIC load and memory pressure. Every test opens
 # MR_ABORT_NUM_EPS endpoints per side, packed MR_ABORT_EPS_PER_DOMAIN to
 # a domain, and MRs (and thus their ops) are distributed round-robin
-# across the initiator endpoints. Cap the in-flight operations at
-# MR_ABORT_MAX_OPS_PER_ITER by deriving -W from -N
+# across the initiator endpoints. Cap the load per endpoint at
+# MR_ABORT_OPS_PER_EP by deriving -W from -N and the endpoint count, so
+# every domain carries MR_ABORT_EPS_PER_DOMAIN * MR_ABORT_OPS_PER_EP
+# ops per iteration regardless of how many domains a test spreads over.
 MR_ABORT_NUM_EPS = 4
 MR_ABORT_EPS_PER_DOMAIN = 4
 MR_ABORT_OPS_PER_EP = 512
-MR_ABORT_MAX_OPS_PER_ITER = MR_ABORT_NUM_EPS * MR_ABORT_OPS_PER_EP
 
 MR_ABORT_EP_ARGS = (f" --num-eps {MR_ABORT_NUM_EPS}"
                     f" --eps-per-domain {MR_ABORT_EPS_PER_DOMAIN}")
 
 
-def mr_abort_num_mrs(ops_per_mr):
-    """-W value that keeps ops per iteration at MR_ABORT_MAX_OPS_PER_ITER."""
-    return MR_ABORT_MAX_OPS_PER_ITER // ops_per_mr
+def mr_abort_num_mrs(ops_per_mr, num_eps=MR_ABORT_NUM_EPS):
+    """-W value that keeps the load at MR_ABORT_OPS_PER_EP ops per endpoint."""
+    return num_eps * MR_ABORT_OPS_PER_EP // ops_per_mr
 
 BASE_MESSAGE_SIZES = [
     64,
@@ -182,6 +183,61 @@ def test_mr_abort_partial(cmdline_args, rma_fabric, rma_op, high_pps,
                         "domain so every split op pair shares a domain")
         command += " --partial-split-eps"
 
+    if high_pps:
+        assert(rma_op != "read")
+        command += " --high-pps"
+
+    if sl_low_latency:
+        assert(rma_op != "read")
+        assert(message_size <= SL_LOW_LATENCY_MAX_WRITE_SIZE)
+        command += " --sl-low-latency"
+
+    test = ClientServerTest(cmdline_args, command, timeout=300, fabric=rma_fabric, memory_type=memory_type)
+    test.run()
+
+
+# --- Test: incast (many initiator EPs, one target EP) ---
+MR_ABORT_INCAST_NUM_DOMAINS = 4
+MR_ABORT_INCAST_INITIATOR_EPS = (MR_ABORT_INCAST_NUM_DOMAINS *
+                                 MR_ABORT_EPS_PER_DOMAIN)
+
+
+@pytest.mark.functional
+@pytest.mark.fabric(params=["efa-direct"])  # TODO add test for efa fabric
+@pytest.mark.memory_type(memory_type_list_symm, prefer_accelerator=True)  # TODO run both system + hmem memory cases on the efa fabric
+@pytest.mark.parametrize(
+    "message_size, rma_op, high_pps, sl_low_latency, cancel_order, ops_per_mr",
+    list(abort_case_params()))
+def test_mr_abort_incast(cmdline_args, rma_fabric, rma_op, cancel_order, ops_per_mr,
+                         high_pps, sl_low_latency, message_size, memory_type,
+                         num_domains):
+    """
+    Incast: 16 initiator endpoints, 4 per EFA NIC across 4 NICs, all
+    targeting a single endpoint on a separate platform. Skipped when
+    either host has fewer than 4 EFA NICs.
+
+    The load is per-domain: each NIC carries the same 4-endpoint,
+    512-ops-per-endpoint load as the single-domain tests, so the lone
+    target endpoint absorbs a 4-NIC incast.
+
+    Only the initiator close is exercised: a high incast only makes sense
+    to cancel on the transmit side.
+    """
+    if cmdline_args.server_id == cmdline_args.client_id:
+        pytest.skip("mr_abort incast test requires two platforms")
+
+    if num_domains < MR_ABORT_INCAST_NUM_DOMAINS:
+        pytest.skip(f"mr_abort incast test requires at least "
+                    f"{MR_ABORT_INCAST_NUM_DOMAINS} EFA NICs")
+
+    command = (f"fi_mr_abort -T abort -o {rma_op} -C {cancel_order}"
+               f" -R initiator -N {ops_per_mr}"
+               f" -W {mr_abort_num_mrs(ops_per_mr, MR_ABORT_INCAST_INITIATOR_EPS)}"
+               f" -S {message_size}"
+               f" --num-initiator-eps {MR_ABORT_INCAST_INITIATOR_EPS}"
+               f" --num-target-eps 1"
+               f" --eps-per-domain {MR_ABORT_EPS_PER_DOMAIN}"
+               f" -I 3")
     if high_pps:
         assert(rma_op != "read")
         command += " --high-pps"

--- a/fabtests/pytest/efa/test_mr_abort.py
+++ b/fabtests/pytest/efa/test_mr_abort.py
@@ -6,12 +6,25 @@ from efa.efa_common import memory_type_list_symm
 pytestmark = pytest.mark.pre_release
 
 
-# fi_mr_abort fabtest will allocate MR_ABORT_NUM_MRS and attempt
-# to post N transfers per MR until the provider returns -FI_EAGAIN
-# or we posted transactions for each MR. A larger number corresponds
-# to increased load on the NIC and increased memory preassure on the
-# instance.
-MR_ABORT_NUM_MRS = 2046
+# fi_mr_abort allocates -W MRs and posts -N transfers per MR, so a run
+# submits up to W*N operations per iteration; more in-flight operations
+# means more NIC load and memory pressure. Every test opens
+# MR_ABORT_NUM_EPS endpoints per side, packed MR_ABORT_EPS_PER_DOMAIN to
+# a domain, and MRs (and thus their ops) are distributed round-robin
+# across the initiator endpoints. Cap the in-flight operations at
+# MR_ABORT_MAX_OPS_PER_ITER by deriving -W from -N
+MR_ABORT_NUM_EPS = 4
+MR_ABORT_EPS_PER_DOMAIN = 4
+MR_ABORT_OPS_PER_EP = 512
+MR_ABORT_MAX_OPS_PER_ITER = MR_ABORT_NUM_EPS * MR_ABORT_OPS_PER_EP
+
+MR_ABORT_EP_ARGS = (f" --num-eps {MR_ABORT_NUM_EPS}"
+                    f" --eps-per-domain {MR_ABORT_EPS_PER_DOMAIN}")
+
+
+def mr_abort_num_mrs(ops_per_mr):
+    """-W value that keeps ops per iteration at MR_ABORT_MAX_OPS_PER_ITER."""
+    return MR_ABORT_MAX_OPS_PER_ITER // ops_per_mr
 
 BASE_MESSAGE_SIZES = [
     64,
@@ -120,8 +133,8 @@ def test_mr_abort(cmdline_args, rma_fabric, rma_op, cancel_order, close_side, op
         pytest.skip("fi_mr_abort not supported with efa with SHM")
 
     command = (f"fi_mr_abort -T abort -o {rma_op} -C {cancel_order}"
-               f" -R {close_side} -N {ops_per_mr} -W {MR_ABORT_NUM_MRS}"
-               f" -S {message_size}")
+               f" -R {close_side} -N {ops_per_mr} -W {mr_abort_num_mrs(ops_per_mr)}"
+               f" -S {message_size}{MR_ABORT_EP_ARGS}")
     if high_pps:
         assert(rma_op != "read")
         command += " --high-pps"
@@ -146,7 +159,8 @@ def test_mr_abort_partial(cmdline_args, rma_fabric, rma_op, high_pps,
     if rma_fabric == "efa" and cmdline_args.server_id == cmdline_args.client_id:
         pytest.skip("fi_mr_abort not supported with efa with SHM")
 
-    command = (f"fi_mr_abort -T partial -o {rma_op} -S {message_size}")
+    command = (f"fi_mr_abort -T partial -o {rma_op} -S {message_size}"
+               f"{MR_ABORT_EP_ARGS}")
 
     if high_pps:
         assert(rma_op != "read")
@@ -358,8 +372,9 @@ def test_mr_abort_send(cmdline_args, fabric, cancel_order, close_side,
     # one completion per send.
     homogeneous_flag = " -H" if protocol == "LONGREAD" else ""
     command = (f"fi_mr_abort -T {send_op} -C {cancel_order}"
-               f" -R {close_side} -N {ops_per_mr} -W {MR_ABORT_NUM_MRS}"
-               f" -S {message_size}{owe_flag}{homogeneous_flag}  -A ep_first")
+               f" -R {close_side} -N {ops_per_mr} -W {mr_abort_num_mrs(ops_per_mr)}"
+               f" -S {message_size}{owe_flag}{homogeneous_flag}"
+               f"{MR_ABORT_EP_ARGS}  -A ep_first")
     test = ClientServerTest(cmdline_args, command, timeout=360, fabric=fabric,
                             memory_type=memory_type, additional_env=env)
     test.run()

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -115,7 +115,7 @@ def test_rdm_tagged_bw_no_inject_range(cmdline_args, completion_semantic, messag
 @pytest.mark.parametrize("env_vars", [["FI_EFA_TX_SIZE=64"], ["FI_EFA_RX_SIZE=64"], ["FI_EFA_TX_SIZE=64", "FI_EFA_RX_SIZE=64"], ["FI_EFA_TX_SIZE=43", "FI_EFA_RX_SIZE=51"]])
 @pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_tagged_bw_small_tx_rx(cmdline_args, completion_semantic, memory_type, completion_type, env_vars):
-    cmdline_args_copy = copy.copy(cmdline_args)
+    cmdline_args_copy = copy.deepcopy(cmdline_args)
     for env_var in env_vars:
         cmdline_args_copy.append_environ(env_var)
     # Use a window size larger than tx/rx size
@@ -126,7 +126,7 @@ def test_rdm_tagged_bw_small_tx_rx(cmdline_args, completion_semantic, memory_typ
 @pytest.mark.functional
 @pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_tagged_bw_small_recv_window(cmdline_args, completion_semantic, memory_type, completion_type):
-    cmdline_args_copy = copy.copy(cmdline_args)
+    cmdline_args_copy = copy.deepcopy(cmdline_args)
     cmdline_args_copy.append_environ("FI_EFA_RECVWIN_SIZE=1")
     efa_run_client_server_test(cmdline_args_copy, "fi_rdm_tagged_bw -W 128", "short",
                                completion_semantic, memory_type, "all", completion_type=completion_type,
@@ -147,7 +147,7 @@ def test_rdm_tagged_bw_use_fi_more(cmdline_args, completion_semantic, memory_typ
 @pytest.mark.pr_ci
 @pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic, memory_type):
-    from copy import copy
+    from copy import deepcopy
 
     from common import ClientServerTest
 
@@ -157,7 +157,7 @@ def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic, memory_ty
     # the rdm_atomic test's run time has a high variance when running single c6gn instance.
     # the issue is tracked in:  https://github.com/ofiwg/libfabric/issues/7002
     # to mitigate the issue, set the maximum timeout of fi_rdm_atomic to 1800 seconds.
-    cmdline_args_copy = copy(cmdline_args)
+    cmdline_args_copy = deepcopy(cmdline_args)
     command = "fi_rdm_atomic"  + " " + perf_progress_model_cli
     test = ClientServerTest(cmdline_args_copy, "fi_rdm_atomic", iteration_type, completion_semantic,
                             memory_type=memory_type, timeout=1800, fabric="efa")
@@ -166,8 +166,6 @@ def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic, memory_ty
 @pytest.mark.pr_ci
 @pytest.mark.functional
 def test_rdm_tagged_peek(cmdline_args):
-    from copy import copy
-
     from common import ClientServerTest
 
     test = ClientServerTest(cmdline_args, "fi_rdm_tagged_peek", timeout=1800)

--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -28,7 +28,7 @@ def test_rma_bw(cmdline_args, iteration_type, rma_operation_type, rma_bw_complet
 @pytest.mark.parametrize("env_vars", [["FI_EFA_TX_SIZE=64"], ["FI_EFA_RX_SIZE=64"], ["FI_EFA_TX_SIZE=64", "FI_EFA_RX_SIZE=64"]])
 @pytest.mark.memory_type(memory_type_list_all)
 def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, rma_bw_completion_semantic, rma_bw_memory_type, env_vars, rma_fabric, message_sizes):
-    cmdline_args_copy = copy.copy(cmdline_args)
+    cmdline_args_copy = copy.deepcopy(cmdline_args)
     for env_var in env_vars:
         cmdline_args_copy.append_environ(env_var)
     # Use a window size larger than tx/rx size

--- a/fabtests/pytest/efa/test_rnr.py
+++ b/fabtests/pytest/efa/test_rnr.py
@@ -14,7 +14,7 @@ def test_rnr_read_cq_error(cmdline_args, fabric):
     # and the test will return FI_ENOSYS.
     # Disable the strict mode for this test explicitly to mark it as skipped
     # in this case.
-    cmdline_args_copy = copy.copy(cmdline_args)
+    cmdline_args_copy = copy.deepcopy(cmdline_args)
     cmdline_args_copy.strict_fabtests_mode = False
     test = ClientServerTest(cmdline_args_copy, "fi_efa_rnr_read_cq_error", fabric=fabric)
     test.run()
@@ -63,7 +63,7 @@ def test_rnr_queue_resend(cmdline_args, packet_type):
     # and the test will return FI_ENOSYS.
     # Disable the strict mode for this test explicitly to mark it as skipped
     # in this case.
-    cmdline_args_copy = copy.copy(cmdline_args)
+    cmdline_args_copy = copy.deepcopy(cmdline_args)
     cmdline_args_copy.strict_fabtests_mode = False
     test = ClientServerTest(cmdline_args_copy,
             "fi_efa_rnr_queue_resend " + packet_type_option_map[packet_type], fabric="efa")


### PR DESCRIPTION
* 396e87b4 (HEAD -> make-fi-mr-abort-tests-use-multiple-eps-per-domain, szegel/make-fi-mr-abort-tests-use-multiple-eps-per-domain) fabtests/efa: Add MR abort incast test across multiple NICs
* 3f2cc431 fabtests/efa: Add split-endpoint mode to the MR abort partial test
* 46ad40f7 fabtests/efa: Run MR abort tests with 4 endpoints and 2048 ops per iteration