### PR TITLE
prov/efa: remove stale bug-history comments

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_pkt_type.h
+++ b/prov/efa/src/rdm/efa_rdm_pkt_type.h
@@ -88,11 +88,6 @@ bool efa_rdm_pkt_type_is_eager(int pkt_type)
  * @brief determine whether a req pkt type is an eager two-sided RTM
  *        (send/tagged), excluding the one-sided RTW variants.
  *
- * Used by the sender-side peer-abort path: only two-sided sends consume
- * a per-peer msg_id in the receiver's reorder window, so only these need
- * a MSG_ID_SKIP notification when aborted at the source. One-sided eager
- * RTW is self-contained and owes the target nothing.
- *
  * @param[in]		pkt_type		REQ packet type
  * @return		a boolean
  */
@@ -128,13 +123,6 @@ bool efa_rdm_pkt_type_is_medium(int pkt_type)
 /**
  * @brief determine whether a req pkt type is a longcts two-sided RTM
  *        (send/tagged), excluding the one-sided RTW variants.
- *
- * Used by the sender-side peer-abort path: a LONGCTS RTM aborted before
- * its first CTS (still in EFA_RDM_TXE_REQ) has no receiver ope index
- * (txe->rx_id), so it is signalled by per-peer msg_id with
- * REF_MSG_ID_SKIP -- exactly like the EAGER / medium / runt-only abort.
- * One-sided LONGCTS RTW targets no two-sided reorder window and is
- * excluded.
  *
  * @param[in]		pkt_type		REQ packet type
  * @return		a boolean

--- a/prov/efa/test/efa_unit_test_av.c
+++ b/prov/efa/test/efa_unit_test_av.c
@@ -382,8 +382,8 @@ void test_av_reverse_av_remove_qpn_collision(void **state)
 	assert_int_equal(efa_av_reverse_lookup_rdm(av, ahn, 100, NULL),
 			 fi_addr2);
 
-	/* Remove peer1 first. Without the fix this would incorrectly delete
-	 * peer2's cur_reverse_av entry and leave peer1's prv entry orphaned. */
+	/* Remove peer1 first: peer2's cur_reverse_av entry must survive and
+	 * peer1's prv entry must not be orphaned. */
 	err = fi_av_remove(resource->av, &fi_addr1, 1, 0);
 	assert_int_equal(err, 0);
 	/* peer1's prv entry is gone; peer2's cur entry must still be intact. */
@@ -391,8 +391,8 @@ void test_av_reverse_av_remove_qpn_collision(void **state)
 	assert_int_equal(efa_av_reverse_lookup_rdm(av, ahn, 100, NULL),
 			 fi_addr2);
 
-	/* Remove peer2. Without the fix this hits a NULL prv_reverse_av_entry
-	 * in efa_av_reverse_av_remove() -> SEGV / assertion failure. */
+	/* Remove peer2: efa_av_reverse_av_remove() must tolerate a NULL
+	 * prv_reverse_av_entry. */
 	err = fi_av_remove(resource->av, &fi_addr2, 1, 0);
 	assert_int_equal(err, 0);
 	test_av_verify_av_hash_cnt(av, 0, 0, 0, 0);

