### PR TITLE
prov/efa: Change write lock for ep peer map

### DIFF
--- a/prov/efa/src/efa_av.c
+++ b/prov/efa/src/efa_av.c
@@ -459,7 +459,7 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 	dlist_foreach(&av->util_av.ep_list, entry) {
 		ep = container_of(entry, struct efa_rdm_ep, base_ep.util_ep.av_entry);
 		/* move from implicit to explicit peer map, using new fi_addr */
-		EFA_GENLOCK_LOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
+		EFA_GENLOCK_LOCK(&ep->ctrl_lock, efa_ctrl_lock_sym);
 		peer = efa_rdm_ep_peer_map_remove(ep->fi_addr_to_peer_map_implicit,
 					       implicit_fi_addr);
 		if (peer) {
@@ -470,7 +470,7 @@ static int efa_conn_implicit_to_explicit(struct efa_av *av,
 					 "Failed to insert peer into explicit map for addr %lu\n",
 					 *fi_addr);
 		}
-		EFA_GENLOCK_UNLOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
+		EFA_GENLOCK_UNLOCK(&ep->ctrl_lock, efa_ctrl_lock_sym);
 		peer_srx = util_get_peer_srx(ep->peer_srx_ep);
 		peer_srx->owner_ops->foreach_unspec_addr(peer_srx, &efa_av_get_addr_from_peer_rx_entry);
 	}

--- a/prov/efa/src/efa_conn.c
+++ b/prov/efa/src/efa_conn.c
@@ -211,13 +211,13 @@ void efa_conn_rdm_deinit(struct efa_av *av, struct efa_conn *conn)
 			peer_map = ep->fi_addr_to_peer_map_implicit;
 			fi_addr = conn->implicit_fi_addr;
 		}
-		EFA_GENLOCK_LOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
+		EFA_GENLOCK_LOCK(&ep->ctrl_lock, efa_ctrl_lock_sym);
 		peer = efa_rdm_ep_peer_map_remove(peer_map, fi_addr);
 		if (peer) {
 			efa_rdm_peer_destruct(peer, ep);
 			ofi_buf_free(peer);
 		}
-		EFA_GENLOCK_UNLOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
+		EFA_GENLOCK_UNLOCK(&ep->ctrl_lock, efa_ctrl_lock_sym);
 	}
 	ofi_genlock_unlock(&av->util_av.ep_list_lock);
 }

--- a/prov/efa/src/efa_thread_annotations.c
+++ b/prov/efa/src/efa_thread_annotations.c
@@ -6,5 +6,6 @@
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_qp_table_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_implicit_av_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_util_ep_lock_sym);
+OFI_TSA_LOCK_SYMBOL_DEFINE(efa_ctrl_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_util_av_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_util_domain_lock_sym);

