### PR TITLE
prov/rxm: reduce the ordering claimed with multiple msg endpoints

### DIFF
--- a/man/fi_rxm.7.md
+++ b/man/fi_rxm.7.md
@@ -112,6 +112,19 @@ hints parameter specifies FI_ATOMIC. If FI_ATOMIC is requested, message order
 FI_ORDER_RAR, FI_ORDER_RAW, FI_ORDER_WAR, FI_ORDER_WAW, FI_ORDER_SAR, and
 FI_ORDER_SAW can not be supported.
 
+## Message ordering limitations with multiple MSG endpoints
+
+When FI_OFI_RXM_NUM_MSG_EPS is greater than 1, a peer connection spans several
+MSG endpoints, and hence several core provider connections that are unordered
+with respect to each other. Message, tagged and atomic transfers are issued on
+the first endpoint, so they remain ordered relative to each other, but RMA and
+rendezvous payload are spread across the remaining endpoints. Only FI_ORDER_SAS,
+FI_ORDER_ATOMIC_RAR, FI_ORDER_ATOMIC_RAW, FI_ORDER_ATOMIC_WAR and
+FI_ORDER_ATOMIC_WAW are reported, and max_order_raw_size, max_order_war_size
+and max_order_waw_size are reported as 0. fi_getinfo returns -FI_ENODATA if the
+hints request ordering beyond this. Applications that need an RMA operation to
+be ordered against a later transfer must wait for its completion instead.
+
 ## Miscellaneous limitations
  * RxM protocol peers should have same endian-ness otherwise connections won't
    successfully complete. This enables better performance at run-time as byte
@@ -185,8 +198,9 @@ with (default: 256).
 : Number of MSG endpoints (and underlying connections/QPs) to open per RxM
   peer connection. Values greater than 1 spread traffic across multiple QPs
   in a round-robin fashion, which can improve throughput on hardware that
-  benefits from multiple QPs per peer. The value is clamped to the range
-  [1, 255]. (default: 1)
+  benefits from multiple QPs per peer. Values greater than 1 also reduce the
+  message ordering the provider guarantees, see the message ordering
+  limitations above. The value is clamped to the range [1, 255]. (default: 1)
 
 # Tuning
 

--- a/prov/rxm/src/rxm_init.c
+++ b/prov/rxm/src/rxm_init.c
@@ -43,6 +43,14 @@
 					  FI_ORDER_WAW | FI_ORDER_WAR |  \
 					  FI_ORDER_SAR | FI_ORDER_SAW)
 
+/* Ordering that survives when a connection spans several msg endpoints:
+ * receive matching happens on packets pinned to msg ep 0, while RMA and
+ * rendezvous payload are round-robined over mutually unordered connections.
+ */
+#define RXM_MQP_MSG_ORDER (FI_ORDER_SAS | FI_ORDER_ATOMIC_RAR |		\
+			   FI_ORDER_ATOMIC_RAW | FI_ORDER_ATOMIC_WAR |	\
+			   FI_ORDER_ATOMIC_WAW)
+
 #define RXM_PASSTHRU_CAPS (FI_MSG | FI_RMA | FI_SEND | FI_RECV |	\
 			   FI_READ | FI_WRITE | FI_REMOTE_READ |	\
 			   FI_REMOTE_WRITE | FI_HMEM)
@@ -391,10 +399,29 @@ int rxm_info_to_rxm(uint32_t version, const struct fi_info *core_info,
 	return 0;
 }
 