--- a/prov/efa/test/efa_unit_test_cq.c
+++ b/prov/efa/test/efa_unit_test_cq.c
@@ -2249,8 +2249,8 @@ void test_efa_cq_poll_ep_close_bypass_path(void **state)
  * 3. fi_close(ep) destroys the QP (freeing cur_wq's target), then drains the CQ
  * 4. The drain's next_poll mock reads cur_wq->wrid_idx_pool_next → SEGV if dangling
  *
- * Without the fix: SEGV/SIGBUS (cur_wq points to freed QP memory)
- * With the fix (NULLing cur_wq after consumption): passes
+ * cur_wq must be NULLed after consumption so the drain never touches
+ * freed QP memory.
  */
 void test_efa_cq_next_poll_stale_cur_wq_segv_on_ep_close(void **state)
 {

--- a/prov/efa/test/efa_unit_test_mr.c
+++ b/prov/efa/test/efa_unit_test_mr.c
@@ -1495,7 +1495,7 @@ void test_efa_mr_reg_out_of_range_iface(void **state)
 
 /**
  * Verify that efa_direct_ope is released when fi_recv fails after
- * allocating the ope. Without the fix the ope leaks on the error path.
+ * allocating the ope, so the error path does not leak it.
  */
 void test_efa_direct_ope_released_on_recv_error(void **state)
 {
@@ -1542,7 +1542,7 @@ void test_efa_direct_ope_released_on_recv_error(void **state)
 
 /**
  * Verify that efa_direct_ope is released when fi_sendmsg fails after
- * allocating the ope. Without the fix the ope leaks on the error path.
+ * allocating the ope, so the error path does not leak it.
  */
 void test_efa_direct_ope_released_on_send_error(void **state)
 {
@@ -1601,7 +1601,7 @@ void test_efa_direct_ope_released_on_send_error(void **state)
 
 /**
  * Verify that efa_direct_ope is released when fi_readmsg fails after
- * allocating the ope. Without the fix the ope leaks on the error path.
+ * allocating the ope, so the error path does not leak it.
  */
 void test_efa_direct_ope_released_on_read_error(void **state)
 {
@@ -1670,7 +1670,7 @@ void test_efa_direct_ope_released_on_read_error(void **state)
 
 /**
  * Verify that efa_direct_ope is released when fi_writemsg fails after
- * allocating the ope. Without the fix the ope leaks on the error path.
+ * allocating the ope, so the error path does not leak it.
  */
 void test_efa_direct_ope_released_on_write_error(void **state)
 {

--- a/prov/efa/test/efa_unit_test_ope.c
+++ b/prov/efa/test/efa_unit_test_ope.c
@@ -4604,11 +4604,10 @@ void test_efa_rdm_txe_handle_error_no_emit_when_not_longcts(void **state)
  * still completes successfully lands in
  * efa_rdm_pke_handle_rma_completion()'s READ path.
  *
- * Before the fix that success path had no drain call and no
- * EFA_RDM_OPE_PEER_ABORT_PENDING guard: if the successful sibling was the last
- * WR to drain, efa_outstanding_tx_ops reached 0 in a handler that
- * never released the rxe -> permanent leak (and it would also post a
- * spurious EOR / success completion). This test fails one read WR,
+ * That success path must call the drain helper under the
+ * EFA_RDM_OPE_PEER_ABORT_PENDING guard: when the successful sibling is
+ * the last WR to drain, the rxe must be released there, and no spurious
+ * EOR / success completion posted. This test fails one read WR,
  * then drives a successful completion for the sibling and asserts
  * the rxe leaves ep->base_ep.ope_list (freed exactly once), the user gets a
  * single clean peer-abort error completion, and no spurious success
@@ -4733,9 +4732,7 @@ void test_efa_rdm_pke_handle_rma_read_completion_drains_recovered_rxe(
  * but the drain is a no-op while the CTS is outstanding
  * (efa_outstanding_tx_ops > 0).
  *
- * Before the fix the CTS send-completion case was a bare break with
- * no drain retry, so the rxe was never freed -> leak. The fix makes
- * the CTS send-completion call the drain helper. This test asserts
+ * The CTS send-completion must call the drain helper. This test asserts
  * the rxe survives the inbound PEER_ERROR_PKT (CTS still in flight)
  * and is freed exactly when the CTS completes.
  */
@@ -5702,11 +5699,10 @@ void test_efa_rdm_pke_handle_tx_error_runtread_with_read_no_emit(void **state)
  * txe, because the PEER_ERROR_PKT (and any sibling CTSDATA WRs) still
  * use it as wr_id.
  *
- * Before the fix nothing freed the errored txe: the success-completion
- * path only releases on bytes_acked == total_len (never true
- * post-abort), sibling failures early-return on OPE_ERR, and the
- * PEER_ERROR_PKT completion only released the RXE direction. The txe
- * leaked until ep close. This test drives the abort, then completes the
+ * The PEER_ERROR_PKT completion must free the errored txe: the
+ * success-completion path only releases on bytes_acked == total_len
+ * (never true post-abort) and sibling failures early-return on
+ * OPE_ERR. This test drives the abort, then completes the
  * emitted PEER_ERROR_PKT and asserts the drain-gated release frees the
  * txe exactly once.
  */

--- a/prov/efa/test/efa_unit_test_rdm_peer.c
+++ b/prov/efa/test/efa_unit_test_rdm_peer.c
@@ -724,12 +724,11 @@ static int deliver_peer_error_skip(struct efa_rdm_ep *efa_rdm_ep,
  * @brief The core fix: a source-aborted msg_id that NEVER arrived must
  *        not head-of-line block the messages buffered behind it.
  *
- * Reproduces the EAGER/MEDIUM heisenbug deterministically. The sender
- * allocated msg_id 0, posted it, then the device flushed it at the
- * source (MR closed) before it ever reached the receiver. Later messages
- * msg_id 1 and 2 DID arrive and are buffered out-of-order, waiting for
- * msg_id 0. Without the fix the window parks on 0 forever and 1, 2 (and
- * everything after) are stranded.
+ * The sender allocated msg_id 0, posted it, then the device flushed it
+ * at the source (MR closed) before it ever reached the receiver. Later
+ * messages msg_id 1 and 2 DID arrive and are buffered out-of-order,
+ * waiting for msg_id 0; the window must slide past 0 or they are
+ * stranded forever.
  *
  * An inbound PEER_ERROR (skip) packet for msg_id 0 is queued into the
  * recvwin as an abort marker; the drain then slides past 0 and continues
@@ -1057,7 +1056,7 @@ void test_efa_rdm_peer_skip_aborted_msg_id_abort_marker_behind_head(
  * efa_rdm_peer_queue_aborted_msg_marker() helper directly, whereas
  * this one exercises the actual receive entry point
  * (efa_rdm_pke_handle_peer_error_recv) for the LONGCTS never-arrived
- * scenario -- the exact packet the sender-side fix now emits.
+ * case.
  *
  * msg_id 0 (the aborted LONGCTS RTM) never arrives; msg_id 1 arrives OOO
  * and is buffered (then aborted so the drain releases it without the

--- a/prov/efa/test/efa_unit_test_rnr.c
+++ b/prov/efa/test/efa_unit_test_rnr.c
@@ -97,7 +97,7 @@ void test_efa_rnr_queue_and_resend_tagged(void **state)
 
 /**
  * @brief Verify that a pkt is released when efa_rdm_ep_post_queued_pkts
- * encounters a non-EAGAIN error on repost. Without the fix the pkt leaks.
+ * encounters a non-EAGAIN error on repost, so it does not leak.
  */
 void test_efa_rdm_ep_post_queued_pkts_releases_pkt_on_error(void **state)
 {
@@ -162,9 +162,8 @@ void test_efa_rdm_ep_post_queued_pkts_releases_pkt_on_error(void **state)
 	/*
 	 * The proof that the pkt was released is in the test teardown:
 	 * ofi_bufpool_destroy asserts that all entries have been returned
-	 * (use_cnt == 0). Without the fix, the leaked pkt causes that
-	 * assertion to fire during endpoint close, crashing the test.
-	 * With the fix, teardown completes cleanly.
+	 * (use_cnt == 0); a leaked pkt makes that assertion fire during
+	 * endpoint close.
 	 */
 	efa_unit_test_buff_destruct(&send_buff);
 }


### PR DESCRIPTION
Drop packet-type comments left over from earlier iterations of the MR-abort work that no longer match the code they describe, and reword unit-test comments that narrate previous bugs (without the fix this would leak or crash) to state the invariant being verified instead. No functional change.