### PR TITLE
prov/rxm: fix the msg_ep use-after-free at connection teardown

### DIFF
--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -516,6 +516,10 @@ struct rxm_rx_buf {
 	struct dlist_entry repost_entry;
 	struct dlist_entry unexp_entry;
 	struct rxm_conn *conn;		/* msg ep data was received on */
+	/* Conn owning rx_ep's msg_eps[] slot.  Unlike conn, the data path
+	 * never re-points it.  Unused on the msg_srx path, where rx_ep is
+	 * the shared context and has no owning conn. */
+	struct rxm_conn *rx_ep_conn;
 	struct fi_peer_rx_entry *peer_entry;
 	struct rxm_proto_info *proto_info;
 	uint64_t comp_flags;
@@ -962,9 +966,11 @@ rxm_free_rx_buf(struct rxm_rx_buf *rx_buf)
 		rx_buf->data = &rx_buf->pkt.data;
 	}
 
-	/* Discard rx buffer if the msg ep it was posted to was closed */
+	/* Discard rx buffer if the msg ep it was posted to was closed.  Ask
+	 * the owning conn: the SAR path re-points rx_buf->conn at the wire
+	 * header's conn, so it would miss a perfectly open ep. */
 	if (rx_buf->repost && (rx_buf->ep->msg_srx ||
-	     rxm_get_ep_idx(rx_buf->conn, &rx_buf->rx_ep->fid) >= 0)) {
+	     rxm_get_ep_idx(rx_buf->rx_ep_conn, &rx_buf->rx_ep->fid) >= 0)) {
 		rxm_post_recv(rx_buf);
 	} else {
 		ofi_buf_free(rx_buf);

--- a/prov/rxm/src/rxm.h
+++ b/prov/rxm/src/rxm.h
@@ -270,6 +270,9 @@ static inline int rxm_get_ep_idx(struct rxm_conn *conn, struct fid *fid)
 {
 	uint8_t i;
 
+	if (!conn->msg_eps)
+		return -1;
+
 	for (i = 0; i < conn->num_msg_eps; i++)
 		if (conn->msg_eps[i] && &conn->msg_eps[i]->fid == fid)
 			return i;
@@ -959,9 +962,9 @@ rxm_free_rx_buf(struct rxm_rx_buf *rx_buf)
 		rx_buf->data = &rx_buf->pkt.data;
 	}
 
-	/* Discard rx buffer if its msg_ep was closed */
+	/* Discard rx buffer if the msg ep it was posted to was closed */
 	if (rx_buf->repost && (rx_buf->ep->msg_srx ||
-	     (rx_buf->conn->msg_eps && rx_buf->conn->msg_eps[0]))) {
+	     rxm_get_ep_idx(rx_buf->conn, &rx_buf->rx_ep->fid) >= 0)) {
 		rxm_post_recv(rx_buf);
 	} else {
 		ofi_buf_free(rx_buf);

--- a/prov/rxm/src/rxm_conn.c
+++ b/prov/rxm/src/rxm_conn.c
@@ -95,13 +95,14 @@ static void rxm_close_conn(struct rxm_conn *conn)
 		if (rx_entry && rx_entry->peer_context)
 			rx_entry->srx->owner_ops->free_entry(rx_entry);
 	}
+
+	rxm_flush_msg_cq(conn->ep);
 	if (conn->msg_eps) {
 		for (uint8_t i = 0; i < conn->num_msg_eps; i++) {
 			if (conn->msg_eps[i])
 				fi_close(&conn->msg_eps[i]->fid);
 		}
 	}
-	rxm_flush_msg_cq(conn->ep);
 	dlist_remove_init(&conn->loopback_entry);
 	free(conn->msg_eps);
 	conn->msg_eps = NULL;
@@ -609,6 +610,12 @@ void rxm_process_connect(struct rxm_eq_cm_entry *cm_entry)
 	       "processing connected for handle: %p ep %d\n", conn, idx);
 
 	assert(ofi_genlock_held(&conn->ep->util_ep.lock));
+
+	/* The msg ep may have been dropped after this event was queued;
+	 * without this we index msg_eps[-1] and write states[-1].
+	 */
+	if (idx < 0)
+		return;
 
 	if (idx == 0 && conn->states[0] == RXM_CM_CONNECTING) {
 		conn->remote_index = rxm_peer_index(cm_entry->data.accept.

--- a/prov/rxm/src/rxm_cq.c
+++ b/prov/rxm/src/rxm_cq.c
@@ -76,8 +76,10 @@ rxm_rx_buf_alloc(struct rxm_ep *rxm_ep, struct fid_ep *rx_ep)
 	rx_buf->rx_ep = rx_ep;
 	rx_buf->repost = true;
 
-	if (!rxm_ep->msg_srx)
-		rx_buf->conn = rx_ep->fid.context;
+	if (!rxm_ep->msg_srx) {
+		/* rxm_open_msg_ep() passes the conn as the endpoint context. */
+		rx_buf->conn = rx_buf->rx_ep_conn = rx_ep->fid.context;
+	}
 
 	return rx_buf;
 }


### PR DESCRIPTION
rxm_close_conn() closed every msg_ep slot and only then flushed the shared MSG CQ. Any completion still queued at that point references an already-freed endpoint; for a credit packet rxm_handle_credit() hands rx_buf->rx_ep to add_credits(), which writes peer_rq_credits through it, tripping the FI_CLASS_EP assert in a debug build and silently corrupting freed memory otherwise. The rndv and atomic response paths reached from the same drain send on conn->msg_eps[] and are exposed the same way.

The post-close flush dates from aa04cff9f9, when a connection owned a single msg_ep that was closed immediately before it. e9ffd9b2c ("prov/rxm: open a distinct QP per msg_ep slot on demand") turned that into N closes ahead of one flush of the shared CQ, so every secondary slot carrying credit traffic can leave a completion behind. fi_multi_ep aborts at teardown for FI_OFI_RXM_NUM_MSG_EPS >= 4. Flush first, while all slots are still valid, then close them.

A second path frees an endpoint under a live rx buf. rxm_free_rx_buf() decided whether to repost by testing conn->msg_eps[0], not the slot the buffer was actually posted to. rxm_drop_secondary_ep() closes and NULLs a secondary slot during normal progress (CM reject and shutdown of a not-yet-connected slot) while slot 0 stays live, and recvs are preposted in rxm_open_msg_ep() before the CM connected event, so a buffer outstanding on the dropped slot passes the slot-0 test and is reposted onto a freed endpoint. Ask about the buffer's own rx_ep via rxm_get_ep_idx() instead, and give rxm_get_ep_idx() the NULL msg_eps check the open-coded expression used to carry: rxm_free_rx_buf() also runs after rxm_close_conn() has freed the array.

Finally, bail out of rxm_process_connect() when the fid is no longer in msg_eps. A connected event queued for a slot that was dropped before it was processed leaves idx at -1, and the function then reads msg_eps[-1] and writes states[-1].