### PR TITLE
core: fix missing abi bump and fi_tostr for FI_XPU API

### DIFF
--- a/man/fi_domain.3.md
+++ b/man/fi_domain.3.md
@@ -213,6 +213,7 @@ struct fi_domain_attr {
 	uint32_t              max_group_id;
 	uint64_t              max_cntr_value;
 	uint64_t              max_err_cntr_value;
+	size_t                max_xpu_ctx_cnt;
 };
 ```
 
@@ -857,6 +858,14 @@ return a value larger than the one requested.
 Applications must manage error counter values that approach this limit.
 See [`fi_cntr`(3)](fi_cntr.3.html) for details on counter limit handling
 responsibilities.
+
+## Maximum XPU Context Count (max_xpu_ctx_cnt)
+
+The number of XPU contexts the domain supports for XPU-initiated communication
+(the FI_XPU capability). A value of 0 indicates the domain does not support
+XPU-initiated communication; a value of 1 indicates a 1:1 mapping between the
+domain and an XPU. This field is an output of fi_getinfo. See
+[`fi_xpu`(3)](fi_xpu.3.html) for details on the XPU API and context model.
 
 # RETURN VALUE
 

--- a/src/abi_1_0.c
+++ b/src/abi_1_0.c
@@ -856,9 +856,42 @@ struct fi_ep_attr_1_9 {
 	uint8_t			*auth_key;
 };
 
+struct fi_domain_attr_1_9 {
+	struct fid_domain	*domain;
+	char			*name;
+	enum fi_threading	threading;
+	enum fi_progress	control_progress;
+	enum fi_progress	data_progress;
+	enum fi_resource_mgmt	resource_mgmt;
+	enum fi_av_type		av_type;
+	int			mr_mode;
+	size_t			mr_key_size;
+	size_t			cq_data_size;
+	size_t			cq_cnt;
+	size_t			ep_cnt;
+	size_t			tx_ctx_cnt;
+	size_t			rx_ctx_cnt;
+	size_t			max_ep_tx_ctx;
+	size_t			max_ep_rx_ctx;
+	size_t			max_ep_stx_ctx;
+	size_t			max_ep_srx_ctx;
+	size_t			cntr_cnt;
+	size_t			mr_iov_limit;
+	uint64_t		caps;
+	uint64_t		mode;
+	uint8_t			*auth_key;
+	size_t 			auth_key_size;
+	size_t			max_err_data;
+	size_t			mr_cnt;
+	uint32_t		tclass;
+	size_t			max_ep_auth_key;
+	uint32_t		max_group_id;
+	uint64_t		max_cntr_value;
+	uint64_t		max_err_cntr_value;
+};
+
 #define fi_tx_attr_1_9 fi_tx_attr_1_8
 #define fi_rx_attr_1_9 fi_rx_attr_1_8
-#define fi_domain_attr_1_9 fi_domain_attr_1_8
 #define fi_fabric_attr_1_9 fi_fabric_attr_1_8
 #define fid_nic_1_9 fid_nic_1_8
 

--- a/src/fi_tostr.c
+++ b/src/fi_tostr.c
@@ -408,6 +408,8 @@ ofi_tostr_ep_attr(char *buf, size_t len, const struct fi_ep_attr *attr,
 
 	ofi_strncatf(buf, len, "%s%sauth_key_size: %zu\n", prefix, TAB,
 		     attr->auth_key_size);
+	ofi_strncatf(buf, len, "%s%sxpu_ctx: %p\n", prefix, TAB,
+		     (void *) attr->xpu_ctx);
 }
 
 static void
@@ -551,6 +553,8 @@ ofi_tostr_domain_attr(char *buf, size_t len, const struct fi_domain_attr *attr,
 		     attr->max_cntr_value);
 	ofi_strncatf(buf, len, "%s%smax_err_cntr_value: %lu\n", prefix, TAB,
 		     attr->max_err_cntr_value);
+	ofi_strncatf(buf, len, "%s%smax_xpu_ctx_cnt: %zu\n", prefix, TAB,
+		     attr->max_xpu_ctx_cnt);
 }
 
 static void
@@ -839,6 +843,7 @@ ofi_tostr_cq_attr(char *buf, size_t len, const struct fi_cq_attr *attr)
 	ofi_strncatf(buf, len, "%swait_cond: ", TAB);
 	ofi_tostr_cq_wait_cond(buf, len, attr->wait_cond);
 	ofi_strncatf(buf, len, "\n");
+	ofi_strncatf(buf, len, "%sxpu_ctx: %p\n", TAB, (void *) attr->xpu_ctx);
 }
 
 static void ofi_tostr_mr_access(char *buf, size_t len, uint64_t access)
@@ -904,6 +909,7 @@ ofi_tostr_cntr_attr(char *buf, size_t len, const struct fi_cntr_attr *attr)
 	ofi_tostr_wait_obj(buf, len, attr->wait_obj);
 	ofi_strncatf(buf, len, "\n");
 	ofi_strncatf(buf, len, "%sflags: 0x%lx\n", TAB, attr->flags);
+	ofi_strncatf(buf, len, "%sxpu_ctx: %p\n", TAB, (void *) attr->xpu_ctx);
 }
 
 static void


### PR DESCRIPTION
Fix the missing ABI bump for fi_domain_attr, update the fi_domain man page for the max_xpu_cntr field, add the xpu_attrs in fi_tostr of domain/ep/cq/cntr_attr