### PR TITLE
man: Add more details to verbs NIC affinity setting parameters

### DIFF
--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -211,13 +211,21 @@ The verbs provider checks for the following environment variables.
   corresponding kernel driver. (default: yes)
 
 *FI_VERBS_NIC_AFFINITY_POLICY*
-: NIC affinity policy for ordering NICs in fi_getinfo results. (default: none)
+: NIC affinity policy for ordering NICs in fi_getinfo results. Supported
+  options are "manual", "auto" or "none". When set to "manual", NIC affinity
+  mapping is specified in a configuration file (see FI_VERBS_NIC_AFFINITY_CONFIG).
+  When set to "auto" NIC affinity mapping is determined automatically based on
+  the information provided by `hwloc`. In either case, the mapping key is
+  supplied via FI_VERBS_AFFINITY_DEVICE. (default: none)
 
 *FI_VERBS_AFFINITY_DEVICE*
 : PCI address of device for NIC affinity.
 
 *FI_VERBS_NIC_AFFINITY_CONFIG*
-: Path to NIC affinity configuration file for 'manual' policy.
+: Path to NIC affinity configuration file for the "manual" policy. The
+  configuration file can have any number of lines. Each line consists of a
+  PCIe address followed by a NIC name, seperated by a single space. Empty
+  lines and lines starting with "#" are ignored.
 
 ### Variables specific to MSG endpoints
 


### PR DESCRIPTION
- Describe valid values for FI_VERBS_NIC_AFFINITY_POLICY
- Describe the format of NIC affinity configuration file