### PR TITLE
prov/cxi: Support extended NIDs used by SR-IOV VFs

### DIFF
--- a/prov/cxi/src/cxip_dom.c
+++ b/prov/cxi/src/cxip_dom.c
@@ -1926,7 +1926,7 @@ int cxip_domain(struct fid_fabric *fabric, struct fi_info *info,
 {
 	struct cxip_domain *cxi_domain;
 	struct cxip_fabric *fab;
-	struct cxip_addr *src_addr;
+	struct cxip_nic_attr *nic_attr;
 	uint32_t seed;
 	int ret;
 
@@ -1968,8 +1968,8 @@ int cxip_domain(struct fid_fabric *fabric, struct fi_info *info,
 		CXIP_WARN("Invalid fi_info\n");
 		goto close_util_dom;
 	}
-	src_addr = (struct cxip_addr *)info->src_addr;
-	cxi_domain->nic_addr = src_addr->nic;
+	nic_attr = (struct cxip_nic_attr *)info->nic->prov_attr;
+	cxi_domain->nic_addr = nic_attr->addr;
 
 	if (info->domain_attr->auth_key) {
 		/* Auth key size is verified in ofi_prov_check_info(). */

--- a/prov/cxi/src/cxip_ep.c
+++ b/prov/cxi/src/cxip_ep.c
@@ -1455,8 +1455,7 @@ int cxip_alloc_endpoint(struct cxip_domain *cxip_dom, struct fi_info *hints,
 	int ret;
 	struct cxip_ep_obj *ep_obj;
 	uint32_t txc_tclass = FI_TC_UNSPEC;
-	uint32_t nic;
-	uint32_t pid;
+	struct cxip_addr ep_addr;
 	int i;
 
 	if (!hints || !hints->ep_attr || !hints->tx_attr || !hints->rx_attr)
@@ -1477,16 +1476,16 @@ int cxip_alloc_endpoint(struct cxip_domain *cxip_dom, struct fi_info *hints,
 	if (ret)
 		return ret;
 
-	nic = cxip_dom->nic_addr;
+	ep_addr.nic = cxip_dom->nic_addr;
 	if (hints->src_addr) {
 		struct cxip_addr *src = hints->src_addr;
-		if (src->nic != nic) {
+		if (src->nic != ep_addr.nic) {
 			CXIP_WARN("bad src_addr NIC value\n");
 			return -FI_EINVAL;
 		}
-		pid = src->pid;
+		ep_addr.pid = src->pid;
 	} else {
-		pid = C_PID_ANY;
+		ep_addr.pid = C_PID_ANY;
 	}
 
 	ep_obj = calloc(1, sizeof(struct cxip_ep_obj));
@@ -1515,8 +1514,8 @@ int cxip_alloc_endpoint(struct cxip_domain *cxip_dom, struct fi_info *hints,
 		ofi_genlock_init(&ep_obj->lock, OFI_LOCK_SPINLOCK);
 
 	ep_obj->domain = cxip_dom;
-	ep_obj->src_addr.nic = nic;
-	ep_obj->src_addr.pid = pid;
+	ep_obj->src_addr.nic = ep_addr.nic;
+	ep_obj->src_addr.pid = ep_addr.pid;
 	ep_obj->fi_addr = FI_ADDR_NOTAVAIL;
 
 	/* Default to allowing non-dev reg copy APIs unless the caller

--- a/prov/cxi/src/cxip_info.c
+++ b/prov/cxi/src/cxip_info.c
@@ -1605,20 +1605,14 @@ static int cxip_validate_iface_auth_key(struct cxip_if *iface,
 
 int cxip_check_auth_key_info(struct fi_info *info)
 {
-	struct cxip_addr *src_addr;
+	struct cxip_nic_attr *nic_attr = (struct cxip_nic_attr *)info->nic->prov_attr;
 	struct cxip_if *iface;
 	int ret;
 
-	src_addr = (struct cxip_addr *)info->src_addr;
-	if (!src_addr) {
-		CXIP_WARN("NULL src_addr in fi_info\n");
-		return -FI_EINVAL;
-	}
-
-	ret = cxip_get_if(src_addr->nic, &iface);
+	ret = cxip_get_if(nic_attr->addr, &iface);
 	if (ret) {
 		CXIP_WARN("cxip_get_if with NIC %#x failed: %d:%s\n",
-				src_addr->nic, ret, fi_strerror(-ret));
+				nic_attr->addr, ret, fi_strerror(-ret));
 		return ret;
 	}
 


### PR DESCRIPTION
Virtual functions hosted on the same physical NIC are differentiated in software by the top bits of the NID (which are otherwise unused on the wire). For example, first VF belonging to the PF with NID 0x42 will have NID `0x42 | 1 << C_DFA_NIC_BITS`, the second will be `0x42 | 2 << C_DFA_NIC_BITS`, etc.

The CXI provider's `struct cxip_addr` representation only allows for a 20-bit NID (as sent out on the wire). To avoid collisions between VFs and PFs when looking up a NIC, we need to ensure that these lookups use the full-width 'extended' NID as supplied by the driver, rather than the truncated wire-format NID represented in `struct cxip_addr`. This has the side effect that direct comparisons between a 32-bit NID and the wire-format 20-bit version in `struct cxip_addr` are no longer valid - they must be converted to `struct cxip_addr` first to strip the extra bits off.