### PR TITLE
prov/efa: Update supported threading models in man page

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -92,7 +92,7 @@ The following features are supported:
   for a detailed comparison of `efa` vs `efa-direct` fabrics.
 
 *Threading*
-: Both RDM and DGRAM endpoints supports *FI_THREAD_SAFE*.
+: Both RDM and DGRAM endpoints supports *FI_THREAD_SAFE*, *FI_THREAD_COMPLETION*, *FI_THREAD_DOMAIN*.
 
 *Completion counters*
 : The `efa-direct` fabric supports hardware completion counters backed by


### PR DESCRIPTION
EFA provider supports FI_THREADS_SAFE, FI_THREAD_COMPLETION and FI_THREAD_DOMAIN.