### PR TITLE
prov/efa: unify QKEY generation across all endpoint types

### DIFF
--- a/prov/efa/src/efa.h
+++ b/prov/efa/src/efa.h
@@ -77,8 +77,6 @@
 #define EFA_INFO_TYPE_IS_DGRAM(_info) \
 	(_info && _info->ep_attr && (_info->ep_attr->type == FI_EP_DGRAM))
 
-#define EFA_DGRAM_CONNID (0x0)
-
 #define EFA_DEF_POOL_ALIGNMENT (8)
 #define EFA_MEM_ALIGNMENT (64)
 

--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -224,15 +224,13 @@ void efa_av_implicit_av_lru_conn_move(struct efa_av *av,
 /*
  * @brief Add newly insert address to the reverse AVs
  *
- * @param[in]		av		EFA AV object
  * @param[in,out]	cur_reverse_av	Reverse AV with AHN and QPN as key
  * @param[in,out]	prv_reverse_av	Reverse AV with AHN, QPN and QKEY as key
  * @param[in]		conn		efa_conn object
  * @return		On success, return 0.
  * 			Otherwise, return a negative libfabric error code
  */
-int efa_av_reverse_av_add(struct efa_av *av,
-				 struct efa_cur_reverse_av **cur_reverse_av,
+int efa_av_reverse_av_add(struct efa_cur_reverse_av **cur_reverse_av,
 				 struct efa_prv_reverse_av **prv_reverse_av,
 				 struct efa_conn *conn)
 {
@@ -262,10 +260,6 @@ int efa_av_reverse_av_add(struct efa_av *av,
 		return 0;
 	}
 
-	/* We used a static connid for all dgram endpoints, therefore cur_entry should always be NULL,
-	 * and only RDM endpoint can reach here. hence the following assertion
-	 */
-	assert(av->domain->info_type == EFA_INFO_RDM);
 	prv_entry = malloc(sizeof(*prv_entry));
 	if (!prv_entry) {
 		EFA_WARN(FI_LOG_AV, "Cannot allocate memory for prv_reverse_av entry\n");
@@ -409,7 +403,7 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 		return err;
 	}
 
-	err = efa_av_reverse_av_add(av, &av->cur_reverse_av, &av->prv_reverse_av, explicit_conn);
+	err = efa_av_reverse_av_add(&av->cur_reverse_av, &av->prv_reverse_av, explicit_conn);
 	if (err) {
 		EFA_WARN(FI_LOG_AV, "Failed to insert explicit connection for fi_addr %" PRIu64 " into reverse AV: %s\n",
 			 *fi_addr, fi_strerror(-err));
@@ -489,9 +483,6 @@ static inline int efa_av_insert_one_validate(struct efa_av *av,
 		*fi_addr = FI_ADDR_NOTAVAIL;
 		return -FI_EADDRNOTAVAIL;
 	}
-
-	if (av->domain->info_type == EFA_INFO_DGRAM)
-		addr->qkey = EFA_DGRAM_CONNID;
 
 	memset(raw_gid_str, 0, INET6_ADDRSTRLEN);
 	if (!inet_ntop(AF_INET6, addr->raw, raw_gid_str, INET6_ADDRSTRLEN)) {

--- a/prov/efa/src/efa_av.h
+++ b/prov/efa/src/efa_av.h
@@ -113,8 +113,7 @@ fi_addr_t efa_av_reverse_lookup_rdm_implicit(struct efa_av *av, uint16_t ahn,
 
 fi_addr_t efa_av_reverse_lookup(struct efa_av *av, uint16_t ahn, uint16_t qpn);
 
-int efa_av_reverse_av_add(struct efa_av *av,
-			  struct efa_cur_reverse_av **cur_reverse_av,
+int efa_av_reverse_av_add(struct efa_cur_reverse_av **cur_reverse_av,
 			  struct efa_prv_reverse_av **prv_reverse_av,
 			  struct efa_conn *conn);
 

--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -197,7 +197,17 @@ static int efa_read_random(struct efa_device *device, uint32_t *val)
 }
 #endif
 
-static uint32_t efa_generate_rdm_connid(struct efa_device *device)
+/**
+ * @brief Generate a random QKEY for a QP
+ *
+ * The QKEY doubles as the connection ID (connid) that distinguishes two
+ * endpoints sharing the same GID and QPN, so it is generated the same way
+ * for every endpoint type.
+ *
+ * @param[in]	device	efa device
+ * @return	the generated QKEY
+ */
+static uint32_t efa_generate_qkey(struct efa_device *device)
 {
 	uint32_t val;
 
@@ -570,9 +580,7 @@ int efa_base_ep_enable_qp(struct efa_base_ep *base_ep, struct efa_qp *qp)
 	}
 #endif
 
-	qp->qkey = (base_ep->util_ep.type == FI_EP_DGRAM) ?
-			   EFA_DGRAM_CONNID :
-			   efa_generate_rdm_connid(base_ep->domain->device);
+	qp->qkey = efa_generate_qkey(base_ep->domain->device);
 	err = efa_base_ep_modify_qp_rst2rts(base_ep, qp);
 	if (err)
 		return err;

--- a/prov/efa/src/efa_conn.c
+++ b/prov/efa/src/efa_conn.c
@@ -303,7 +303,7 @@ struct efa_conn *efa_conn_alloc_explicit(struct efa_av *av, struct efa_ep_addr *
 		goto err_rdm_deinit;
 	}
 
-	err = efa_av_reverse_av_add(av, cur_reverse_av, prv_reverse_av, conn);
+	err = efa_av_reverse_av_add(cur_reverse_av, prv_reverse_av, conn);
 	if (err) {
 		EFA_WARN(FI_LOG_AV, "Failed to insert connection for fi_addr %" PRIu64
 			" into reverse AV: %s\n", fi_addr, fi_strerror(-err));
@@ -404,7 +404,7 @@ struct efa_conn *efa_conn_alloc_implicit(struct efa_av *av, struct efa_ep_addr *
 	 * transmission. Therefore shm av insertion should not happen here.
 	 */
 
-	err = efa_av_reverse_av_add(av, &av->cur_reverse_av_implicit, &av->prv_reverse_av_implicit, conn);
+	err = efa_av_reverse_av_add(&av->cur_reverse_av_implicit, &av->prv_reverse_av_implicit, conn);
 	if (err) {
 		efa_conn_rdm_deinit(av, conn);
 		goto err_release;

--- a/prov/efa/test/gtest/efa_gtest_common_mocks.h
+++ b/prov/efa/test/gtest/efa_gtest_common_mocks.h
@@ -42,10 +42,10 @@ struct efa_ah;
 	   uint32_t inlen),                                                    \
 	  (ibv_ah, attr, inlen))                                               \
 	X(int, efa_av_reverse_av_add,                                          \
-	  (struct efa_av * av, struct efa_cur_reverse_av * *cur_reverse_av,    \
+	  (struct efa_cur_reverse_av * *cur_reverse_av,                        \
 	   struct efa_prv_reverse_av * *prv_reverse_av,                        \
 	   struct efa_conn * conn),                                            \
-	  (av, cur_reverse_av, prv_reverse_av, conn))                          \
+	  (cur_reverse_av, prv_reverse_av, conn))                              \
 	X(int, efa_ibv_cq_start_poll,                                          \
 	  (struct efa_ibv_cq * ibv_cq, struct ibv_poll_cq_attr * attr),        \
 	  (ibv_cq, attr))                                                      \


### PR DESCRIPTION
Code cleanup. The provider has two separate QKEY-creation paths that do the same job, and this collapses them into one.

DGRAM endpoints were given a hardcoded QKEY of 0 (EFA_DGRAM_CONNID), while RDM and efa-direct endpoints got a randomly generated one from efa_generate_rdm_connid(). The DGRAM special case also required efa_av_insert_one() to overwrite the peer's QKEY with the same constant on every insert, so the two halves had to be kept in sync by hand.

- Rename efa_generate_rdm_connid() to efa_generate_qkey() and call it unconditionally in efa_base_ep_enable_qp(). DGRAM QPs now get the same randomly generated QKEY that RDM and efa-direct QPs already got.
- Stop rewriting addr->qkey in the AV insert path. The peer's QKEY is now used as given, which is what the send path already expects.
- Drop the now-unreachable EFA_INFO_RDM assertion in efa_av_reverse_av_add(), along with the stale comment justifying it. With a per-QP QKEY, an AHN and QPN collision in cur_reverse_av is a legitimate QPN reuse for any endpoint type, not an RDM-only case, and it is already handled by demoting the existing conn to prv_reverse_av. This leaves the av argument unused, so remove it; efa_av_reverse_av_remove() already takes no av.
- Remove the now unused EFA_DGRAM_CONNID define.