### PR TITLE
fabtests/pytest: derive server_id/client_id from request

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -331,7 +331,7 @@ class UnitTest:
             failing_warn_msgs = [failing_warn_msgs]
 
         if failing_warn_msgs:
-            self._cmdline_args = copy.deepcopy(cmdline_args)
+            self._cmdline_args = copy.copy(cmdline_args)
             self._cmdline_args.append_environ("FI_LOG_LEVEL=warn")
         else:
             self._cmdline_args = cmdline_args
@@ -811,7 +811,7 @@ class MultinodeTest(ClientServerTest):
         self._server_base_command = cmdline_args.populate_command(server_base_command, "server", self._timeout)
         self._client_base_command_list = []
         for client_hostname in client_hostname_list:
-            cmdline_args_copy = copy.deepcopy(cmdline_args)
+            cmdline_args_copy = copy.copy(cmdline_args)
             cmdline_args_copy.client_id = client_hostname
             self._client_base_command_list.append(cmdline_args_copy.populate_command(client_base_command, "client", self._timeout))
         self._run_client_asynchronously = run_client_asynchronously

--- a/fabtests/pytest/conftest.py
+++ b/fabtests/pytest/conftest.py
@@ -286,7 +286,7 @@ class CmdlineArgs:
 
         return command
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def cmdline_args(request):
     return CmdlineArgs(request)
 

--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -374,7 +374,7 @@ def support_sread(cmdline_args):
 
 
 @pytest.fixture(scope="session")
-def num_domains(cmdline_args):
+def num_domains(request):
     """
     Number of EFA domains (NICs) a test can spread endpoints across.
 
@@ -383,10 +383,11 @@ def num_domains(cmdline_args):
     as far as the host with fewer devices.
 
     Session-scoped so the device lookup runs once per xdist worker instead of
-    once per test; cmdline_args is session-scoped too, so it can be used here.
+    once per test. The server/client ids are read from the session scoped request
+    fixture
     """
-    server_id = cmdline_args.server_id
-    client_id = cmdline_args.client_id
+    server_id = request.config.getoption("--server-id")
+    client_id = request.config.getoption("--client-id")
 
     counts = [len(get_efa_device_names(host_id))
               for host_id in dict.fromkeys(filter(None, (server_id, client_id)))]

--- a/fabtests/pytest/efa/test_dgram.py
+++ b/fabtests/pytest/efa/test_dgram.py
@@ -15,7 +15,7 @@ def test_dgram_pingpong(cmdline_args, iteration_type, message_sizes):
     # dgram is unreliable, therefore it is expected that receiver does not always get all the messages
     # when that happened, the test will return -FI_ENODATA
     # Disable the strict mode to mark such return code as pass
-    cmdline_args_copy = copy.deepcopy(cmdline_args)
+    cmdline_args_copy = copy.copy(cmdline_args)
     cmdline_args_copy.strict_fabtests_mode = False
 
     client_tx_bytes_before_test = efa_retrieve_hw_counter_value(cmdline_args.client_id, "tx_bytes")

--- a/fabtests/pytest/efa/test_efa_device_selection.py
+++ b/fabtests/pytest/efa/test_efa_device_selection.py
@@ -48,7 +48,7 @@ def test_efa_device_selection(cmdline_args, fabric, selection_approach):
             server_domain_name = server_device_name + "-" + suffix
             client_domain_name = client_device_name + "-" + suffix
 
-            cmdline_args_copy = copy.deepcopy(cmdline_args)
+            cmdline_args_copy = copy.copy(cmdline_args)
             if selection_approach == "domain name":
                 cmdline_args_copy.additional_server_arguments = "-d " + server_domain_name
                 cmdline_args_copy.additional_client_arguments = "-d " + client_domain_name

