### PR TITLE
prov/util: Require callers to hold srx lock in util_srx_close

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -1103,12 +1103,6 @@ static int efa_rdm_ep_close(struct fid *fid)
 				efa_rdm_rxe_release(rxe);
 		}
 		/*
-		* Drop srx_lock here since util_srx_close acquires it
-		* internally, so calling it while holding the lock would
-		* self-deadlock.
-		*/
-		ofi_genlock_unlock(&((struct efa_rdm_domain *) domain)->srx_lock);
-		/*
 		* util_srx_close will clean all efa_rdm_rxes that are
 		* associated with peer_rx_entries in unexp msg/tag lists.
 		* It also decrements the ref count of rx cq. So it must
@@ -1117,8 +1111,6 @@ static int efa_rdm_ep_close(struct fid *fid)
 		*/
 		util_srx_close(&efa_rdm_ep->peer_srx_ep->fid);
 		efa_rdm_ep->peer_srx_ep = NULL;
-
-		ofi_genlock_lock(&((struct efa_rdm_domain *) domain)->srx_lock);
 	}
 
 	/* We need to free the util_ep first to avoid race conditions

--- a/prov/rxm/src/rxm_ep.c
+++ b/prov/rxm/src/rxm_ep.c
@@ -177,8 +177,11 @@ free_rx_pool:
  * has not yet been called */
 static void rxm_ep_txrx_res_close(struct rxm_ep *ep)
 {
-	if (ep->srx && ep->util_ep.ep_fid.msg != &rxm_no_recv_msg_ops)
+	if (ep->srx && ep->util_ep.ep_fid.msg != &rxm_no_recv_msg_ops) {
+		ofi_genlock_lock(&ep->util_ep.lock);
 		(void) util_srx_close(&ep->srx->ep_fid.fid);
+		ofi_genlock_unlock(&ep->util_ep.lock);
+	}
 
 	if (ep->rx_pool) {
 		ofi_bufpool_destroy(ep->rx_pool);

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -639,13 +639,13 @@ static int smr_ep_close(struct fid *fid)
 		ep->srx->owner_ops->free_entry(cmd_ctx->rx_entry);
 		ofi_buf_free(cmd_ctx);
 	}
-	ofi_genlock_unlock(&ep->util_ep.lock);
 
 	if (ep->srx) {
 		/* shm is an owner provider */
 		if (ep->util_ep.ep_fid.msg != &smr_no_recv_msg_ops)
 			(void) util_srx_close(&ep->srx->ep_fid.fid);
 	}
+	ofi_genlock_unlock(&ep->util_ep.lock);
 
 	ofi_endpoint_close(&ep->util_ep);
 

--- a/prov/sm2/src/sm2_ep.c
+++ b/prov/sm2/src/sm2_ep.c
@@ -356,8 +356,11 @@ static int sm2_ep_close(struct fid *fid)
 
 	cleanup_shm_resources(ep);
 
-	if (ep->srx && ep->util_ep.ep_fid.msg != &sm2_no_recv_msg_ops)
+	if (ep->srx && ep->util_ep.ep_fid.msg != &sm2_no_recv_msg_ops) {
+		ofi_genlock_lock(&ep->util_ep.lock);
 		(void) util_srx_close(&ep->srx->fid);
+		ofi_genlock_unlock(&ep->util_ep.lock);
+	}
 
 	ofi_endpoint_close(&ep->util_ep);
 

--- a/prov/util/src/util_srx.c
+++ b/prov/util/src/util_srx.c
@@ -1009,7 +1009,7 @@ int util_srx_close(struct fid *fid)
 	if (!srx)
 		return -FI_EINVAL;
 
-	ofi_genlock_lock(srx->lock);
+	assert(ofi_genlock_held(srx->lock));
 	(void)ofi_array_iter(&srx->src_recv_queues, srx, util_cleanup_queues);
 	(void)ofi_array_iter(&srx->src_trecv_queues, srx, util_cleanup_queues);
 	ofi_array_destroy(&srx->src_recv_queues);
@@ -1072,7 +1072,6 @@ int util_srx_close(struct fid *fid)
 	ofi_atomic_dec32(&srx->cq->ref);
 	ofi_bufpool_destroy(srx->rx_pool);
 
-	ofi_genlock_unlock(srx->lock);
 	ofi_genlock_destroy(&srx->unspec_lock);
 	free(srx);
 


### PR DESCRIPTION
Previously util_srx_close acquired and released srx->lock internally. This forced a fragile contract on callers that hold the srx lock across the whole endpoint teardown: they had to drop and reacquire the lock around the call, splitting the critical section and leaving a window in which a concurrent CQ read could touch a closing endpoint.

Change util_srx_close to assert the lock is held rather than taking it, and update the owner providers (efa, rxm, shm, sm2) to hold the srx lock across the call. This lets each provider cover the full close in a single critical section and closes the race window.