### PR TITLE
prov/shm: Fix srx_context data race exposed by EFA multi-EP stress test

### DIFF
--- a/fabtests/prov/efa/src/multi_ep_stress.c
+++ b/fabtests/prov/efa/src/multi_ep_stress.c
@@ -218,6 +218,7 @@ struct worker_context {
 	struct ep_message_queue *control_queue;
 	struct fid_ep *ep;
 	struct fid_cq *cq;
+	struct fid_eq *eq;
 	struct fid_av *av;
 	struct context_pool pool;
 	uint16_t worker_id;
@@ -284,6 +285,11 @@ static void cleanup_endpoint(struct worker_context *ctx)
 		assert(ret == FI_SUCCESS);
 		ctx->ep = NULL;
 	}
+	if (ctx->eq) {
+		ret = fi_close(&ctx->eq->fid);
+		assert(ret == FI_SUCCESS);
+		ctx->eq = NULL;
+	}
 	if (!topts.shared_av && ctx->av) {
 		ret = fi_close(&ctx->av->fid);
 		assert(ret == FI_SUCCESS);
@@ -337,6 +343,12 @@ static int setup_endpoint(struct worker_context *ctx, uint64_t total_ops)
 		}
 	}
 
+	ret = fi_eq_open(fabric, &eq_attr, &ctx->eq, NULL);
+	if (ret) {
+		FT_PRINTERR("fi_eq_open", ret);
+		goto error;
+	}
+
 	ret = fi_ep_bind(ctx->ep, &ctx->cq->fid, FI_SEND | FI_RECV);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind", ret);
@@ -349,7 +361,7 @@ static int setup_endpoint(struct worker_context *ctx, uint64_t total_ops)
 		goto error;
 	}
 
