### PR TITLE
prov/efa: Make domain->num_read_msg_in_flight atomic

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_domain.c
+++ b/prov/efa/src/rdm/efa_rdm_domain.c
@@ -92,7 +92,7 @@ static int efa_rdm_domain_init(struct efa_rdm_domain *rdm_domain, struct fi_info
 	rdm_domain->addrlen = (info->src_addr) ? info->src_addrlen : info->dest_addrlen;
 	rdm_domain->rdm_cq_size = MAX(info->rx_attr->size + info->tx_attr->size,
 				  efa_env.cq_size);
-	rdm_domain->num_read_msg_in_flight = 0;
+	ofi_atomic_initialize64(&rdm_domain->num_read_msg_in_flight, 0);
 
 	dlist_init(&rdm_domain->ah_lru_list);
 

--- a/prov/efa/src/rdm/efa_rdm_domain.h
+++ b/prov/efa/src/rdm/efa_rdm_domain.h
@@ -17,7 +17,7 @@ struct efa_rdm_domain {
 	size_t			addrlen;
 	size_t			rdm_cq_size;
 	/* number of rdma-read messages in flight */
-	uint64_t		num_read_msg_in_flight;
+	ofi_atomic64_t		num_read_msg_in_flight;
 	/* LRU list of AH entries in this domain */
 	struct dlist_entry ah_lru_list OFI_TSA_GUARDED_BY(efa_util_domain_lock_sym);
 };

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -974,14 +974,16 @@ void efa_rdm_txe_progress_peer_abort_if_drained(struct efa_rdm_ope *txe)
 void efa_rdm_txe_release_read_msg_slot(struct efa_rdm_ope *txe)
 {
 	struct efa_rdm_domain *domain;
+	int64_t num_read_msg_in_flight;
 
 	if (!(txe->internal_flags & EFA_RDM_TXE_READ_MSG_COUNTED))
 		return;
 	txe->internal_flags &= ~EFA_RDM_TXE_READ_MSG_COUNTED;
 
 	domain = efa_rdm_ep_rdm_domain(txe->ep);
-	assert(domain->num_read_msg_in_flight > 0);
-	domain->num_read_msg_in_flight -= 1;
+	num_read_msg_in_flight = ofi_atomic_dec64(&domain->num_read_msg_in_flight);
+	assert(num_read_msg_in_flight >= 0);
+	(void) num_read_msg_in_flight;
 }
 
 /**

--- a/prov/efa/src/rdm/efa_rdm_peer.c
+++ b/prov/efa/src/rdm/efa_rdm_peer.c
@@ -575,7 +575,7 @@ int efa_rdm_peer_select_readbase_rtm(struct efa_rdm_peer *peer,
 
 	assert(op == ofi_op_tagged || op == ofi_op_msg);
 
-	if (efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight == 0 &&
+	if (ofi_atomic_get64(&efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight) == 0 &&
 	    efa_rdm_peer_get_runt_size(peer, ep, ope) > 0 &&
 	    !(ope->fi_flags & FI_DELIVERY_COMPLETE)) {
 		return (op == ofi_op_tagged) ? EFA_RDM_RUNTREAD_TAGRTM_PKT

--- a/prov/efa/src/rdm/efa_rdm_pke_rtm.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_rtm.c
@@ -1185,7 +1185,7 @@ ssize_t efa_rdm_pke_init_longread_tagrtm(struct efa_rdm_pke *pkt_entry,
  */
 void efa_rdm_pke_handle_longread_rtm_sent(struct efa_rdm_pke *pkt_entry)
 {
-	efa_rdm_ep_rdm_domain(pkt_entry->ep)->num_read_msg_in_flight += 1;
+	ofi_atomic_inc64(&efa_rdm_ep_rdm_domain(pkt_entry->ep)->num_read_msg_in_flight);
 	/*
 	 * Record the bump on the txe so a sender-side abort, which receives
 	 * none of the packets that normally decrement the counter, can
@@ -1352,7 +1352,7 @@ void efa_rdm_pke_handle_runtread_rtm_sent(struct efa_rdm_pke *pkt_entry, struct 
 
 	if (efa_rdm_pke_get_runtread_rtm_base_hdr(pkt_entry)->seg_offset == 0 &&
 	    txe->total_len > txe->bytes_runt) {
-		efa_rdm_ep_rdm_domain(pkt_entry->ep)->num_read_msg_in_flight += 1;
+		ofi_atomic_inc64(&efa_rdm_ep_rdm_domain(pkt_entry->ep)->num_read_msg_in_flight);
 		/* Record the bump so a sender-side abort can balance the
 		 * counter; see EFA_RDM_TXE_READ_MSG_COUNTED. */
 		txe->internal_flags |= EFA_RDM_TXE_READ_MSG_COUNTED;

--- a/prov/efa/test/efa_unit_test_ope.c
+++ b/prov/efa/test/efa_unit_test_ope.c
@@ -3767,8 +3767,8 @@ void test_efa_rdm_pke_handle_peer_error_recv_longread_fails_txe(void **state)
 	 * EFA_RDM_TXE_READ_MSG_COUNTED when it sent the LONGREAD/RUNTREAD
 	 * RTM (flag and bump are set together). Simulate both. */
 	txe->internal_flags |= EFA_RDM_TXE_READ_MSG_COUNTED;
-	efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight = 1;
-	in_flight_before = efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight;
+	ofi_atomic_set64(&efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight, 1);
+	in_flight_before = ofi_atomic_get64(&efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight);
 
 	/* Build the inbound PEER_ERROR_PKT pointing at our txe via send_id. */
 	pkt_entry = efa_rdm_pke_alloc(ep, ep->efa_rx_pkt_pool,
@@ -3791,7 +3791,7 @@ void test_efa_rdm_pke_handle_peer_error_recv_longread_fails_txe(void **state)
 	efa_rdm_pke_handle_peer_error_recv(pkt_entry);
 
 	/* num_read_msg_in_flight decremented. */
-	assert_int_equal(efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight,
+	assert_int_equal(ofi_atomic_get64(&efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight),
 			 in_flight_before - 1);
 
 	/* User must see a TX CQ error with the clean, dedicated
@@ -4144,7 +4144,7 @@ void test_efa_rdm_pke_handle_peer_error_recv_invalid_op_id_dropped(void **state)
 
 	/* No txe/rxe allocated; num_read_msg_in_flight stays 0 so an
 	 * unguarded decrement would wrap it. */
-	assert_int_equal(efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight, 0);
+	assert_int_equal(ofi_atomic_get64(&efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight), 0);
 
 	pkt_entry = efa_rdm_pke_alloc(ep, ep->efa_rx_pkt_pool,
 				      EFA_RDM_PKE_FROM_EFA_RX_POOL);
@@ -4166,7 +4166,7 @@ void test_efa_rdm_pke_handle_peer_error_recv_invalid_op_id_dropped(void **state)
 	efa_rdm_pke_handle_peer_error_recv(pkt_entry);
 
 	/* Counter not touched (no underflow). */
-	assert_int_equal(efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight, 0);
+	assert_int_equal(ofi_atomic_get64(&efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight), 0);
 
 	/* No user CQ error written. */
 	ret = fi_cq_readerr(resource->cq, &err_entry, 0);
@@ -4353,7 +4353,7 @@ void test_efa_rdm_txe_handle_error_longread_emits_and_balances_read_cnt(void **s
 	/* Simulate efa_rdm_pke_handle_longread_rtm_sent(): the RTM was
 	 * accepted by the device, bumping the read counter. */
 	txe->internal_flags |= EFA_RDM_TXE_READ_MSG_COUNTED;
-	efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight = 1;
+	ofi_atomic_set64(&efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight, 1);
 
 	outstanding_before = ep->efa_outstanding_tx_ops;
 
@@ -4362,7 +4362,7 @@ void test_efa_rdm_txe_handle_error_longread_emits_and_balances_read_cnt(void **s
 	/* Marked, emitted (PEER_ERROR WR posted), counter balanced. */
 	assert_true(txe->internal_flags & EFA_RDM_OPE_PEER_ABORT_PENDING);
 	assert_int_equal(ep->efa_outstanding_tx_ops, outstanding_before + 1);
-	assert_int_equal(efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight, 0);
+	assert_int_equal(ofi_atomic_get64(&efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight), 0);
 	assert_false(txe->internal_flags & EFA_RDM_TXE_READ_MSG_COUNTED);
 	assert_int_equal(txe->peer_error_prov_errno, FI_EFA_ERR_PKT_POST);
 
@@ -4386,7 +4386,7 @@ void test_efa_rdm_txe_handle_error_longread_emits_and_balances_read_cnt(void **s
 	 * regardless), but the never-bumped counter is left alone. */
 	assert_true(txe_unsent->internal_flags & EFA_RDM_OPE_PEER_ABORT_PENDING);
 	assert_int_equal(ep->efa_outstanding_tx_ops, outstanding_before + 1);
-	assert_int_equal(efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight, 0);
+	assert_int_equal(ofi_atomic_get64(&efa_rdm_ep_rdm_domain(ep)->num_read_msg_in_flight), 0);
 }
 
 /**

--- a/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c
+++ b/prov/efa/test/gtest/efa_gtest_rdm_pke_utils.c
@@ -513,7 +513,7 @@ void efa_test_rtm_sent_build(struct fid_ep *ep, struct fid_av *av,
 		 * the "sent" handler only bumps (drained elsewhere), so repeated
 		 * builds in one test would see a growing absolute value. The
 		 * fresh peer per build makes its counter effectively a delta. */
-		uint64_t read_in_flight_before = domain->num_read_msg_in_flight;
+		uint64_t read_in_flight_before = ofi_atomic_get64(&domain->num_read_msg_in_flight);
 
 		switch (family) {
 		case EFA_TEST_RTM_FAM_MEDIUM:
@@ -535,7 +535,7 @@ void efa_test_rtm_sent_build(struct fid_ep *ep, struct fid_av *av,
 		out->bytes_sent = txe->bytes_sent;
 		out->bytes_acked = txe->bytes_acked;
 		out->num_read_msg_in_flight =
-			domain->num_read_msg_in_flight - read_in_flight_before;
+			ofi_atomic_get64(&domain->num_read_msg_in_flight) - read_in_flight_before;
 		out->num_runt_bytes_in_flight = peer->num_runt_bytes_in_flight;
 		out->txe_on_ope_list = 1;
 		efa_rdm_pke_release_tx(pkt_entry);


### PR DESCRIPTION
Change num_read_msg_in_flight from uint64_t to ofi_atomic64_t to prevent lost updates when multiple EPs on different threads increment/decrement the counter concurrently so it does not rely on a lock.