+/* Applied to the base infos, so ofi_check_info rejects hints asking for more,
+ * and to the returned infos, which rxm_info_to_rxm fills in from the core
+ * provider. max_order_*_size qualifies RAW / WAR / WAW, so it goes too.
+ */
+static void rxm_trim_msg_order(struct fi_info *info)
+{
+	info->tx_attr->msg_order &= RXM_MQP_MSG_ORDER;
+	info->rx_attr->msg_order &= RXM_MQP_MSG_ORDER;
+	info->ep_attr->max_order_raw_size = 0;
+	info->ep_attr->max_order_war_size = 0;
+	info->ep_attr->max_order_waw_size = 0;
+}
+
 static void rxm_init_infos(void)
 {
 	struct fi_info *cur;
 	size_t buf_size, tx_size = 0, rx_size = 0;
+
+	fi_param_get_size_t(&rxm_prov, "num_msg_eps", &rxm_num_msg_eps);
+	if (rxm_num_msg_eps < 1)
+		rxm_num_msg_eps = 1;
+	if (rxm_num_msg_eps > UINT8_MAX)
+		rxm_num_msg_eps = UINT8_MAX;
 
 	/* Historically, 'buffer_size' was the name given for the eager message
 	 * size.  Maintain the name for backwards compatability.
@@ -425,8 +452,11 @@ static void rxm_init_infos(void)
 		rxm_def_rx_size = rx_size;
 
 	for (cur = (struct fi_info *) rxm_util_prov.info; cur; cur = cur->next) {
-		if (!rxm_passthru_info(cur))
+		if (!rxm_passthru_info(cur)) {
 			cur->tx_attr->inject_size = rxm_buffer_size;
+			if (rxm_num_msg_eps > 1)
+				rxm_trim_msg_order(cur);
+		}
 		if (tx_size)
 			cur->tx_attr->size = tx_size;
 		if (rx_size)
@@ -446,6 +476,9 @@ static void rxm_alter_info(const struct fi_info *hints, struct fi_info *info)
 
 		if (rxm_passthru_info(cur))
 			continue;
+
+		if (rxm_num_msg_eps > 1)
+			rxm_trim_msg_order(cur);
 
 		/* Remove the following caps if they are not requested as they
 		 * may affect performance in fast-path */
@@ -713,6 +746,10 @@ RXM_INI
 	fi_param_define(&rxm_prov, "num_msg_eps", FI_PARAM_SIZE_T,
 			"Number of msg endpoints, and hence underlying "
 			"connections and QPs, to open per rxm connection. "
+			"Values greater than 1 reduce the guaranteed message "
+			"ordering to FI_ORDER_SAS and the atomic ordering "
+			"bits, since RMA is spread over unordered "
+			"connections. "
 			"Values are clamped to the range [1, 255]. "
 			"(default: 1)");
 
@@ -748,11 +785,6 @@ RXM_INI
 
 	fi_param_get_bool(&rxm_prov, "detect_hmem_iface", &rxm_detect_hmem_iface);
 	fi_param_get_bool(&rxm_prov, "rescan", &rxm_rescan);
-	fi_param_get_size_t(&rxm_prov, "num_msg_eps", &rxm_num_msg_eps);
-	if (rxm_num_msg_eps < 1)
-		rxm_num_msg_eps = 1;
-	if (rxm_num_msg_eps > UINT8_MAX)
-		rxm_num_msg_eps = UINT8_MAX;
 
 #if HAVE_RXM_DL
 	ofi_mem_init();


### PR DESCRIPTION
A connection that spans several msg endpoints spans several core provider connections, and those are unordered with respect to each other. Receive matching is unaffected, since every packet it depends on is pinned to the first endpoint, but RMA and rendezvous payload are round-robined over the rest, so an RMA operation can no longer be ordered against anything.

Report only FI_ORDER_SAS and the atomic ordering bits when FI_OFI_RXM_NUM_MSG_EPS is above 1, and zero the max_order_*_size fields that qualify the RAW, WAR and WAW guarantees. The base infos are trimmed as well, so ofi_check_info rejects hints asking for more instead of letting an application rely on ordering that is not there. Applications needing an RMA operation ordered against a later transfer have to wait for its completion.

num_msg_eps is now read inside rxm_init_infos(), which is what trims the base infos, so reordering the parameter reads cannot silently turn the trim into a no-op. Passthru infos are left alone: their sends are round-robined too and lose even SAS, which needs separate handling.

This is a no-op at the default of one endpoint.