### PR TITLE
prov/ucx: choose correct UCS_THREAD_MODE based on FI_THREAD mode

### DIFF
--- a/prov/ucx/src/ucx_ep.c
+++ b/prov/ucx/src/ucx_ep.c
@@ -278,7 +278,8 @@ int ucx_ep_open(struct fid_domain *domain, struct fi_info *info,
 	if (ofi_status)
 		goto free_ep;
 
-	if (ucx_descriptor.single_thread)
+	if (ucx_descriptor.single_thread
+		|| u_domain->u_domain.threading == FI_THREAD_DOMAIN)
 		worker_params.thread_mode = UCS_THREAD_MODE_SINGLE;
 	else if (info->domain_attr->threading == FI_THREAD_SAFE)
 		worker_params.thread_mode = UCS_THREAD_MODE_MULTI;


### PR DESCRIPTION
originally, when using FI_THREAD_DOMAIN, UCS_THREAD_MODE_SINGLE was selected, as this was the default.

with the fix to address issues with FI_THREAD_SAFE, it was shifted to select UCS_THREAD_MODE_SERIALIZED for FI_THREAD_DOMAIN, but this can potentially cause performance degredation for some workloads. UCS_THREAD_MODE_SINGLE should be sufficient for FI_THREAD_DOMAIN since UCS workers should be isolated to EPs within that domain.