### PR TITLE
prov/tcp: Fix PEP close use-after-free

### DIFF
--- a/fabtests/Makefile.am
+++ b/fabtests/Makefile.am
@@ -70,7 +70,8 @@ bin_PROGRAMS = \
 	multinode/fi_multinode_coll \
 	component/sock_test \
 	component/dmabuf-rdma/cuda_check_dmabuf \
-	regression/sighandler_test
+	regression/sighandler_test \
+	regression/pep_close_eq_read
 
 if HAVE_ZE_DEVEL
 if HAVE_VERBS_DEVEL
@@ -632,6 +633,14 @@ regression_sighandler_test_SOURCES = \
 regression_sighandler_test_LDADD = libfabtests.la
 
 regression_sighandler_test_CFLAGS = \
+	$(AM_CFLAGS)
+
+regression_pep_close_eq_read_SOURCES = \
+	regression/pep_close_eq_read.c
+
+regression_pep_close_eq_read_LDADD = libfabtests.la
+
+regression_pep_close_eq_read_CFLAGS = \
 	$(AM_CFLAGS)
 
 real_man_pages = \

--- a/fabtests/regression/pep_close_eq_read.c
+++ b/fabtests/regression/pep_close_eq_read.c
@@ -1,0 +1,411 @@
+/*
+ * Copyright (c) 2026 DataDirect Networks, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * PEP close/EQ read regression test: xnet must not use an unowned connection
+ * handle after its PEP has been closed. Build and run with AddressSanitizer
+ * when validating the provider lifetime fix.
+ *
+ * NOTE: This test is most reliable on loopback (127.0.0.1) where TCP connections
+ * complete quickly enough for the bug to trigger consistently.
+ */
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <getopt.h>
+#include <netinet/in.h>
+#include <rdma/fi_cm.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+#include <rdma/fabric.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "shared.h"
+
+#define DEFAULT_PORT "29384"
+
+struct test_resources {
+	struct fi_info *info;
+	struct fid_fabric *fabric;
+	struct fid_domain *domain;
+	struct fid_ep *ep;
+	struct fid_pep *pep;
+	struct fid_eq *eq;
+	struct fid_cq *cq;
+};
+
+static int report(const char *call, int ret)
+{
+	fprintf(stderr, "%s failed: %s (%d)\n", call,
+		ret < 0 ? fi_strerror(-ret) : "unknown error", ret);
+	return ret;
+}
+
+static void close_resources(struct test_resources *r)
+{
+	if (r->ep)
+		fi_close(&r->ep->fid);
+	if (r->cq)
+		fi_close(&r->cq->fid);
+	if (r->pep)
+		fi_close(&r->pep->fid);
+	if (r->domain)
+		fi_close(&r->domain->fid);
+	if (r->eq)
+		fi_close(&r->eq->fid);
+	if (r->fabric)
+		fi_close(&r->fabric->fid);
+	if (r->info)
+		fi_freeinfo(r->info);
+	memset(r, 0, sizeof(*r));
+}
+
+static int make_hints(struct fi_info **hints_out, const char *provider)
+{
+	struct fi_info *hints = fi_allocinfo();
+
+	if (!hints)
+		return -FI_ENOMEM;
+
+	hints->fabric_attr->prov_name = provider ? strdup(provider) : NULL;
+	hints->ep_attr->type = FI_EP_MSG;
+	hints->caps = FI_MSG;
+	hints->addr_format = FI_SOCKADDR_IN;
+
+	*hints_out = hints;
+	return 0;
+}
+
+static int setup_endpoint(struct test_resources *r, const char *node,
+			  const char *service, const char *provider,
+			  int is_server)
+{
+	struct fi_info *hints;
+	struct fi_eq_attr my_eq_attr = {
+		.wait_obj = FI_WAIT_UNSPEC,
+	};
+	uint64_t flags;
+	int ret;
+
+	flags = is_server ? FI_SOURCE : 0;
+
+	ret = make_hints(&hints, provider);
+	if (ret)
+		return ret;
+
+	ret = fi_getinfo(FI_VERSION(1, 9), node, service, flags,
+			 hints, &r->info);
+	fi_freeinfo(hints);
+	if (ret)
+		return report("fi_getinfo", ret);
+
+	ret = fi_fabric(r->info->fabric_attr, &r->fabric, NULL);
+	if (ret)
+		return report("fi_fabric", ret);
+
+	ret = fi_eq_open(r->fabric, &my_eq_attr, &r->eq, NULL);
+	if (ret)
+		return report("fi_eq_open", ret);
+
+	if (is_server) {
+		/* Server: create passive endpoint */
+
+		ret = fi_passive_ep(r->fabric, r->info, &r->pep, NULL);
+		if (ret)
+			return report("fi_passive_ep", ret);
+
+		ret = fi_pep_bind(r->pep, &r->eq->fid, 0);
+		if (ret)
+			return report("fi_pep_bind", ret);
+
+		ret = fi_listen(r->pep);
+		if (ret)
+			return report("fi_listen", ret);
+	} else {
+		/* Client: create active endpoint */
+		ret = fi_domain(r->fabric, r->info, &r->domain, NULL);
+		if (ret)
+			return report("fi_domain", ret);
+
+		{
+			struct fi_cq_attr cq_attr = {
+				.size = 1,
+				.format = FI_CQ_FORMAT_MSG,
+			};
+			ret = fi_cq_open(r->domain, &cq_attr, &r->cq, NULL);
+		}
+		if (ret)
+			return report("fi_cq_open", ret);
+
+		ret = fi_endpoint(r->domain, r->info, &r->ep, NULL);
+		if (ret)
+			return report("fi_endpoint", ret);
+
+		ret = fi_ep_bind(r->ep, &r->cq->fid, FI_SEND | FI_RECV);
+		if (ret)
+			return report("fi_ep_bind(cq)", ret);
+
+		ret = fi_ep_bind(r->ep, &r->eq->fid, 0);
+		if (ret)
+			return report("fi_ep_bind(eq)", ret);
+
+		ret = fi_enable(r->ep);
+		if (ret)
+			return report("fi_enable", ret);
+
+		ret = fi_connect(r->ep, r->info->dest_addr, NULL, 0);
+		if (ret)
+			return report("fi_connect", ret);
+	}
+
+	return 0;
+}
+
+static int drive_client_progress(struct fid_eq *eq)
+{
+	struct fi_eq_cm_entry entry;
+	uint32_t event;
+	ssize_t ret;
+
+	/* Complete the nonblocking connect and send the CM request.
+	 * Do not wait for FI_CONNECTED event: the server closes the PEP
+	 * before accepting the connection. */
+
+	while (1) {
+		ret = fi_eq_read(eq, &event, &entry, sizeof(entry), 0);
+		if (ret == (ssize_t) sizeof(entry)) {
+			if (entry.info)
+				fi_freeinfo(entry.info);
+			continue;
+		}
+		if (ret == -FI_EAGAIN) {
+			/* No more events available */
+			return 0;
+		}
+		/* Error occurred */
+		FT_PROCESS_EQ_ERR(ret, eq, "fi_eq_read", "client");
+		return (int) ret;
+	}
+}
+
+static int run_client(const char *node, const char *service,
+		      const char *provider)
+{
+	struct test_resources r = {0};
+	int ret;
+
+	printf("Running client, connecting to %s:%s\n",
+	       node ? node : "default", service);
+
+	/* Wait for server to be ready */
+	ft_sock_sync(sock, 0);
+
+	ret = setup_endpoint(&r, node, service, provider, 0);
+	if (ret)
+		goto out;
+
+	/* Signal server that client has connected */
+	ft_sock_sync(sock, 1);
+
+	/* Wait for server to accept */
+	ft_sock_sync(sock, 2);
+
+	ret = drive_client_progress(r.eq);
+	if (ret)
+		goto out;
+
+	/* Signal server that CM is ready */
+	ft_sock_sync(sock, 3);
+
+	/* Wait for server to complete */
+	ft_sock_sync(sock, 4);
+
+	printf("Test PASSED\n");
+
+out:
+	close_resources(&r);
+	return ret;
+}
+
+static int run_server(const char *node, const char *service,
+		      const char *provider)
+{
+	struct test_resources r = {0};
+	struct fi_eq_cm_entry entry;
+	uint32_t event;
+	ssize_t ret;
+
+	printf("Running server on %s:%s\n",
+	       node ? node : "default", service);
+
+	ret = setup_endpoint(&r, node, service, provider, 1);
+	if (ret)
+		goto out;
+
+	/* Signal client that server is ready */
+	ft_sock_sync(sock, 0);
+
+	/* Wait for client to connect */
+	ft_sock_sync(sock, 1);
+
+	/* Call fi_eq_read to trigger the provider's progress function.
+	 * This accepts the TCP socket and creates the xnet_conn_handle.
+	 * On loopback, the connection completes quickly and the handle is created.
+	 * On real network interfaces, timing may prevent the handle from being
+	 * created, so the test may not trigger the bug reliably. */
+	ret = fi_eq_read(r.eq, &event, &entry, sizeof(entry), 0);
+	if (ret != -FI_EAGAIN) {
+		fprintf(stderr, "initial fi_eq_read returned %zd; expected -FI_EAGAIN\n",
+			ret);
+		if (ret == (ssize_t) sizeof(entry) && entry.info)
+			fi_freeinfo(entry.info);
+		goto out;
+	}
+
+	/* Signal client that connection was accepted */
+	ft_sock_sync(sock, 2);
+
+	/* Wait for client CM to be ready */
+	ft_sock_sync(sock, 3);
+
+	/* Close the PEP while the unpublished handle still references it. */
+	ret = fi_close(&r.pep->fid);
+	r.pep = NULL;
+	if (ret) {
+		report("fi_close(pep)", (int)ret);
+		goto out;
+	}
+
+	/* The next progress call must not touch the discarded connection handle.
+	 * Call fi_eq_read multiple times to ensure we trigger the provider's
+	 * progress path that accesses the freed handle. */
+	for (int i = 0; i < 10; i++) {
+		ret = fi_eq_read(r.eq, &event, &entry, sizeof(entry), 0);
+		if (ret == (ssize_t) sizeof(entry) && entry.info)
+			fi_freeinfo(entry.info);
+		if (ret != -FI_EAGAIN && ret != (ssize_t) sizeof(entry))
+			break;
+		usleep(1000);  /* Small delay between calls */
+	}
+
+	if (ret == -FI_EAGAIN || ret == (ssize_t) sizeof(entry))
+		ret = 0;
+
+	if (ret == 0)
+		printf("Test PASSED\n");
+
+	/* Signal client that server is done */
+	ft_sock_sync(sock, 4);
+
+out:
+	close_resources(&r);
+	return ret < 0 ? (int) ret : 0;
+}
+
+static void usage(const char *prog_name)
+{
+	fprintf(stderr, "Usage: %s [OPTIONS] [server_address]\n", prog_name);
+	fprintf(stderr, "\n");
+	fprintf(stderr, "Options:\n");
+	fprintf(stderr, "  -p <provider>  Provider name (default: tcp)\n");
+	fprintf(stderr, "  -s <address>   Source/server address (default: 127.0.0.1)\n");
+	fprintf(stderr, "  -P <port>      Port/service (default: %s)\n", DEFAULT_PORT);
+	fprintf(stderr, "  -h             Display this help\n");
+	fprintf(stderr, "\n");
+	fprintf(stderr, "Server mode (no server_address): Listen for connections\n");
+	fprintf(stderr, "Client mode (with server_address): Connect to server\n");
+}
+
+int main(int argc, char **argv)
+{
+	const char *provider = "tcp";
+	const char *node = "127.0.0.1";
+	const char *service = DEFAULT_PORT;
+	const char *oob_port = "47592";  /* OOB port for client/server sync */
+	int op, ret;
+
+	while ((op = getopt(argc, argv, "p:s:P:h")) != -1) {
+		switch (op) {
+		case 'p':
+			provider = optarg;
+			break;
+		case 's':
+			node = optarg;
+			break;
+		case 'P':
+			service = optarg;
+			break;
+		case 'h':
+		default:
+			usage(argv[0]);
+			return EXIT_FAILURE;
+		}
+	}
+
+	/* If a positional argument is provided, it's the server address (client mode) */
+	if (optind < argc) {
+		/* Client mode */
+		node = argv[optind];
+		ret = ft_sock_connect((char *)node, (char *)oob_port);
+		if (ret) {
+			fprintf(stderr, "Failed to connect to OOB server %s:%s\n",
+				node, oob_port);
+			return EXIT_FAILURE;
+		}
+		ret = run_client(node, service, provider);
+		ft_sock_shutdown(sock);
+	} else {
+		/* Server mode */
+		ret = ft_sock_listen((char *)node, (char *)oob_port);
+		if (ret) {
+			fprintf(stderr, "Failed to start OOB server on %s:%s\n",
+				node, oob_port);
+			return EXIT_FAILURE;
+		}
+
+		/* Accept client connection on OOB socket */
+		sock = accept(listen_sock, NULL, 0);
+		if (sock < 0) {
+			perror("accept");
+			return EXIT_FAILURE;
+		}
+
+		ret = run_server(node, service, provider);
+		ft_sock_shutdown(sock);
+	}
+
+	return ret ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -152,6 +152,7 @@ struct xnet_port_range {
 struct xnet_conn_handle {
 	struct fid		fid;
 	struct xnet_pep		*pep;
+	struct xnet_progress	*progress;
 	SOCKET			sock;
 	bool			endian_match;
 	struct ofi_sockapi	*sockapi;

--- a/prov/tcp/src/xnet.h
+++ b/prov/tcp/src/xnet.h
@@ -157,6 +157,11 @@ struct xnet_conn_handle {
 	bool			endian_match;
 	struct ofi_sockapi	*sockapi;
 	struct ofi_sockctx	rx_sockctx;
+	/* Linked on pep->conn_list until FI_CONNREQ is written or the
+	 * handle is freed.  pep is cleared when the handle leaves that
+	 * list so later progress cannot dereference a closed PEP.
+	 */
+	struct dlist_entry	pep_entry;
 };
 
 struct xnet_pep {
@@ -166,10 +171,13 @@ struct xnet_pep {
 	SOCKET			sock;
 	enum xnet_state		state;
 	struct ofi_sockctx	pollin_sockctx;
+	/* Unpublished connection handles (TCP accept done, no FI_CONNREQ). */
+	struct dlist_entry	conn_list;
 };
 
 int xnet_listen(struct xnet_pep *pep, struct xnet_progress *progress);
 void xnet_accept_sock(struct xnet_pep *pep);
+void xnet_conn_unlink_pep(struct xnet_conn_handle *conn);
 void xnet_connect_done(struct xnet_ep *ep);
 void xnet_req_done(struct xnet_ep *ep);
 int xnet_send_cm_msg(struct xnet_ep *ep);

--- a/prov/tcp/src/xnet_cm.c
+++ b/prov/tcp/src/xnet_cm.c
@@ -382,6 +382,7 @@ void xnet_accept_sock(struct xnet_pep *pep)
 	conn->fid.fclass = FI_CLASS_CONNREQ;
 	/* TODO: We need to hold a reference on the pep to defer destruction */
 	conn->pep = pep;
+	conn->progress = pep->progress;
 	conn->sockapi = &pep->progress->sockapi;
 	ofi_sockctx_init(&conn->rx_sockctx, &conn->fid);
 

--- a/prov/tcp/src/xnet_cm.c
+++ b/prov/tcp/src/xnet_cm.c
@@ -369,6 +369,9 @@ void xnet_accept_sock(struct xnet_pep *pep)
 	FI_DBG(&xnet_prov, FI_LOG_EP_CTRL, "accepting socket\n");
 	assert(xnet_progress_locked(pep->progress));
 
+	if (pep->state != XNET_LISTENING)
+		return;
+
 	conn = calloc(1, sizeof(*conn));
 	if (!conn) {
 		FI_WARN(&xnet_prov, FI_LOG_EP_CTRL,

--- a/prov/tcp/src/xnet_cm.c
+++ b/prov/tcp/src/xnet_cm.c
@@ -38,6 +38,19 @@
 #include <sys/types.h>
 #include <ofi_util.h>
 
+/* Remove the handle from pep->conn_list and drop the PEP pointer so later
+ * progress cannot dereference a closed PEP.  Safe if the handle was never
+ * inserted (pep_entry is then a self-linked empty node).
+ */
+void xnet_conn_unlink_pep(struct xnet_conn_handle *conn)
+{
+	if (!conn->pep)
+		return;
+
+	dlist_remove_init(&conn->pep_entry);
+	conn->pep = NULL;
+}
+
 /* The underlying socket has the POLLIN event set.  The entire
  * CM message should be readable, as it fits within a single MTU
  * and is the first data transferred over the socket.
@@ -251,12 +264,18 @@ void xnet_handle_conn(struct xnet_conn_handle *conn, bool error)
 {
 	struct xnet_cm_msg msg;
 	struct xnet_cm_entry cm_entry;
+	struct xnet_pep *pep;
 	socklen_t len;
 	uint16_t datalen;
 	int ret;
 
 	FI_DBG(&xnet_prov, FI_LOG_EP_CTRL, "Receiving connect request\n");
-	assert(xnet_progress_locked(conn->pep->progress));
+
+	pep = conn->pep;
+	if (!pep || pep->state != XNET_LISTENING)
+		return;
+
+	assert(xnet_progress_locked(pep->progress));
 
 	if (error) {
 		FI_WARN(&xnet_prov, FI_LOG_EP_CTRL, "socket error\n");
@@ -272,12 +291,12 @@ void xnet_handle_conn(struct xnet_conn_handle *conn, bool error)
 		goto close;
 	}
 
-	cm_entry.fid = &conn->pep->util_pep.pep_fid.fid;
-	cm_entry.info = fi_dupinfo(conn->pep->info);
+	cm_entry.fid = &pep->util_pep.pep_fid.fid;
+	cm_entry.info = fi_dupinfo(pep->info);
 	if (!cm_entry.info)
 		goto close;
 
-	cm_entry.info->dest_addrlen = conn->pep->info->src_addrlen;
+	cm_entry.info->dest_addrlen = pep->info->src_addrlen;
 	len = (socklen_t) cm_entry.info->dest_addrlen;
 
 	free(cm_entry.info->dest_addr);
@@ -299,7 +318,7 @@ void xnet_handle_conn(struct xnet_conn_handle *conn, bool error)
 	if (datalen)
 		memcpy(cm_entry.data, msg.data, datalen);
 
-	ret = xnet_eq_write(conn->pep->util_pep.eq,
+	ret = xnet_eq_write(pep->util_pep.eq,
 			    FI_CONNREQ, &cm_entry,
 			    sizeof(struct fi_eq_cm_entry) + datalen, 0);
 	if (ret < 0) {
@@ -307,12 +326,17 @@ void xnet_handle_conn(struct xnet_conn_handle *conn, bool error)
 		goto freeinfo;
 	}
 
+	/* App now owns accept/reject via conn->sock.  Unlink so pep
+	 * close will not abort this handle or free pep under it.
+	 */
+	xnet_conn_unlink_pep(conn);
 	return;
 
 freeinfo:
 	fi_freeinfo(cm_entry.info);
 close:
 	ofi_close_socket(conn->sock);
+	xnet_conn_unlink_pep(conn);
 	free(conn);
 }
 
@@ -380,18 +404,24 @@ void xnet_accept_sock(struct xnet_pep *pep)
 	}
 
 	conn->fid.fclass = FI_CLASS_CONNREQ;
-	/* TODO: We need to hold a reference on the pep to defer destruction */
 	conn->pep = pep;
 	conn->progress = pep->progress;
 	conn->sockapi = &pep->progress->sockapi;
 	ofi_sockctx_init(&conn->rx_sockctx, &conn->fid);
+	dlist_init(&conn->pep_entry);
 
 	ret = conn->sockapi->accept(conn->sockapi, pep->sock, NULL, 0,
 				    &conn->rx_sockctx);
 	if (ret < 0) {
 		conn->sock = INVALID_SOCKET;
-		if (ret == -OFI_EINPROGRESS_URING)
+		if (ret == -OFI_EINPROGRESS_URING) {
+			/* Accept is in-flight.  Track the handle so
+			 * pep close can cancel it.
+			 */
+			dlist_insert_tail(&conn->pep_entry,
+					  &pep->conn_list);
 			return;
+		}
 
 		/* FIXME: handle EAGAIN */
 
@@ -407,10 +437,12 @@ void xnet_accept_sock(struct xnet_pep *pep)
 	if (ret)
 		goto close;
 
+	dlist_insert_tail(&conn->pep_entry, &pep->conn_list);
 	return;
 
 close:
 	ofi_close_socket(conn->sock);
 free:
+	xnet_conn_unlink_pep(conn);
 	free(conn);
 }

--- a/prov/tcp/src/xnet_ep.c
+++ b/prov/tcp/src/xnet_ep.c
@@ -392,6 +392,7 @@ xnet_ep_accept(struct fid_ep *ep_fid, const void *param, size_t paramlen)
 	}
 
 	/* Only free conn on success; on failure, app may try to reject */
+	xnet_conn_unlink_pep(conn);
 	free(conn);
 	return 0;
 }

--- a/prov/tcp/src/xnet_pep.c
+++ b/prov/tcp/src/xnet_pep.c
@@ -41,16 +41,56 @@
 #include <errno.h>
 
 
+/* Abort unpublished connection handles before freeing the PEP.  Handles
+ * that already published FI_CONNREQ were unlinked from conn_list and are
+ * owned by the app (accept/reject).
+ */
+static void xnet_pep_abort_conns(struct xnet_pep *pep)
+{
+	struct xnet_conn_handle *conn;
+	struct dlist_entry *tmp;
+	struct dlist_entry abort_list;
+
+	/* Splice first.  uring cancel can progress other CQEs, which
+	 * must not walk or unlink entries while we iterate.
+	 */
+	dlist_init(&abort_list);
+	dlist_foreach_container_safe(&pep->conn_list, struct xnet_conn_handle,
+				     conn, pep_entry, tmp) {
+		if (!xnet_io_uring && conn->sock != INVALID_SOCKET)
+			xnet_halt_sock(pep->progress, conn->sock);
+		dlist_remove_init(&conn->pep_entry);
+		dlist_insert_tail(&conn->pep_entry, &abort_list);
+	}
+
+	/* Cancel first so a CQE for one handle cannot fire after
+	 * another handle on this list has already been freed.
+	 */
+	dlist_foreach_container_safe(&abort_list, struct xnet_conn_handle,
+				     conn, pep_entry, tmp) {
+		if (xnet_io_uring && conn->rx_sockctx.uring_sqe_inuse) {
+			(void) xnet_uring_cancel(pep->progress,
+						 &pep->progress->rx_uring,
+						 &conn->rx_sockctx,
+						 &conn->fid);
+		}
+	}
+
+	dlist_foreach_container_safe(&abort_list, struct xnet_conn_handle,
+				     conn, pep_entry, tmp) {
+		dlist_remove_init(&conn->pep_entry);
+		ofi_close_socket(conn->sock);
+		xnet_conn_unlink_pep(conn);
+		free(conn);
+	}
+}
+
 static int xnet_pep_close(struct fid *fid)
 {
 	struct xnet_pep *pep;
 	int ret;
 
 	pep = container_of(fid, struct xnet_pep, util_pep.pep_fid.fid);
-	/* TODO: We need to abort any outstanding active connection requests.
-	 * The xnet_conn_handle points back to the pep and will dereference
-	 * the freed memory if we continue.
-	 */
 
 	if (pep->state == XNET_LISTENING) {
 		ofi_genlock_lock(&pep->progress->ep_lock);
@@ -64,9 +104,14 @@ static int xnet_pep_close(struct fid *fid)
 			xnet_halt_sock(pep->progress, pep->sock);
 			ret = 0;
 		}
-		ofi_genlock_unlock(&pep->progress->ep_lock);
-		if (ret)
+
+		if (ret) {
+			ofi_genlock_unlock(&pep->progress->ep_lock);
 			return ret;
+		} else {
+			xnet_pep_abort_conns(pep);
+			ofi_genlock_unlock(&pep->progress->ep_lock);
+		}
 	}
 
 	ofi_close_socket(pep->sock);

--- a/prov/tcp/src/xnet_pep.c
+++ b/prov/tcp/src/xnet_pep.c
@@ -314,6 +314,7 @@ static int xnet_pep_reject(struct fid_pep *pep, fid_t fid_handle,
 		return ret;
 
 free:
+	xnet_conn_unlink_pep(conn);
 	free(conn);
 	return FI_SUCCESS;
 }
@@ -394,6 +395,7 @@ int xnet_passive_ep(struct fid_fabric *fabric, struct fi_info *info,
 
 	pep->sock = INVALID_SOCKET;
 	pep->state = XNET_IDLE;
+	dlist_init(&pep->conn_list);
 
 	if (info->src_addr) {
 		ret = xnet_pep_sock_create(pep);

--- a/prov/tcp/src/xnet_pep.c
+++ b/prov/tcp/src/xnet_pep.c
@@ -54,6 +54,7 @@ static int xnet_pep_close(struct fid *fid)
 
 	if (pep->state == XNET_LISTENING) {
 		ofi_genlock_lock(&pep->progress->ep_lock);
+		pep->state = XNET_IDLE;
 		if (xnet_io_uring) {
 			ret = xnet_uring_cancel(pep->progress,
 						&pep->progress->rx_uring,

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1491,10 +1491,10 @@ static void xnet_run_ep(struct xnet_ep *ep, bool pin, bool pout, bool perr)
 static void
 xnet_run_conn(struct xnet_conn_handle *conn, bool pin, bool pout, bool perr)
 {
-	assert(xnet_progress_locked(conn->pep->progress));
+	assert(xnet_progress_locked(conn->progress));
 
 	/* Don't monitor the socket until the user calls fi_accept */
-	xnet_halt_sock(conn->pep->progress, conn->sock);
+	xnet_halt_sock(conn->progress, conn->sock);
 	xnet_handle_conn(conn, perr);
 }
 

--- a/prov/tcp/src/xnet_progress.c
+++ b/prov/tcp/src/xnet_progress.c
@@ -1326,11 +1326,19 @@ static void xnet_uring_run_ep(struct xnet_ep *ep, struct ofi_sockctx *sockctx,
 
 static void xnet_uring_run_conn(struct xnet_conn_handle *conn, int res)
 {
-	if (res >= 0) {
+	if (res >= 0)
 		conn->sock = res;
+
+	/* PEP close changes the state before canceling the accept. */
+	if (!conn->pep || conn->pep->state != XNET_LISTENING)
+		return;
+
+	if (res >= 0) {
 		xnet_handle_conn(conn, false);
 	} else {
 		FI_WARN(&xnet_prov, FI_LOG_EP_CTRL, "accept socket error\n");
+		ofi_close_socket(conn->sock);
+		xnet_conn_unlink_pep(conn);
 		free(conn);
 	}
 }


### PR DESCRIPTION
## Summary

Fix a use-after-free in the xnet provider when a passive endpoint (PEP) is   
closed while an accepted connection has not yet published its `FI_CONNREQ`   
event.                                                                       
                                                                             
The connection handle retains references to the PEP while it is being        
processed by the progress engine. Closing the PEP without first stopping and 
releasing those unpublished handles allowed a later progress event to        
dereference freed PEP memory. The fix makes the PEP and connection-handle    
lifecycle explicit and adds a regression test covering the failure scenario. 

 ## Correctness and ownership                                                    
                                                                                 
 Published connection requests are removed from the PEP's unpublished-handle     
 list and remain owned by the application until `fi_accept` or `fi_reject`.      
 Unpublished handles remain attached to the PEP until cancellation and cleanup   
 are complete. This prevents both stale PEP references and double cleanup when   
 an asynchronous completion arrives during PEP close.                            
                                                                                 
 The change does not alter the behavior of already-published connection          
 requests or the public libfabric API.                                           