### PR TITLE
prov/efa: Make srx_lock NOOP for FI_THREAD_COMPLETION

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_domain.c
+++ b/prov/efa/src/rdm/efa_rdm_domain.c
@@ -146,9 +146,9 @@ int efa_rdm_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	efa_domain = &rdm_domain->efa_domain;
 
 	/* Initialize srx_lock first so efa_rdm_domain_close can always destroy it */
-	use_lock = ofi_thread_level(info->domain_attr->threading) <=
-		   ofi_thread_level(FI_THREAD_COMPLETION);
-	err = ofi_genlock_init(&rdm_domain->srx_lock, use_lock ? OFI_LOCK_MUTEX : OFI_LOCK_NOOP);
+    use_lock = ofi_thread_level(info->domain_attr->threading) ==
+           ofi_thread_level(FI_THREAD_SAFE);
+	err = ofi_genlock_init(&rdm_domain->srx_lock, use_lock ? OFI_LOCK_MUTEX : OFI_LOCK_NONE);
 	if (err) {
 		EFA_WARN(FI_LOG_DOMAIN, "srx lock init failed! err: %d\n", err);
 		free(rdm_domain);


### PR DESCRIPTION
srx lock is only in the data path now. Applications must serialize access to all objects that are associated by a common completion mechanism under FI_THREAD_COMPLETION so we can make it noop.