--- a/fabtests/pytest/efa/test_efa_protocol_selection.py
+++ b/fabtests/pytest/efa/test_efa_protocol_selection.py
@@ -36,7 +36,7 @@ def test_transfer_with_read_protocol_cuda(cmdline_args, fabtest_name, cntrl_env_
 
     message_size = 1024
 
-    cmdline_args_copy = copy.deepcopy(cmdline_args)
+    cmdline_args_copy = copy.copy(cmdline_args)
     cmdline_args_copy.append_environ("FI_EFA_USE_DEVICE_RDMA=1")
     cmdline_args_copy.append_environ(f"{cntrl_env_var}=1000")
     cmdline_args_copy.append_environ("FI_EFA_RUNT_SIZE=0")

--- a/fabtests/pytest/efa/test_fork_support.py
+++ b/fabtests/pytest/efa/test_fork_support.py
@@ -7,7 +7,7 @@ import pytest
 def test_fork_support(cmdline_args, completion_semantic, environment_variable, fabric):
     from common import ClientServerTest
     import copy
-    cmdline_args_copy = copy.deepcopy(cmdline_args)
+    cmdline_args_copy = copy.copy(cmdline_args)
 
     cmdline_args_copy.append_environ("{}=1".format(environment_variable))
     test = ClientServerTest(cmdline_args_copy, "fi_rdm_bw -K",

--- a/fabtests/pytest/efa/test_mr.py
+++ b/fabtests/pytest/efa/test_mr.py
@@ -21,7 +21,7 @@ def test_mr_hmem(cmdline_args, hmem_type, fabric):
     if hmem_type == "neuron" and not has_neuron(cmdline_args.server_id):
         pytest.skip("no neuron device")
 
-    cmdline_args_copy = copy.deepcopy(cmdline_args)
+    cmdline_args_copy = copy.copy(cmdline_args)
 
     test_command = f"fi_mr_test -D {hmem_type} -f {fabric}"
 
@@ -47,7 +47,7 @@ def test_efa_mr_hmem(cmdline_args, hmem_type, fabric):
     if not cmdline_args.do_dmabuf_reg_for_hmem:
         pytest.skip("This test tests neuron get_dmabuf_fd_vX and needs dmabuf to be enabled and working to test these apis")
 
-    cmdline_args_copy = copy.deepcopy(cmdline_args)
+    cmdline_args_copy = copy.copy(cmdline_args)
 
     test_command = f"fi_efa_mr_test -D neuron -f {fabric}"
 

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -115,7 +115,7 @@ def test_rdm_tagged_bw_no_inject_range(cmdline_args, completion_semantic, messag
 @pytest.mark.parametrize("env_vars", [["FI_EFA_TX_SIZE=64"], ["FI_EFA_RX_SIZE=64"], ["FI_EFA_TX_SIZE=64", "FI_EFA_RX_SIZE=64"], ["FI_EFA_TX_SIZE=43", "FI_EFA_RX_SIZE=51"]])
 @pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_tagged_bw_small_tx_rx(cmdline_args, completion_semantic, memory_type, completion_type, env_vars):
-    cmdline_args_copy = copy.deepcopy(cmdline_args)
+    cmdline_args_copy = copy.copy(cmdline_args)
     for env_var in env_vars:
         cmdline_args_copy.append_environ(env_var)
     # Use a window size larger than tx/rx size
@@ -126,7 +126,7 @@ def test_rdm_tagged_bw_small_tx_rx(cmdline_args, completion_semantic, memory_typ
 @pytest.mark.functional
 @pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_tagged_bw_small_recv_window(cmdline_args, completion_semantic, memory_type, completion_type):
-    cmdline_args_copy = copy.deepcopy(cmdline_args)
+    cmdline_args_copy = copy.copy(cmdline_args)
     cmdline_args_copy.append_environ("FI_EFA_RECVWIN_SIZE=1")
     efa_run_client_server_test(cmdline_args_copy, "fi_rdm_tagged_bw -W 128", "short",
                                completion_semantic, memory_type, "all", completion_type=completion_type,
@@ -147,7 +147,7 @@ def test_rdm_tagged_bw_use_fi_more(cmdline_args, completion_semantic, memory_typ
 @pytest.mark.pr_ci
 @pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic, memory_type):
-    from copy import deepcopy
+    from copy import copy
 
     from common import ClientServerTest
 
@@ -157,7 +157,7 @@ def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic, memory_ty
     # the rdm_atomic test's run time has a high variance when running single c6gn instance.
     # the issue is tracked in:  https://github.com/ofiwg/libfabric/issues/7002
     # to mitigate the issue, set the maximum timeout of fi_rdm_atomic to 1800 seconds.
-    cmdline_args_copy = deepcopy(cmdline_args)
+    cmdline_args_copy = copy(cmdline_args)
     command = "fi_rdm_atomic"  + " " + perf_progress_model_cli
     test = ClientServerTest(cmdline_args_copy, "fi_rdm_atomic", iteration_type, completion_semantic,
                             memory_type=memory_type, timeout=1800, fabric="efa")
@@ -166,6 +166,8 @@ def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic, memory_ty
 @pytest.mark.pr_ci
 @pytest.mark.functional
 def test_rdm_tagged_peek(cmdline_args):
+    from copy import copy
+
     from common import ClientServerTest
 
     test = ClientServerTest(cmdline_args, "fi_rdm_tagged_peek", timeout=1800)

--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -28,7 +28,7 @@ def test_rma_bw(cmdline_args, iteration_type, rma_operation_type, rma_bw_complet
 @pytest.mark.parametrize("env_vars", [["FI_EFA_TX_SIZE=64"], ["FI_EFA_RX_SIZE=64"], ["FI_EFA_TX_SIZE=64", "FI_EFA_RX_SIZE=64"]])
 @pytest.mark.memory_type(memory_type_list_all)
 def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, rma_bw_completion_semantic, rma_bw_memory_type, env_vars, rma_fabric, message_sizes):
-    cmdline_args_copy = copy.deepcopy(cmdline_args)
+    cmdline_args_copy = copy.copy(cmdline_args)
     for env_var in env_vars:
         cmdline_args_copy.append_environ(env_var)
     # Use a window size larger than tx/rx size

--- a/fabtests/pytest/efa/test_rnr.py
+++ b/fabtests/pytest/efa/test_rnr.py
@@ -14,7 +14,7 @@ def test_rnr_read_cq_error(cmdline_args, fabric):
     # and the test will return FI_ENOSYS.
     # Disable the strict mode for this test explicitly to mark it as skipped
     # in this case.
-    cmdline_args_copy = copy.deepcopy(cmdline_args)
+    cmdline_args_copy = copy.copy(cmdline_args)
     cmdline_args_copy.strict_fabtests_mode = False
     test = ClientServerTest(cmdline_args_copy, "fi_efa_rnr_read_cq_error", fabric=fabric)
     test.run()
@@ -63,7 +63,7 @@ def test_rnr_queue_resend(cmdline_args, packet_type):
     # and the test will return FI_ENOSYS.
     # Disable the strict mode for this test explicitly to mark it as skipped
     # in this case.
-    cmdline_args_copy = copy.deepcopy(cmdline_args)
+    cmdline_args_copy = copy.copy(cmdline_args)
     cmdline_args_copy.strict_fabtests_mode = False
     test = ClientServerTest(cmdline_args_copy,
             "fi_efa_rnr_queue_resend " + packet_type_option_map[packet_type], fabric="efa")


### PR DESCRIPTION
copy.deepcopy fails on Python 3.6: it cannot copy compiled regex (re.Pattern) objects, which CmdlineArgs stores in its _exclusion_patterns list, raising "TypeError: cannot deepcopy this pattern object". deepcopy support for compiled patterns was only added in Python 3.7. Restoring function-scoped cmdline_args + copy.copy avoids the need to deepcopy.

Also need to re-implement the num_domains to derive server / client id from session scoped request fixture