--- a/prov/efa/src/efa_thread_annotations.h
+++ b/prov/efa/src/efa_thread_annotations.h
@@ -95,6 +95,7 @@ efa_genlock_held(struct ofi_genlock *lock, struct ofi_tsa_lock_symbol *sym)
 OFI_TSA_LOCK_SYMBOL_DECLARE(efa_qp_table_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DECLARE(efa_implicit_av_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DECLARE(efa_util_ep_lock_sym);
+OFI_TSA_LOCK_SYMBOL_DECLARE(efa_ctrl_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DECLARE(efa_util_av_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DECLARE(efa_util_domain_lock_sym);
 

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -153,6 +153,8 @@ struct efa_rdm_ep {
 	struct efa_av_array *fi_addr_to_peer_map;
 	struct efa_av_array *fi_addr_to_peer_map_implicit;
 	struct ofi_bufpool *efa_rdm_peer_pool;
+	/* Serializes configuration-path ep-level operations. */
+	struct ofi_genlock ctrl_lock;
 
 	/* buffer pool for peer reorder circular buffer */
 	struct ofi_bufpool *peer_robuf_pool;
@@ -254,10 +256,10 @@ int efa_rdm_ep_peer_map_init(struct efa_av_array **arr);
 struct efa_rdm_peer *efa_rdm_ep_peer_map_lookup(struct efa_av_array *arr, fi_addr_t addr);
 
 int efa_rdm_ep_peer_map_insert(struct efa_av_array *arr, fi_addr_t addr, struct efa_rdm_peer *peer)
-	OFI_TSA_REQUIRES(efa_util_ep_lock_sym);
+	OFI_TSA_REQUIRES(efa_ctrl_lock_sym);
 
 struct efa_rdm_peer *efa_rdm_ep_peer_map_remove(struct efa_av_array *arr, fi_addr_t addr)
-	OFI_TSA_REQUIRES(efa_util_ep_lock_sym);
+	OFI_TSA_REQUIRES(efa_ctrl_lock_sym);
 
 struct efa_rdm_ope *efa_rdm_ep_alloc_rxe(struct efa_rdm_ep *ep,
 					   struct efa_rdm_peer *peer, uint32_t op);

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -564,9 +564,16 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 	efa_rdm_ep->efa_rx_pkts_held = 0;
 	efa_rdm_ep->efa_outstanding_tx_ops = 0;
 
-	ret = efa_rdm_ep_create_buffer_pools(efa_rdm_ep);
+	ret = ofi_genlock_init(&efa_rdm_ep->ctrl_lock,
+			       ofi_thread_level(efa_rdm_ep->base_ep.util_ep.domain->threading) <=
+			       ofi_thread_level(FI_THREAD_COMPLETION) ?
+			       OFI_LOCK_MUTEX : OFI_LOCK_NOOP);
 	if (ret)
 		goto err_close_shm_ep;
+
+	ret = efa_rdm_ep_create_buffer_pools(efa_rdm_ep);
+	if (ret)
+		goto err_destroy_ctrl_lock;
 
 	efa_rdm_ep_init_linked_lists(efa_rdm_ep);
 
@@ -639,6 +646,8 @@ err_free_pke_vec:
 	free(efa_rdm_ep->pke_vec);
 err_destroy_buffer_pools:
 	efa_rdm_ep_destroy_buffer_pools(efa_rdm_ep);
+err_destroy_ctrl_lock:
+	ofi_genlock_destroy(&efa_rdm_ep->ctrl_lock);
 err_close_shm_ep:
 	if (efa_rdm_ep->shm_ep) {
 		retv = fi_close(&efa_rdm_ep->shm_ep->fid);
@@ -1142,6 +1151,8 @@ static int efa_rdm_ep_close(struct fid *fid)
 		retv = ret;
 
 	efa_rdm_ep_destroy_buffer_pools(efa_rdm_ep);
+
+	ofi_genlock_destroy(&efa_rdm_ep->ctrl_lock);
 
 	if (efa_rdm_ep->pke_vec)
 		free(efa_rdm_ep->pke_vec);

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -100,7 +100,7 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer_explicit(struct efa_rdm_ep *ep, fi_addr
 
 	/* Path 2: the peer is not in the map. Take the lock, then create the
 	 * peer and insert it. */
-	EFA_GENLOCK_LOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
+	EFA_GENLOCK_LOCK(&ep->ctrl_lock, efa_ctrl_lock_sym);
 
 	/* Path 2.1: two writers can race here -- both looked up, neither found
 	 * the peer, so both would try to insert. Re-check under the lock; if
@@ -133,7 +133,7 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer_explicit(struct efa_rdm_ep *ep, fi_addr
 	}
 
 unlock:
-	EFA_GENLOCK_UNLOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
+	EFA_GENLOCK_UNLOCK(&ep->ctrl_lock, efa_ctrl_lock_sym);
 	return peer;
 }
 
@@ -169,7 +169,7 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer_implicit(struct efa_rdm_ep *ep, fi_addr
 	 */
 	EFA_GENLOCK_LOCK(&ep->base_ep.domain->util_domain.lock, efa_util_domain_lock_sym);
 	EFA_GENLOCK_LOCK(&ep->base_ep.av->util_av_implicit.lock, efa_implicit_av_lock_sym);
-	EFA_GENLOCK_LOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
+	EFA_GENLOCK_LOCK(&ep->ctrl_lock, efa_ctrl_lock_sym);
 
 	peer = efa_rdm_ep_peer_map_lookup(ep->fi_addr_to_peer_map_implicit, addr);
 	if (peer)
@@ -202,7 +202,7 @@ struct efa_rdm_peer *efa_rdm_ep_get_peer_implicit(struct efa_rdm_ep *ep, fi_addr
 	}
 
 unlock_ep:
-	EFA_GENLOCK_UNLOCK(&ep->base_ep.util_ep.lock, efa_util_ep_lock_sym);
+	EFA_GENLOCK_UNLOCK(&ep->ctrl_lock, efa_ctrl_lock_sym);
 
 	/* Move to the front of the LRU list; peer->conn stays valid under the
 	 * implicit-AV lock held here. */


### PR DESCRIPTION
Currently, we use ep_util to lock ep peer map, but as this lock is meant only for fast-path operations and is a noop for THREAD_COMPLETION level locking, it does not provide the protection ep peer map needs.

This patch adds a new ep configuration lock which will be used for all slow-path ep-level resource configuration which needs to be locked.