-	ret = fi_ep_bind(ctx->ep, &eq->fid, 0);
+	ret = fi_ep_bind(ctx->ep, &ctx->eq->fid, 0);
 	if (ret) {
 		FT_PRINTERR("fi_ep_bind(eq)", ret);
 		goto error;
@@ -370,6 +382,7 @@ error:
 /**
  * wait_for_comp - Poll completion queue until expected completions arrive
  * @cq: Completion queue to poll
+ * @eq: Event queue associated with the endpoint
  * @num_completions: Number of completions to wait for
  *
  * Polls the specified completion queue until the requested number of
@@ -380,7 +393,7 @@ error:
  * Returns: Number of completions successfully received (may be less than
  *          requested if timeout expires or error occurs)
  */
-static int wait_for_comp(struct fid_cq *cq, int num_completions)
+static int wait_for_comp(struct fid_cq *cq, struct fid_eq *eq, int num_completions)
 {
 	static pthread_mutex_t shared_cq_lock = PTHREAD_MUTEX_INITIALIZER;
 	struct fi_cq_data_entry comp;
@@ -668,7 +681,7 @@ static void *run_sender_worker(void *arg)
 			if (ret == 0) {
 				break;
 			} else if (ret == -FI_EAGAIN) {
-				comp_ret = wait_for_comp(ctx->cq, 1);
+				comp_ret = wait_for_comp(ctx->cq, ctx->eq, 1);
 				if (comp_ret < 0) {
 					fprintf(stderr,
 						"Sender %d: peer endpoint closed, exiting now\n",
@@ -709,7 +722,7 @@ static void *run_sender_worker(void *arg)
 					"completions\n",
 					ctx->worker_id, cycle);
 				uint64_t ops_pending =  ops_total_in_this_cycle - ops_completed_in_this_cycle;
-				comp_ret = wait_for_comp(ctx->cq, ops_pending);
+				comp_ret = wait_for_comp(ctx->cq, ctx->eq, ops_pending);
 				if (comp_ret < 0) {
 					fprintf(stderr,
 						"Sender %d: peer endpoint closed, exiting now\n",
@@ -900,7 +913,7 @@ static void *run_receiver_worker(void *arg)
 				printf("Receiver %u EP cycle %d: Waiting for "
 					"completions\n",
 					ctx->worker_id, cycle);
-				ops_completed += wait_for_comp(ctx->cq, ops_total_in_this_cycle);
+				ops_completed += wait_for_comp(ctx->cq, ctx->eq, ops_total_in_this_cycle);
 			} else {
 				printf("Receiver %u EP cycle %d: Not waiting for "
 					"completions\n",

--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -17,7 +17,7 @@ import pytest
 
 
 perf_progress_model_cli = "--data-progress manual --control-progress unified"
-SERVER_RESTART_DELAY_MS = 10_1000
+SERVER_RESTART_DELAY_MS = 10_000
 CLIENT_RETRY_INTERVAL_MS = 1_000
 
 # Shared non-interactive SSH command.

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -209,7 +209,11 @@ struct smr_domain {
 	struct util_domain	util_domain;
 	bool			fast_rma;
 	struct ofi_mr_cache	*ipc_cache;
+};
+
+struct smr_peer_srx {
 	struct fid_ep		rx_ep;
+	struct smr_domain	*domain;
 	struct fid_peer_srx	*srx;
 };
 

--- a/prov/shm/src/smr_domain.c
+++ b/prov/shm/src/smr_domain.c
@@ -36,10 +36,11 @@ extern struct fi_ops_srx_peer smr_srx_peer_ops;
 
 static int smr_srx_close(struct fid *fid)
 {
-	struct smr_domain *domain = container_of(fid, struct smr_domain,
-						 rx_ep.fid);
+	struct smr_peer_srx *peer_srx = container_of(fid, struct smr_peer_srx,
+						rx_ep.fid);
 
-	ofi_atomic_dec32(&domain->util_domain.ref);
+	ofi_atomic_dec32(&peer_srx->domain->util_domain.ref);
+	free(peer_srx);
 
 	return FI_SUCCESS;
 }
@@ -82,19 +83,24 @@ static int smr_srx_context(struct fid_domain *domain, struct fi_rx_attr *attr,
 			   struct fid_ep **rx_ep, void *context)
 {
 	struct smr_domain *smr_domain;
+	struct smr_peer_srx *peer_srx;
 
 	smr_domain = container_of(domain, struct smr_domain,
 				  util_domain.domain_fid);
 
 	if (attr->op_flags & FI_PEER) {
-		smr_domain->srx = ((struct fi_peer_srx_context *)
-					(context))->srx;
-		smr_domain->srx->peer_ops = &smr_srx_peer_ops;
-		smr_domain->rx_ep.msg = &smr_srx_msg_ops;
-		smr_domain->rx_ep.tagged = &smr_srx_tagged_ops;
-		smr_domain->rx_ep.fid.ops = &smr_srx_fi_ops;
-		smr_domain->rx_ep.fid.fclass = FI_CLASS_SRX_CTX;
-		*rx_ep = &smr_domain->rx_ep;
+		peer_srx = calloc(1, sizeof(*peer_srx));
+		if (!peer_srx)
+			return -FI_ENOMEM;
+
+		peer_srx->domain = smr_domain;
+		peer_srx->srx = ((struct fi_peer_srx_context *) context)->srx;
+		peer_srx->srx->peer_ops = &smr_srx_peer_ops;
+		peer_srx->rx_ep.msg = &smr_srx_msg_ops;
+		peer_srx->rx_ep.tagged = &smr_srx_tagged_ops;
+		peer_srx->rx_ep.fid.ops = &smr_srx_fi_ops;
+		peer_srx->rx_ep.fid.fclass = FI_CLASS_SRX_CTX;
+		*rx_ep = &peer_srx->rx_ep;
 		ofi_atomic_inc32(&smr_domain->util_domain.ref);
 		return FI_SUCCESS;
 	}

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -781,7 +781,7 @@ static int smr_ep_bind(struct fid *ep_fid, struct fid *bfid, uint64_t flags)
 				struct util_cntr, cntr_fid.fid), flags);
 		break;
 	case FI_CLASS_SRX_CTX:
-		ep->srx = container_of(bfid, struct smr_domain, rx_ep.fid)->srx;
+		ep->srx = container_of(bfid, struct smr_peer_srx, rx_ep.fid)->srx;
 		break;
 	default:
 		FI_WARN(&smr_prov, FI_LOG_EP_CTRL, "invalid fid class\n");


### PR DESCRIPTION
- **fabtest/efa: Give each worker EP its own EQ**
- **fabtests/pytest: Fix server restart delay 101sec -> 10sec**
- **prov/shm: Fix data race in smr_srx_context()**
