### PR TITLE
prov/verbs: Add a knob to turn on/off flow control

### DIFF
--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -189,6 +189,10 @@ The verbs provider checks for the following environment variables.
 *FI_VERBS_MIN_RNR_TIMER*
 : Set min_rnr_timer QP attribute (0 - 31) (default: 12)
 
+*FI_VERBS_USE_ODP*
+: Enable on-demand paging memory registrations, if supported.  This is
+  currently required to register DAX file system mmapped memory. (default: no)
+
 *FI_VERBS_CQREAD_BUNCH_SIZE*
 : The number of entries to be read from the verbs completion queue
   at a time (default: 8).
@@ -235,7 +239,7 @@ The verbs provider checks for the following environment variables.
   used to resolve IP-addresses to provider specific addresses (default: 1,
   if "OMPI_COMM_WORLD_RANK" and "PMI_RANK" environment variables aren't defined)
 
-*FI_VERBS_NAME_SERVER_PORT*
+*FI_VERBS_DGRAM_NAME_SERVER_PORT*
 : The port on which Name Server thread listens incoming connections and
   requests (default: 5678)
 

--- a/man/fi_verbs.7.md
+++ b/man/fi_verbs.7.md
@@ -219,6 +219,9 @@ The verbs provider checks for the following environment variables.
 *FI_VERBS_NIC_AFFINITY_CONFIG*
 : Path to NIC affinity configuration file for 'manual' policy.
 
+*FI_VERBS_USE_FLOW_CTRL*
+: Enable credit based flow control. Requires RxM to work. (default: yes)
+
 ### Variables specific to MSG endpoints
 
 *FI_VERBS_IFACE*

--- a/prov/verbs/src/verbs_domain.c
+++ b/prov/verbs/src/verbs_domain.c
@@ -54,7 +54,7 @@ static bool vrb_flow_ctrl_available(struct fid_ep *ep_fid)
 	struct vrb_ep *ep = container_of(ep_fid, struct vrb_ep, util_ep.ep_fid);
 
 	// only enable if we are not using SRQ
-	return (!ep->srx && ep->util_ep.type == FI_EP_MSG);
+	return (!ep->srx && ep->util_ep.type == FI_EP_MSG && vrb_gl_data.use_flow_ctrl);
 }
 
 static int vrb_enable_ep_flow_ctrl(struct fid_ep *ep_fid, uint64_t threshold)

--- a/prov/verbs/src/verbs_init.c
+++ b/prov/verbs/src/verbs_init.c
@@ -70,6 +70,7 @@ struct vrb_gl_data vrb_gl_data = {
 	.nic_affinity_policy	= "none",
 	.affinity_device	= NULL,
 	.nic_affinity_config	= NULL,
+	.use_flow_ctrl		= 1,
 };
 
 struct vrb_dev_preset {
@@ -789,6 +790,13 @@ static int vrb_read_params(void)
 			      "Path to NIC affinity configuration file for 'manual' policy. ",
 			      &vrb_gl_data.nic_affinity_config)) {
 		VRB_WARN(FI_LOG_CORE, "Invalid value of nic_affinity_config\n");
+		return -FI_EINVAL;
+	}
+
+	if (vrb_get_param_bool("use_flow_ctrl", "Enable credit based flow control. "
+			       "Requires RxM to work. Yes by default.",
+			       &vrb_gl_data.use_flow_ctrl)) {
+		VRB_WARN(FI_LOG_CORE, "Invalid value of use_flow_ctrl\n");
 		return -FI_EINVAL;
 	}
 

--- a/prov/verbs/src/verbs_ofi.h
+++ b/prov/verbs/src/verbs_ofi.h
@@ -218,6 +218,8 @@ extern struct vrb_gl_data {
 	char	*nic_affinity_policy;
 	char	*affinity_device;
 	char	*nic_affinity_config;
+
+	int	use_flow_ctrl;
 } vrb_gl_data;
 
 struct verbs_addr {


### PR DESCRIPTION
The credit based flow control can greatly improve performance over heavily congested network, especially for isome RoCE NICs, by reducing/ eliminating RNRs. However, it may also negatively impact performance in other cases like MPI biband tests.

Add a new runtime parameter FI_VERBS_USE_FLOW_CTRL to allow turning on/off the feature based on the needs. The default setting is on.