### PR TITLE
fabtests: Call `_Exit()` in forked child

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -3286,7 +3286,7 @@ int ft_fork_child(void)
 	}
 
 	if (ft_child_pid == 0) {
-		exit(0);
+		_Exit(0);
 	}
 
 	return 0;


### PR DESCRIPTION
The forked child must not run inherited `atexit()` handlers or library destructors. Use `_Exit()` as required for post-fork termination.