### PR TITLE
prov/efa & shm: Move srx lock from domain to ep

### DIFF
--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -467,7 +467,15 @@ static int efa_base_ep_create_qp(struct efa_base_ep *base_ep,
 	assert(tx_cq->data_path_direct_enabled ==
 	       rx_cq->data_path_direct_enabled);
 	if (tx_cq->data_path_direct_enabled) {
-		ret = efa_data_path_direct_qp_initialize(base_ep->qp);
+		struct ofi_genlock *wqlock;
+		if (EFA_INFO_TYPE_IS_RDM(base_ep->info)) {
+			struct efa_rdm_ep *efa_rdm_ep = container_of(
+				base_ep, struct efa_rdm_ep, base_ep);
+			wqlock = &efa_rdm_ep->srx_lock;
+		} else {
+			wqlock = &base_ep->util_ep.lock;
+		}
+		ret = efa_data_path_direct_qp_initialize(base_ep->qp, wqlock);
 		if (ret) {
 			efa_base_ep_destruct_qp_unsafe(base_ep);
 			return ret;

--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -29,32 +29,6 @@ int efa_base_ep_bind_av(struct efa_base_ep *base_ep, struct efa_av *av)
 	return 0;
 }
 
-static inline void efa_base_ep_lock_cq(struct efa_base_ep *base_ep)
-{
-	struct efa_cq *tx_cq, *rx_cq;
-
-	tx_cq = efa_base_ep_get_tx_cq(base_ep);
-	rx_cq = efa_base_ep_get_rx_cq(base_ep);
-
-	if (rx_cq)
-		ofi_genlock_lock(&rx_cq->util_cq.ep_list_lock);
-	if (tx_cq && tx_cq != rx_cq)
-		ofi_genlock_lock(&tx_cq->util_cq.ep_list_lock);
-}
-
-static inline void efa_base_ep_unlock_cq(struct efa_base_ep *base_ep)
-{
-	struct efa_cq *tx_cq, *rx_cq;
-
-	tx_cq = efa_base_ep_get_tx_cq(base_ep);
-	rx_cq = efa_base_ep_get_rx_cq(base_ep);
-
-	if (tx_cq && tx_cq != rx_cq)
-		ofi_genlock_unlock(&tx_cq->util_cq.ep_list_lock);
-	if (rx_cq)
-		ofi_genlock_unlock(&rx_cq->util_cq.ep_list_lock);
-}
-
 int efa_base_ep_destruct_qp(struct efa_base_ep *base_ep)
 {
 	/*
@@ -66,9 +40,9 @@ int efa_base_ep_destruct_qp(struct efa_base_ep *base_ep)
 	 * Lock ordering: device lock -> CQ locks -> QP operations
 	 */
 	EFA_GENLOCK_LOCK(&base_ep->domain->device->qp_table_lock, efa_qp_table_lock_sym);
-	efa_base_ep_lock_cq(base_ep);
+	efa_cq_lock_ep_list(base_ep);
 	efa_base_ep_destruct_qp_unsafe(base_ep);
-	efa_base_ep_unlock_cq(base_ep);
+	efa_cq_unlock_ep_list(base_ep);
 	EFA_GENLOCK_UNLOCK(&base_ep->domain->device->qp_table_lock, efa_qp_table_lock_sym);
 	return 0;
 }
@@ -1082,7 +1056,7 @@ int efa_base_ep_create_and_enable_qp(struct efa_base_ep *ep)
 	 * Lock ordering: device lock -> CQ locks -> QP operations
 	 */
 	EFA_GENLOCK_LOCK(&ep->domain->device->qp_table_lock, efa_qp_table_lock_sym);
-	efa_base_ep_lock_cq(ep);
+	efa_cq_lock_ep_list(ep);
 	err = efa_base_ep_create_qp(ep, &scq->ibv_cq, &rcq->ibv_cq);
 	if (err)
 		goto out;
@@ -1090,7 +1064,7 @@ int efa_base_ep_create_and_enable_qp(struct efa_base_ep *ep)
 	err = efa_base_ep_enable(ep);
 
 out:
-	efa_base_ep_unlock_cq(ep);
+	efa_cq_unlock_ep_list(ep);
 	EFA_GENLOCK_UNLOCK(&ep->domain->device->qp_table_lock, efa_qp_table_lock_sym);
 	return err;
 }

--- a/prov/efa/src/efa_cq.h
+++ b/prov/efa/src/efa_cq.h
@@ -49,6 +49,32 @@ extern struct fi_ops_cq efa_cq_bypass_util_cq_ops;
 
 extern struct fi_ops efa_cq_fi_ops;
 
+static inline void efa_cq_lock_ep_list(struct efa_base_ep *base_ep)
+{
+	struct efa_cq *tx_cq, *rx_cq;
+
+	tx_cq = efa_base_ep_get_tx_cq(base_ep);
+	rx_cq = efa_base_ep_get_rx_cq(base_ep);
+
+	if (rx_cq)
+		ofi_genlock_lock(&rx_cq->util_cq.ep_list_lock);
+	if (tx_cq && tx_cq != rx_cq)
+		ofi_genlock_lock(&tx_cq->util_cq.ep_list_lock);
+}
+
+static inline void efa_cq_unlock_ep_list(struct efa_base_ep *base_ep)
+{
+	struct efa_cq *tx_cq, *rx_cq;
+
+	tx_cq = efa_base_ep_get_tx_cq(base_ep);
+	rx_cq = efa_base_ep_get_rx_cq(base_ep);
+
+	if (tx_cq && tx_cq != rx_cq)
+		ofi_genlock_unlock(&tx_cq->util_cq.ep_list_lock);
+	if (rx_cq)
+		ofi_genlock_unlock(&rx_cq->util_cq.ep_list_lock);
+}
+
 /*
  * Control header with completion data. CQ data length is static.
  */

--- a/prov/efa/src/efa_data_path_direct.c
+++ b/prov/efa/src/efa_data_path_direct.c
@@ -56,19 +56,21 @@
  * - Configuring doorbell register access
  *
  * @param efa_qp Pointer to the EFA queue pair to initialize
+ * @param wqlock Lock that serializes access to the send/recv work-queue wrid
+ *               translation table (wrid[]/wrid_idx_pool).
  * @return 0 on success, negative error code on failure
  *
  * @note This function requires that the underlying IBV queue pair has
  *       been successfully created before being called
  */
-int efa_data_path_direct_qp_initialize(struct efa_qp *efa_qp)
+int efa_data_path_direct_qp_initialize(struct efa_qp *efa_qp,
+				       struct ofi_genlock *wqlock)
 {
 	/**
 	 * Called during efa_base_ep_create_qp.
 	 * See also rdma-core/providers/efa/verbs.c: efa_setup_qp
 	 */
 	struct efa_data_path_direct_qp *direct_qp = &efa_qp->data_path_direct_qp;
-	struct efa_base_ep *base_ep = efa_qp->base_ep;
 
 	struct efadv_wq_attr sq_attr = {0}; /* Send queue attributes from hardware */
 	struct efadv_wq_attr rq_attr = {0}; /* Receive queue attributes from hardware */
@@ -92,7 +94,7 @@ int efa_data_path_direct_qp_initialize(struct efa_qp *efa_qp)
 	direct_qp->rq.wq.max_batch = rq_attr.max_batch;
 	/* Initialize receive work queue management structures */
 	efa_data_path_direct_wq_initialize(&direct_qp->rq.wq, rq_attr.num_entries,
-			   false, &base_ep->util_ep.lock);
+			   false, wqlock);
 
 	/* Configure send queue with hardware attributes */
 	direct_qp->sq.desc = sq_attr.buffer;          /* Hardware SQ buffer */
@@ -108,7 +110,7 @@ int efa_data_path_direct_qp_initialize(struct efa_qp *efa_qp)
 #endif
 	/* Initialize send work queue management structures */
 	efa_data_path_direct_wq_initialize(&direct_qp->sq.wq, sq_attr.num_entries,
-			   sq_req_id_64_bit, &base_ep->util_ep.lock);
+			   sq_req_id_64_bit, wqlock);
 
 	/* Mirror efa_qp_init_indices functionality - indices already initialized */
 

--- a/prov/efa/src/efa_data_path_direct.h
+++ b/prov/efa/src/efa_data_path_direct.h
@@ -44,7 +44,8 @@
  * @note This function is called during queue pair creation and requires
  *       that the underlying hardware queue pair has been successfully created
  */
-int efa_data_path_direct_qp_initialize(struct efa_qp *efa_qp);
+int efa_data_path_direct_qp_initialize(struct efa_qp *efa_qp,
+				       struct ofi_genlock *wqlock);
 
 /**
  * @brief Initialize direct completion queue operations for a completion queue

--- a/prov/efa/src/efa_data_path_direct_internal.h
+++ b/prov/efa/src/efa_data_path_direct_internal.h
@@ -92,6 +92,14 @@ efa_wq_get_next_wrid_idx(struct efa_data_path_direct_wq *wq, uint64_t wr_id)
 {
 	uint32_t wrid_idx;
 
+	/*
+	 * The wrid translation table (wrid[]/wrid_idx_pool/wrid_idx_pool_next)
+	 * is shared with the completion path (efa_wq_cqe_finalize). The caller
+	 * must hold wq->wqlock so post and completion serialize on one lock;
+	 * otherwise a wrid_idx can resolve to the wrong wr_id/pkt_entry.
+	 */
+	assert(ofi_genlock_held(wq->wqlock));
+
 	/* Get the next wrid index to be used from the free index pool */
 	wrid_idx = wq->wrid_idx_pool[wq->wrid_idx_pool_next];
 	wq->wrid[wrid_idx] = wr_id;

--- a/prov/efa/src/efa_domain.h
+++ b/prov/efa/src/efa_domain.h
@@ -80,6 +80,24 @@ struct fi_info *efa_domain_get_prov_info(struct efa_domain *efa_domain, enum fi_
 	return (ep_type == FI_EP_RDM) ? efa_domain->device->rdm_info : efa_domain->device->dgram_info;
 }
 
+/**
+ * @brief select the lock type for a domain based on its threading model
+ *
+ * When the domain is not FI_THREAD_SAFE, applications must serialize access 
+ * to all objects that are associated by a common completion mechanism so a 
+ * no-op lock is sufficient. Otherwise a real mutex is required.
+ *
+ * @param	domain[in]		EFA domain
+ * @return	OFI_LOCK_NOOP if the domain does not require FI_THREAD_SAFE
+ *		locking, OFI_LOCK_MUTEX otherwise
+ */
+static inline
+enum ofi_lock_type efa_domain_data_progress_lock_type(struct efa_domain *domain)
+{
+	return domain->util_domain.threading != FI_THREAD_SAFE ?
+	       OFI_LOCK_NOOP : OFI_LOCK_MUTEX;
+}
+
 static inline
 bool efa_domain_support_rnr_retry_modify(struct efa_domain *domain)
 {

--- a/prov/efa/src/efa_domain_util.h
+++ b/prov/efa/src/efa_domain_util.h
@@ -13,7 +13,7 @@
  * (efa-rdm) for setup that doesn't depend on which extended struct embeds
  * the base efa_domain.
  *
- * Caller must allocate efa_domain, initialize srx_lock, and validate the
+ * Caller must allocate efa_domain and validate the
  * info type before calling. After this returns 0 the caller installs
  * path-specific ops tables, runs path-specific init, and then calls
  * efa_domain_finalize_base.

--- a/prov/efa/src/rdm/efa_rdm_atomic.c
+++ b/prov/efa/src/rdm/efa_rdm_atomic.c
@@ -136,7 +136,7 @@ ssize_t efa_rdm_atomic_generic_efa(struct efa_rdm_ep *efa_rdm_ep,
 	assert(msg->iov_count <= efa_rdm_ep->base_ep.info->tx_attr->iov_limit);
 	efa_perfset_start(efa_rdm_ep, perf_efa_tx);
 
-	assert(ofi_genlock_held(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock));
+	ofi_genlock_lock(&efa_rdm_ep->srx_lock);
 
 	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, msg->addr);
 	assert(peer);
@@ -162,6 +162,7 @@ ssize_t efa_rdm_atomic_generic_efa(struct efa_rdm_ep *efa_rdm_ep,
 	}
 
 out:
+	ofi_genlock_unlock(&efa_rdm_ep->srx_lock);
 	efa_perfset_end(efa_rdm_ep, perf_efa_tx);
 	return err;
 }
@@ -212,10 +213,9 @@ efa_rdm_atomic_inject(struct fid_ep *ep,
 	msg.op = op;
 	msg.context = NULL;
 	msg.data = 0;
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+
 	err = efa_rdm_atomic_generic_efa(efa_rdm_ep, &msg, NULL, ofi_op_atomic,
 				      FI_INJECT, EFA_RDM_TXE_NO_COMPLETION);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return err;
 }
 
@@ -255,9 +255,8 @@ efa_rdm_atomic_writemsg(struct fid_ep *ep,
 			return fi_atomicmsg(efa_rdm_ep->shm_ep, &shm_msg, flags);
 		}
 	}
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+
 	err = efa_rdm_atomic_generic_efa(efa_rdm_ep, msg, NULL, ofi_op_atomic, flags, 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return err;
 }
 
@@ -359,9 +358,8 @@ efa_rdm_atomic_readwritemsg(struct fid_ep *ep,
 
 	ofi_ioc_to_iov(resultv, atomic_ex.resp_iov, result_count, datatype_size);
 	memcpy(atomic_ex.result_desc, result_desc, sizeof(void*) * result_count);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+
 	err = efa_rdm_atomic_generic_efa(efa_rdm_ep, msg, &atomic_ex, ofi_op_atomic_fetch, flags, 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return err;
 }
 
@@ -480,9 +478,8 @@ efa_rdm_atomic_compwritemsg(struct fid_ep *ep,
 	if (compare_desc)
 		memcpy(atomic_ex.compare_desc, compare_desc, sizeof(void*) * compare_count);
 	memcpy(atomic_ex.result_desc, result_desc, sizeof(void*) * result_count);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+
 	err = efa_rdm_atomic_generic_efa(efa_rdm_ep, msg, &atomic_ex, ofi_op_atomic_compare, flags, 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return err;
 }
 

--- a/prov/efa/src/rdm/efa_rdm_cntr.c
+++ b/prov/efa/src/rdm/efa_rdm_cntr.c
@@ -14,25 +14,15 @@
 static uint64_t efa_rdm_cntr_read(struct fid_cntr *cntr_fid)
 {
 	struct efa_rdm_cntr *efa_rdm_cntr;
-	struct efa_domain *domain;
 	uint64_t ret;
 
 	efa_rdm_cntr = container_of(cntr_fid, struct efa_rdm_cntr, efa_cntr.util_cntr.cntr_fid);
-	domain = container_of(efa_rdm_cntr->efa_cntr.util_cntr.domain, struct efa_domain, util_domain);
 
 	/* Flush SHM completions into the peer counter before reading */
-	ofi_genlock_lock(&((struct efa_rdm_domain *) domain)->srx_lock);
 	if (efa_rdm_cntr->shm_cntr)
 		fi_cntr_read(efa_rdm_cntr->shm_cntr);
 
-	/*
-	 * keep srx_lock for ofi_cntr_read because the registered
-	 * progress callback (efa_rdm_cntr_progress) drives ibv_cq polling,
-	 * and the CQ poll path looks up peers and the implicit AV, which the
-	 * datapath serializes under srx_lock.
-	 */
 	ret = ofi_cntr_read(cntr_fid);
-	ofi_genlock_unlock(&((struct efa_rdm_domain *) domain)->srx_lock);
 
 	return ret;
 }
@@ -40,24 +30,14 @@ static uint64_t efa_rdm_cntr_read(struct fid_cntr *cntr_fid)
 static uint64_t efa_rdm_cntr_readerr(struct fid_cntr *cntr_fid)
 {
 	struct efa_rdm_cntr *efa_rdm_cntr;
-	struct efa_domain *domain;
 	uint64_t ret;
 
 	efa_rdm_cntr = container_of(cntr_fid, struct efa_rdm_cntr, efa_cntr.util_cntr.cntr_fid);
-	domain = container_of(efa_rdm_cntr->efa_cntr.util_cntr.domain, struct efa_domain, util_domain);
 
-	ofi_genlock_lock(&((struct efa_rdm_domain *) domain)->srx_lock);
 	if (efa_rdm_cntr->shm_cntr)
 		fi_cntr_read(efa_rdm_cntr->shm_cntr);
 
-	/*
-	 * keep srx_lock for ofi_cntr_readerr because the registered
-	 * progress callback (efa_rdm_cntr_progress) drives ibv_cq polling,
-	 * and the CQ poll path looks up peers and the implicit AV, which the
-	 * datapath serializes under srx_lock.
-	 */
 	ret = ofi_cntr_readerr(cntr_fid);
-	ofi_genlock_unlock(&((struct efa_rdm_domain *) domain)->srx_lock);
 
 	return ret;
 }
@@ -123,8 +103,10 @@ static void efa_rdm_cntr_progress(struct util_cntr *cntr)
 		dlist_foreach(&cntr->ep_list, item) {
 			fid_entry = container_of(item, struct fid_list_entry, entry);
 			efa_rdm_ep = container_of(fid_entry->fid, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
+			ofi_genlock_lock(&efa_rdm_ep->srx_lock);
 			if (efa_rdm_ep->base_ep.efa_qp_enabled)
 				efa_rdm_ep_post_internal_rx_pkts(efa_rdm_ep);
+			ofi_genlock_unlock(&efa_rdm_ep->srx_lock);
 		}
 		efa_rdm_cntr->need_to_scan_ep_list = false;
 	}

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -678,6 +678,14 @@ enum ibv_wc_status efa_rdm_cq_process_wc_closing_ep(struct efa_ibv_cq *cq, struc
 	struct efa_rdm_pke *pkt_entry = efa_rdm_cq_get_pke_from_wr_id(cq, wr_id);
 	int prov_errno;
 
+	/*
+	 * Two locks are required on the completion path:
+	 * 1. the ibv-CQ's ep_list_lock serializes the shared ibv CQ poll cursor
+	 * 2. the ep's srx_lock serializes SRX recv-matching and per-ep ope/pke state.
+	 */
+	assert(ofi_genlock_held(&container_of(cq, struct efa_cq, ibv_cq)->util_cq.ep_list_lock));
+	assert(ofi_genlock_held(&ep->srx_lock));
+
 #if HAVE_LTTNG
 	efa_rdm_tracepoint(poll_cq, (size_t) wr_id);
 	if (pkt_entry && pkt_entry->ope) {
@@ -739,6 +747,8 @@ enum ibv_wc_status efa_rdm_cq_process_wc_closing_ep(struct efa_ibv_cq *cq, struc
 static inline
 enum ibv_wc_status efa_rdm_cq_process_wc(struct efa_ibv_cq *cq, struct efa_rdm_ep *ep)
 {
+	assert(ofi_genlock_held(&container_of(cq, struct efa_cq, ibv_cq)->util_cq.ep_list_lock));
+	assert(ofi_genlock_held(&ep->srx_lock));
 	uint64_t wr_id = cq->ibv_cq_ex->wr_id;
 	enum ibv_wc_status status = cq->ibv_cq_ex->status;
 	enum ibv_wc_opcode opcode = efa_ibv_cq_wc_read_opcode(cq);
@@ -852,28 +862,36 @@ void efa_rdm_cq_poll_ibv_cq_closing_ep(struct efa_ibv_cq *ibv_cq, struct efa_rdm
 	struct efa_cq *efa_cq = container_of(ibv_cq, struct efa_cq, ibv_cq);
 	struct efa_domain *efa_domain = container_of(efa_cq->util_cq.domain, struct efa_domain, util_domain);
 	struct dlist_entry rx_progressed_ep_list, *tmp;
+	enum ibv_wc_status status;
 
+	assert(ofi_genlock_held(&efa_cq->util_cq.ep_list_lock));
 	dlist_init(&rx_progressed_ep_list);
 
 	efa_cq_start_poll(ibv_cq);
 	while (efa_cq_wc_available(ibv_cq)) {
 		ep = efa_rdm_cq_get_rdm_ep(ibv_cq, efa_domain);
+		ofi_genlock_lock(&ep->srx_lock);
 		if (ep == closing_ep) {
-			if (OFI_UNLIKELY(efa_rdm_cq_process_wc_closing_ep(ibv_cq, ep) != IBV_WC_SUCCESS))
-				break;
+			status = efa_rdm_cq_process_wc_closing_ep(ibv_cq, ep);
 		} else {
-			if (OFI_UNLIKELY(efa_rdm_cq_process_wc(ibv_cq, ep) != IBV_WC_SUCCESS))
-				break;
-			if (ep->efa_rx_pkts_to_post > 0 && !dlist_find_first_match(&rx_progressed_ep_list, &efa_rdm_cq_match_ep, ep))
+			status = efa_rdm_cq_process_wc(ibv_cq, ep);
+			if (status == IBV_WC_SUCCESS &&
+			    ep->efa_rx_pkts_to_post > 0 &&
+			    !dlist_find_first_match(&rx_progressed_ep_list, &efa_rdm_cq_match_ep, ep))
 				dlist_insert_tail(&ep->entry, &rx_progressed_ep_list);
 		}
+		ofi_genlock_unlock(&ep->srx_lock);
+		if (OFI_UNLIKELY(status != IBV_WC_SUCCESS))
+			break;
 		efa_cq_next_poll(ibv_cq);
 	}
 	efa_cq_end_poll(ibv_cq);
 	dlist_foreach_container_safe(
 		&rx_progressed_ep_list, struct efa_rdm_ep, ep, entry, tmp) {
+		ofi_genlock_lock(&ep->srx_lock);
 		efa_rdm_ep_post_internal_rx_pkts(ep);
 		dlist_remove(&ep->entry);
+		ofi_genlock_unlock(&ep->srx_lock);
 	}
 	assert(dlist_empty(&rx_progressed_ep_list));
 }
@@ -896,6 +914,7 @@ int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 
 	struct dlist_entry rx_progressed_ep_list, *tmp;
 
+	assert(ofi_genlock_held(&efa_cq->util_cq.ep_list_lock));
 	dlist_init(&rx_progressed_ep_list);
 
 	/* Call ibv_start_poll only once */
@@ -903,10 +922,14 @@ int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 
 	while (efa_cq_wc_available(ibv_cq)) {
 		ep = efa_rdm_cq_get_rdm_ep(ibv_cq, efa_domain);
-		if (OFI_UNLIKELY(efa_rdm_cq_process_wc(ibv_cq, ep) != IBV_WC_SUCCESS))
+		ofi_genlock_lock(&ep->srx_lock);
+		if (OFI_UNLIKELY(efa_rdm_cq_process_wc(ibv_cq, ep) != IBV_WC_SUCCESS)) {
+			ofi_genlock_unlock(&ep->srx_lock);
 			break;
+		}
 		if (ep->efa_rx_pkts_to_post > 0 && !dlist_find_first_match(&rx_progressed_ep_list, &efa_rdm_cq_match_ep, ep))
 			dlist_insert_tail(&ep->entry, &rx_progressed_ep_list);
+		ofi_genlock_unlock(&ep->srx_lock);
 		if (++i >= cqe_to_process)
 			break;
 
@@ -921,8 +944,10 @@ int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 	efa_cq_end_poll(ibv_cq);
 	dlist_foreach_container_safe(
 		&rx_progressed_ep_list, struct efa_rdm_ep, ep, entry, tmp) {
+		ofi_genlock_lock(&ep->srx_lock);
 		efa_rdm_ep_post_internal_rx_pkts(ep);
 		dlist_remove(&ep->entry);
+		ofi_genlock_unlock(&ep->srx_lock);
 	}
 	assert(dlist_empty(&rx_progressed_ep_list));
 
@@ -930,7 +955,9 @@ int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 	dlist_foreach_container_safe(&efa_rdm_cq->progress_ep_list,
 				     struct efa_rdm_ep, ep,
 				     progress_ep_entry, tmp) {
+		ofi_genlock_lock(&ep->srx_lock);
 		efa_rdm_ep_progress_peers_and_queues(ep);
+		ofi_genlock_unlock(&ep->srx_lock);
 	}
 	ofi_genlock_unlock(&efa_rdm_cq->progress_ep_list_lock);
 
@@ -941,14 +968,8 @@ static ssize_t efa_rdm_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t coun
 {
 	struct efa_rdm_cq *cq;
 	ssize_t ret;
-	struct efa_domain *domain;
 
 	cq = container_of(cq_fid, struct efa_rdm_cq, efa_cq.util_cq.cq_fid.fid);
-
-	domain = container_of(cq->efa_cq.util_cq.domain, struct efa_domain, util_domain);
-
-	ofi_genlock_lock(&((struct efa_rdm_domain *) domain)->srx_lock);
-
 	if (cq->shm_cq) {
 		fi_cq_read(cq->shm_cq, NULL, 0);
 
@@ -966,7 +987,6 @@ static ssize_t efa_rdm_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t coun
 	ret = ofi_cq_readfrom(&cq->efa_cq.util_cq.cq_fid, buf, count, src_addr);
 
 out:
-	ofi_genlock_unlock(&((struct efa_rdm_domain *) domain)->srx_lock);
 
 	return ret;
 }
@@ -1122,6 +1142,7 @@ static void efa_rdm_cq_progress(struct util_cq *cq)
 	struct efa_rdm_cq *efa_rdm_cq;
 	struct efa_ibv_cq_poll_list_entry *poll_list_entry;
 	struct efa_rdm_ep *efa_rdm_ep;
+	struct efa_cq *efa_cq;
 	struct fid_list_entry *fid_entry;
 
 	ofi_genlock_lock(&cq->ep_list_lock);
@@ -1138,17 +1159,26 @@ static void efa_rdm_cq_progress(struct util_cq *cq)
 		dlist_foreach(&cq->ep_list, item) {
 			fid_entry = container_of(item, struct fid_list_entry, entry);
 			efa_rdm_ep = container_of(fid_entry->fid, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-			if (efa_rdm_ep->base_ep.efa_qp_enabled)
+			if (efa_rdm_ep->base_ep.efa_qp_enabled) {
+				ofi_genlock_lock(&efa_rdm_ep->srx_lock);
 				efa_rdm_ep_post_internal_rx_pkts(efa_rdm_ep);
+				ofi_genlock_unlock(&efa_rdm_ep->srx_lock);
+			}
 		}
 		efa_rdm_cq->need_to_scan_ep_list = false;
 	}
 
 	dlist_foreach(&efa_rdm_cq->ibv_cq_poll_list, item) {
 		poll_list_entry = container_of(item, struct efa_ibv_cq_poll_list_entry, entry);
-		(void) efa_rdm_cq_poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
+		efa_cq = container_of(poll_list_entry->cq, struct efa_cq, ibv_cq);
+		if (&efa_cq->util_cq.ep_list_lock != &cq->ep_list_lock) {
+			ofi_genlock_lock(&efa_cq->util_cq.ep_list_lock);
+			(void) efa_rdm_cq_poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
+			ofi_genlock_unlock(&efa_cq->util_cq.ep_list_lock);
+		} else {
+			(void) efa_rdm_cq_poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
+		}
 	}
-
 	ofi_genlock_unlock(&cq->ep_list_lock);
 }
 

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -123,6 +123,8 @@ int efa_rdm_cq_close(struct fid *fid)
 	ret = efa_cq_destroy_comp_channel(&cq->efa_cq);
 	if (ret)
 		return ret;
+
+	ofi_genlock_destroy(&cq->progress_ep_list_lock);
 	free(cq);
 	return retv;
 }
@@ -924,11 +926,13 @@ int efa_rdm_cq_poll_ibv_cq(ssize_t cqe_to_process, struct efa_ibv_cq *ibv_cq)
 	}
 	assert(dlist_empty(&rx_progressed_ep_list));
 
+	ofi_genlock_lock(&efa_rdm_cq->progress_ep_list_lock);
 	dlist_foreach_container_safe(&efa_rdm_cq->progress_ep_list,
 				     struct efa_rdm_ep, ep,
 				     progress_ep_entry, tmp) {
 		efa_rdm_ep_progress_peers_and_queues(ep);
 	}
+	ofi_genlock_unlock(&efa_rdm_cq->progress_ep_list_lock);
 
 	return err;
 }
@@ -1277,11 +1281,16 @@ int efa_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	dlist_init(&cq->progress_ep_list);
 	cq->need_to_scan_ep_list = false;
 
+	ret = ofi_genlock_init(&cq->progress_ep_list_lock,
+			       efa_domain_data_progress_lock_type(&rdm_domain->efa_domain));
+	if (ret)
+		goto free;
+
 	ret = ofi_cq_init(&efa_prov, domain, attr, &cq->efa_cq.util_cq,
 			  &efa_rdm_cq_progress, context);
 
 	if (ret)
-		goto free;
+		goto destroy_progress_lock;
 
 	ret = efa_rdm_cq_init_entry_size(cq, attr->format);
 	if (ret)
@@ -1340,6 +1349,8 @@ close_util_cq:
 	if (retv)
 		EFA_WARN(FI_LOG_CQ, "Unable to close util cq: %s\n",
 			 fi_strerror(-retv));
+destroy_progress_lock:
+	ofi_genlock_destroy(&cq->progress_ep_list_lock);
 free:
 	free(cq);
 	return ret;

--- a/prov/efa/src/rdm/efa_rdm_cq.h
+++ b/prov/efa/src/rdm/efa_rdm_cq.h
@@ -14,6 +14,7 @@ struct efa_rdm_cq {
 	struct dlist_entry ibv_cq_poll_list;
 	/* list of EPs that have queued work needing progress */
 	struct dlist_entry progress_ep_list;
+	struct ofi_genlock progress_ep_list_lock;
 	size_t entry_size;
 	bool need_to_scan_ep_list;
 };

--- a/prov/efa/src/rdm/efa_rdm_domain.c
+++ b/prov/efa/src/rdm/efa_rdm_domain.c
@@ -123,7 +123,6 @@ int efa_rdm_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	struct efa_rdm_domain *rdm_domain;
 	struct efa_domain *efa_domain;
 	int ret = 0, err;
-	bool use_lock;
 
 	/* DGRAM is also served by the "efa" fabric but uses the base
 	 * struct and base ops. Forward to the base path.
@@ -145,21 +144,9 @@ int efa_rdm_domain_open(struct fid_fabric *fabric_fid, struct fi_info *info,
 	}
 	efa_domain = &rdm_domain->efa_domain;
 
-	/* Initialize srx_lock first so efa_rdm_domain_close can always destroy it */
-    use_lock = ofi_thread_level(info->domain_attr->threading) ==
-           ofi_thread_level(FI_THREAD_SAFE);
-	err = ofi_genlock_init(&rdm_domain->srx_lock, use_lock ? OFI_LOCK_MUTEX : OFI_LOCK_NONE);
-	if (err) {
-		EFA_WARN(FI_LOG_DOMAIN, "srx lock init failed! err: %d\n", err);
-		free(rdm_domain);
-		*domain_fid = NULL;
-		return err;
-	}
-
 	if (!EFA_INFO_TYPE_IS_RDM(info)) {
 		EFA_WARN(FI_LOG_DOMAIN,
 			 "efa_rdm_domain_open called with non-rdm info\n");
-		ofi_genlock_destroy(&rdm_domain->srx_lock);
 		free(rdm_domain);
 		*domain_fid = NULL;
 		return -FI_EINVAL;
@@ -244,7 +231,6 @@ static int efa_rdm_domain_close(fid_t fid)
 
 	efa_domain_destruct(efa_domain);
 
-	ofi_genlock_destroy(&rdm_domain->srx_lock);
 	free(rdm_domain);
 	return 0;
 }

--- a/prov/efa/src/rdm/efa_rdm_domain.h
+++ b/prov/efa/src/rdm/efa_rdm_domain.h
@@ -10,7 +10,6 @@
 struct efa_rdm_domain {
 	struct efa_domain	efa_domain;
 
-	struct ofi_genlock	srx_lock; /* shared among peer providers */
 	struct fid_domain	*shm_domain;
 	struct ofi_mr_cache	*cache;
 	size_t			mtu_size;

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -241,6 +241,8 @@ void efa_rdm_ep_progress_peers_and_queues(struct efa_rdm_ep *ep);
 
 void efa_rdm_ep_enqueue_progress_list(struct efa_rdm_ep *ep);
 
+void efa_rdm_ep_dequeue_progress_list(struct efa_rdm_ep *ep);
+
 void efa_rdm_ep_purge_queued_blocking_copy_for_rxe(struct efa_rdm_ope *rxe);
 
 #define efa_rdm_rx_flags(efa_rdm_ep) ((efa_rdm_ep)->base_ep.util_ep.rx_op_flags)

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -59,6 +59,8 @@ struct efa_rdm_ep_queued_copy {
 struct efa_rdm_ep {
 	struct efa_base_ep base_ep;
 
+	struct ofi_genlock srx_lock;
+
 	/* self_ah necessary for local reads when application does not insert
 	 * its own address into the AV */
 	struct efa_ah *self_ah;

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -1074,6 +1074,12 @@ static int efa_rdm_ep_close(struct fid *fid)
 	domain = efa_rdm_ep_domain(efa_rdm_ep);
 
 	/**
+	 * Hold cq.ep_list_lock so the cq progress cannot run concurrently, 
+	 * which prevents the deadlock of srx_lock -> progress_ep_list_lock.
+	 */
+	efa_cq_lock_ep_list(&efa_rdm_ep->base_ep);
+
+	/**
 	 * The QP destroy and op entries clean up must be in the same lock,
 	 * otherwise there can be race condition that efa_rdm_ep_progress_peers_and_queues
 	 * (part of fi_cq_read) can access entries that are from a closed QP.
@@ -1082,10 +1088,8 @@ static int efa_rdm_ep_close(struct fid *fid)
 	if (efa_rdm_ep->base_ep.efa_qp_enabled)
 		efa_rdm_ep_wait_send(efa_rdm_ep);
 
-	if (efa_rdm_ep->needs_progress) {
-		dlist_remove(&efa_rdm_ep->progress_ep_entry);
-		efa_rdm_ep->needs_progress = false;
-	}
+	efa_rdm_ep_dequeue_progress_list(efa_rdm_ep);
+	efa_cq_unlock_ep_list(&efa_rdm_ep->base_ep);
 
 	if (efa_rdm_ep->peer_srx_ep) {
 		/*

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -489,6 +489,11 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 	if (ret)
 		goto err_free_ep;
 
+	ret = ofi_genlock_init(&efa_rdm_ep->srx_lock,
+			       efa_domain_data_progress_lock_type(efa_domain));
+	if (ret)
+		goto err_destroy_base_ep;
+
 	if (rdm_domain->shm_domain) {
 		efa_rdm_ep->shm_info = NULL;
 		efa_shm_info_create(info, &efa_rdm_ep->shm_info);
@@ -496,7 +501,7 @@ int efa_rdm_ep_open(struct fid_domain *domain, struct fi_info *info,
 			ret = fi_endpoint(rdm_domain->shm_domain, efa_rdm_ep->shm_info,
 					  &efa_rdm_ep->shm_ep, efa_rdm_ep);
 			if (ret)
-				goto err_destroy_base_ep;
+				goto err_destroy_lock;
 		} else {
 			efa_rdm_ep->shm_ep = NULL;
 		}
@@ -655,6 +660,8 @@ err_close_shm_ep:
 			EFA_WARN(FI_LOG_EP_CTRL, "Unable to close shm EP: %s\n",
 				fi_strerror(-retv));
 	}
+err_destroy_lock:
+	ofi_genlock_destroy(&efa_rdm_ep->srx_lock);
 err_destroy_base_ep:
 	efa_base_ep_destruct(&efa_rdm_ep->base_ep);
 err_free_ep:
@@ -904,12 +911,15 @@ bool efa_rdm_ep_close_should_wait_send(struct efa_rdm_ep *efa_rdm_ep)
 	struct efa_rdm_ope *ope;
 	struct dlist_entry *entry;
 
+	ofi_genlock_lock(&efa_rdm_ep->srx_lock);
 	dlist_foreach(&efa_rdm_ep->ope_posted_ack_list, entry) {
 		ope = container_of(entry, struct efa_rdm_ope, ack_list_entry);
 		if (ope->peer && !(ope->peer->flags & EFA_RDM_PEER_UNRESP)) {
+			ofi_genlock_unlock(&efa_rdm_ep->srx_lock);
 			return true;
 		}
 	}
+	ofi_genlock_unlock(&efa_rdm_ep->srx_lock);
 
 	return false;
 }
@@ -920,6 +930,7 @@ static inline void progress_queues_closing_ep(struct efa_rdm_ep *ep)
 	struct dlist_entry *tmp;
 	struct efa_rdm_ope *ope;
 
+	ofi_genlock_lock(&ep->srx_lock);
 	/* Update timers for peers that are in backoff list*/
 	dlist_foreach_container_safe(&ep->peer_backoff_list,
 			struct efa_rdm_peer, peer, rnr_backoff_entry, tmp) {
@@ -949,6 +960,7 @@ static inline void progress_queues_closing_ep(struct efa_rdm_ep *ep)
 			break;
 		}
 	}
+	ofi_genlock_unlock(&ep->srx_lock);
 }
 
 /*
@@ -958,9 +970,9 @@ static inline void progress_queues_closing_ep(struct efa_rdm_ep *ep)
  * complete. Only polls CQ when there are operations with
  * posted RECEIPT or EOR packets from responsive peers.
  *
- * The caller must hold the domain's srx_lock. This function
- * polls the CQ and progresses queued operations, both of which
- * require the srx_lock to be held.
+ * This function polls the tx/rx CQs and progresses queued operations
+ * until all inflight sends complete. It manages locking internally in the
+ * order ep_list_lock -> srx_lock.
  *
  * @param[in]	efa_rdm_ep		endpoint
  * @return 	no return
@@ -969,8 +981,6 @@ void efa_rdm_ep_wait_send(struct efa_rdm_ep *efa_rdm_ep)
 {
 	struct efa_cq *tx_cq, *rx_cq;
 
-	assert(ofi_genlock_held(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock));
-
 	tx_cq = efa_base_ep_get_tx_cq(&efa_rdm_ep->base_ep);
 	rx_cq = efa_base_ep_get_rx_cq(&efa_rdm_ep->base_ep);
 
@@ -978,7 +988,7 @@ void efa_rdm_ep_wait_send(struct efa_rdm_ep *efa_rdm_ep)
 		/* poll cq until empty */
 		if (tx_cq)
 			efa_rdm_cq_poll_ibv_cq_closing_ep(&tx_cq->ibv_cq, efa_rdm_ep);
-		if (rx_cq)
+		if (rx_cq && rx_cq != tx_cq)
 			efa_rdm_cq_poll_ibv_cq_closing_ep(&rx_cq->ibv_cq, efa_rdm_ep);
 		progress_queues_closing_ep(efa_rdm_ep);
 	}
@@ -1079,14 +1089,14 @@ static int efa_rdm_ep_close(struct fid *fid)
 	 */
 	efa_cq_lock_ep_list(&efa_rdm_ep->base_ep);
 
+	if (efa_rdm_ep->base_ep.efa_qp_enabled)
+		efa_rdm_ep_wait_send(efa_rdm_ep);
 	/**
 	 * The QP destroy and op entries clean up must be in the same lock,
 	 * otherwise there can be race condition that efa_rdm_ep_progress_peers_and_queues
 	 * (part of fi_cq_read) can access entries that are from a closed QP.
 	 */
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
-	if (efa_rdm_ep->base_ep.efa_qp_enabled)
-		efa_rdm_ep_wait_send(efa_rdm_ep);
+	ofi_genlock_lock(&efa_rdm_ep->srx_lock);
 
 	efa_rdm_ep_dequeue_progress_list(efa_rdm_ep);
 	efa_cq_unlock_ep_list(&efa_rdm_ep->base_ep);
@@ -1112,6 +1122,9 @@ static int efa_rdm_ep_close(struct fid *fid)
 		* It also decrements the ref count of rx cq. So it must
 		* be called before we clean up the ibv cq poll list which
 		* relies on the correct ref count of tx/rx cq.
+		*
+		* util_srx_close expects the caller to hold srx_lock, so
+		* it is called while the lock is held.
 		*/
 		util_srx_close(&efa_rdm_ep->peer_srx_ep->fid);
 		efa_rdm_ep->peer_srx_ep = NULL;
@@ -1122,17 +1135,6 @@ static int efa_rdm_ep_close(struct fid *fid)
 	efa_base_ep_close_util_ep(&efa_rdm_ep->base_ep);
 
 	efa_rdm_ep_remove_cntr_ibv_cq_poll_list(&efa_rdm_ep->base_ep);
-
-	/*
-	 * Destroying the self AH also requires the util_domain.lock, 
-	 * because it modifies the AH refcnts which can also be
-	 * modified in the CQ read path by implicit-to-explicit AV entry conversion
-	 */
-	if (efa_rdm_ep->self_ah) {
-		EFA_GENLOCK_LOCK(&domain->util_domain.lock, efa_util_domain_lock_sym);
-		efa_ah_release(domain, efa_rdm_ep->self_ah, false);
-		EFA_GENLOCK_UNLOCK(&domain->util_domain.lock, efa_util_domain_lock_sym);
-	}
 
 	efa_rdm_ep_deregister_ibv_cqs(efa_rdm_ep);
 
@@ -1157,8 +1159,21 @@ static int efa_rdm_ep_close(struct fid *fid)
 	if (efa_rdm_ep->send_pkt_entry_vec_data_sizes)
 		free(efa_rdm_ep->send_pkt_entry_vec_data_sizes);
 
-	ofi_genlock_unlock(&((struct efa_rdm_domain *) domain)->srx_lock);
+	ofi_genlock_unlock(&efa_rdm_ep->srx_lock);
 
+	/*
+	 * Destroying the self AH also requires the util_domain.lock,
+	 * because it modifies the AH refcnts which can also be
+	 * modified in the CQ read path by implicit-to-explicit AV entry conversion.
+	 *
+	 */
+	if (efa_rdm_ep->self_ah) {
+		EFA_GENLOCK_LOCK(&domain->util_domain.lock, efa_util_domain_lock_sym);
+		efa_ah_release(domain, efa_rdm_ep->self_ah, false);
+		EFA_GENLOCK_UNLOCK(&domain->util_domain.lock, efa_util_domain_lock_sym);
+	}
+
+	ofi_genlock_destroy(&efa_rdm_ep->srx_lock);
 	free(efa_rdm_ep);
 	return retv;
 }

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -996,6 +996,8 @@ void efa_rdm_ep_post_internal_rx_pkts(struct efa_rdm_ep *ep)
 {
 	int err;
 
+	assert(ofi_genlock_held(&ep->srx_lock));
+
 	if (ep->efa_rx_pkts_posted == 0 && ep->efa_rx_pkts_to_post == 0 && ep->efa_rx_pkts_held == 0) {
 		/* All of efa_rx_pkts_posted, efa_rx_pkts_to_post and
 		 * efa_rx_pkts_held equal to 0 means

--- a/prov/efa/src/rdm/efa_rdm_ep_utils.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_utils.c
@@ -1082,6 +1082,15 @@ int efa_rdm_ep_enforce_handshake_for_txe(struct efa_rdm_ep *ep, struct efa_rdm_o
 	return FI_SUCCESS;
 }
 
+static inline struct efa_rdm_cq *efa_rdm_ep_get_progress_cq(struct efa_rdm_ep *ep)
+{
+	if (ep->base_ep.util_ep.tx_cq)
+		return container_of(ep->base_ep.util_ep.tx_cq, struct efa_rdm_cq, efa_cq.util_cq);
+
+	assert(ep->base_ep.util_ep.rx_cq);
+	return container_of(ep->base_ep.util_ep.rx_cq, struct efa_rdm_cq, efa_cq.util_cq);
+}
+
 void efa_rdm_ep_enqueue_progress_list(struct efa_rdm_ep *ep)
 {
 	struct efa_rdm_cq *cq;
@@ -1091,13 +1100,36 @@ void efa_rdm_ep_enqueue_progress_list(struct efa_rdm_ep *ep)
 
 	ep->needs_progress = true;
 
-	if (ep->base_ep.util_ep.tx_cq) {
-		cq = container_of(ep->base_ep.util_ep.tx_cq, struct efa_rdm_cq, efa_cq.util_cq);
-	} else {
-		assert(ep->base_ep.util_ep.rx_cq);
-		cq = container_of(ep->base_ep.util_ep.rx_cq, struct efa_rdm_cq, efa_cq.util_cq);
-	}
+	cq = efa_rdm_ep_get_progress_cq(ep);
+	/**
+	 * The CQ read path's progress loop walks the list in the opposite order,
+	 * progress_ep_list_lock -> srx_lock. That inversion is safe because the two
+	 * paths operate on disjoint sets of EPs:
+	 *   - enqueue only takes progress_ep_list_lock when the EP is NOT already on
+	 *     the list (guarded by needs_progress); if it is already on the list it
+	 *     early-returns without touching progress_ep_list_lock at all;
+	 *   - the progress loop only takes an EP's srx_lock for EPs that ARE on the
+	 *     list.
+	 */
+	ofi_genlock_lock(&cq->progress_ep_list_lock);
 	dlist_insert_tail(&ep->progress_ep_entry, &cq->progress_ep_list);
+	ofi_genlock_unlock(&cq->progress_ep_list_lock);
+}
+
+void efa_rdm_ep_dequeue_progress_list(struct efa_rdm_ep *ep)
+{
+	struct efa_rdm_cq *cq;
+
+	assert(ofi_genlock_held(&ep->srx_lock));
+	if (!ep->needs_progress)
+		return;
+
+	ep->needs_progress = false;
+
+	cq = efa_rdm_ep_get_progress_cq(ep);
+	ofi_genlock_lock(&cq->progress_ep_list_lock);
+	dlist_remove(&ep->progress_ep_entry);
+	ofi_genlock_unlock(&cq->progress_ep_list_lock);
 }
 
 void efa_rdm_ep_progress_peers_and_queues(struct efa_rdm_ep *ep)

--- a/prov/efa/src/rdm/efa_rdm_msg.c
+++ b/prov/efa/src/rdm/efa_rdm_msg.c
@@ -177,8 +177,8 @@ ssize_t efa_rdm_msg_generic_send(struct efa_rdm_ep *ep, const struct fi_msg *msg
 	assert(msg->iov_count <= ep->base_ep.info->tx_attr->iov_limit);
 
 	efa_perfset_start(ep, perf_efa_tx);
+	ofi_genlock_lock(&ep->srx_lock);
 	peer = efa_rdm_ep_get_peer_explicit(ep, msg->addr);
-	assert(ofi_genlock_held(&efa_rdm_ep_rdm_domain(ep)->srx_lock));
 	if (peer->flags & EFA_RDM_PEER_IN_BACKOFF) {
 		err = -FI_EAGAIN;
 		goto out;
@@ -222,6 +222,7 @@ ssize_t efa_rdm_msg_generic_send(struct efa_rdm_ep *ep, const struct fi_msg *msg
 	}
 
 out:
+	ofi_genlock_unlock(&ep->srx_lock);
 	efa_perfset_end(ep, perf_efa_tx);
 	return err;
 }
@@ -266,9 +267,8 @@ ssize_t efa_rdm_msg_sendmsg(struct fid_ep *ep, const struct fi_msg *msg,
 			return ret;
 		}
 	}
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+
 	ret = efa_rdm_msg_generic_send(efa_rdm_ep, msg, 0, ofi_op_msg, flags, 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return ret;
 }
 
@@ -299,9 +299,8 @@ ssize_t efa_rdm_msg_sendv(struct fid_ep *ep, const struct iovec *iov,
 	}
 
 	efa_rdm_msg_construct(&msg, iov, desc, count, dest_addr, context, 0);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+
 	ret = efa_rdm_msg_generic_send(efa_rdm_ep, &msg, 0, ofi_op_msg, efa_rdm_tx_flags(efa_rdm_ep), 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return ret;
 }
 
@@ -335,9 +334,8 @@ ssize_t efa_rdm_msg_send(struct fid_ep *ep, const void *buf, size_t len,
 	}
 
 	efa_rdm_msg_construct(&msg, &iov, &desc, 1, dest_addr, context, 0);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+
 	ret = efa_rdm_msg_generic_send(efa_rdm_ep, &msg, 0, ofi_op_msg, efa_rdm_tx_flags(efa_rdm_ep), 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return ret;
 }
 
@@ -373,10 +371,9 @@ ssize_t efa_rdm_msg_senddata(struct fid_ep *ep, const void *buf, size_t len,
 	}
 
 	efa_rdm_msg_construct(&msg, &iov, &desc, 1, dest_addr, context, data);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+
 	ret = efa_rdm_msg_generic_send(efa_rdm_ep, &msg, 0, ofi_op_msg,
 				    efa_rdm_tx_flags(efa_rdm_ep) | FI_REMOTE_CQ_DATA, 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return ret;
 }
 
@@ -404,11 +401,10 @@ ssize_t efa_rdm_msg_inject(struct fid_ep *ep, const void *buf, size_t len,
 	iov.iov_len = len;
 
 	efa_rdm_msg_construct(&msg, &iov, NULL, 1, dest_addr, NULL, 0);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	ret = efa_rdm_msg_generic_send(efa_rdm_ep, &msg, 0, ofi_op_msg,
 				    efa_rdm_tx_flags(efa_rdm_ep) | FI_INJECT,
 				    EFA_RDM_TXE_NO_COMPLETION);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return ret;
 }
 
@@ -437,12 +433,11 @@ ssize_t efa_rdm_msg_injectdata(struct fid_ep *ep, const void *buf,
 	iov.iov_len = len;
 
 	efa_rdm_msg_construct(&msg, &iov, NULL, 1, dest_addr, NULL, data);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	ret = efa_rdm_msg_generic_send(efa_rdm_ep, &msg, 0, ofi_op_msg,
 				    efa_rdm_tx_flags(efa_rdm_ep) |
 				    FI_REMOTE_CQ_DATA | FI_INJECT,
 				    EFA_RDM_TXE_NO_COMPLETION);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return ret;
 }
 
@@ -490,9 +485,8 @@ ssize_t efa_rdm_msg_tsendmsg(struct fid_ep *ep_fid, const struct fi_msg_tagged *
 	}
 
 	efa_rdm_msg_construct(&msg, tmsg->msg_iov, tmsg->desc, tmsg->iov_count, tmsg->addr, tmsg->context, tmsg->data);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	ret = efa_rdm_msg_generic_send(efa_rdm_ep, &msg, tmsg->tag, ofi_op_tagged, flags, 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return ret;
 }
 
@@ -523,9 +517,8 @@ ssize_t efa_rdm_msg_tsendv(struct fid_ep *ep_fid, const struct iovec *iov,
 	}
 
 	efa_rdm_msg_construct(&msg, iov, desc, count, dest_addr, context, 0);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	ret = efa_rdm_msg_generic_send(efa_rdm_ep, &msg, tag, ofi_op_tagged, efa_rdm_tx_flags(efa_rdm_ep), 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return ret;
 }
 
@@ -560,9 +553,8 @@ ssize_t efa_rdm_msg_tsend(struct fid_ep *ep_fid, const void *buf, size_t len,
 	}
 
 	efa_rdm_msg_construct(&msg, &msg_iov, &desc, 1, dest_addr, context, 0);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	ret = efa_rdm_msg_generic_send(efa_rdm_ep, &msg, tag, ofi_op_tagged, efa_rdm_tx_flags(efa_rdm_ep), 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return ret;
 }
 
@@ -597,10 +589,9 @@ ssize_t efa_rdm_msg_tsenddata(struct fid_ep *ep_fid, const void *buf, size_t len
 	}
 
 	efa_rdm_msg_construct(&msg, &iov, &desc, 1, dest_addr, context, data);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	ret = efa_rdm_msg_generic_send(efa_rdm_ep, &msg, tag, ofi_op_tagged,
 				    efa_rdm_tx_flags(efa_rdm_ep) | FI_REMOTE_CQ_DATA, 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return ret;
 }
 
@@ -628,11 +619,10 @@ ssize_t efa_rdm_msg_tinject(struct fid_ep *ep_fid, const void *buf, size_t len,
 	iov.iov_len = len;
 
 	efa_rdm_msg_construct(&msg, &iov, NULL, 1, dest_addr, NULL, 0);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	ret = efa_rdm_msg_generic_send(efa_rdm_ep, &msg, tag, ofi_op_tagged,
 				    efa_rdm_tx_flags(efa_rdm_ep) | FI_INJECT,
 				    EFA_RDM_TXE_NO_COMPLETION);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return ret;
 }
 
@@ -660,12 +650,11 @@ ssize_t efa_rdm_msg_tinjectdata(struct fid_ep *ep_fid, const void *buf, size_t l
 	iov.iov_len = len;
 
 	efa_rdm_msg_construct(&msg, &iov, NULL, 1, dest_addr, NULL, data);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	ret = efa_rdm_msg_generic_send(efa_rdm_ep, &msg, tag, ofi_op_tagged,
 				    efa_rdm_tx_flags(efa_rdm_ep) |
 				    FI_REMOTE_CQ_DATA | FI_INJECT,
 				    EFA_RDM_TXE_NO_COMPLETION);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return ret;
 }
 

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -181,7 +181,7 @@ ssize_t efa_rdm_rma_generic_readmsg(struct efa_rdm_ep *efa_rdm_ep,
 	       fi_flags);
 
 	efa_perfset_start(efa_rdm_ep, perf_efa_tx);
-	assert(ofi_genlock_held(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock));
+	ofi_genlock_lock(&efa_rdm_ep->srx_lock);
 
 	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, msg->addr);
 	assert(peer);
@@ -219,6 +219,7 @@ out:
 		}
 	}
 
+	ofi_genlock_unlock(&efa_rdm_ep->srx_lock);
 	efa_perfset_end(efa_rdm_ep, perf_efa_tx);
 	return err;
 }
@@ -265,9 +266,8 @@ ssize_t efa_rdm_rma_readmsg(struct fid_ep *ep, const struct fi_msg_rma *msg, uin
 			return err;
 		}
 	}
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	err = efa_rdm_rma_generic_readmsg(efa_rdm_ep, msg, flags, 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return err;
 }
 
@@ -305,9 +305,8 @@ ssize_t efa_rdm_rma_readv(struct fid_ep *ep, const struct iovec *iov, void **des
 
 	memset(&msg, 0, sizeof(msg));
 	EFA_SETUP_MSG_RMA(msg, iov, desc, iov_count, src_addr, &rma_iov, 1, context, 0);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	err = efa_rdm_rma_generic_readmsg(efa_rdm_ep, &msg, 0, 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return err;
 }
 
@@ -349,9 +348,8 @@ ssize_t efa_rdm_rma_read(struct fid_ep *ep, void *buf, size_t len, void *desc,
 
 	memset(&msg, 0, sizeof(msg));
 	EFA_SETUP_MSG_RMA(msg, &iov, &desc, 1, src_addr, &rma_iov, 1, context, 0);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	err = efa_rdm_rma_generic_readmsg(efa_rdm_ep, &msg, 0, 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return err;
 }
 
@@ -437,7 +435,7 @@ static inline ssize_t efa_rdm_rma_generic_writemsg(struct efa_rdm_ep *efa_rdm_ep
 	       ofi_total_iov_len(msg->msg_iov, msg->iov_count),
 	       fi_flags);
 
-	assert(ofi_genlock_held(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock));
+	ofi_genlock_lock(&efa_rdm_ep->srx_lock);
 
 	peer = efa_rdm_ep_get_peer_explicit(efa_rdm_ep, msg->addr);
 	if (peer->flags & EFA_RDM_PEER_IN_BACKOFF) {
@@ -471,6 +469,7 @@ static inline ssize_t efa_rdm_rma_generic_writemsg(struct efa_rdm_ep *efa_rdm_ep
 		}
 	}
 out:
+	ofi_genlock_unlock(&efa_rdm_ep->srx_lock);
 	efa_perfset_end(efa_rdm_ep, perf_efa_tx);
 	return err;
 }
@@ -521,9 +520,8 @@ ssize_t efa_rdm_rma_writemsg(struct fid_ep *ep,
 			return err;
 		}
 	}
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	err = efa_rdm_rma_generic_writemsg(efa_rdm_ep, msg, flags, 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return err;
 }
 
@@ -560,9 +558,8 @@ ssize_t efa_rdm_rma_writev(struct fid_ep *ep, const struct iovec *iov, void **de
 
 	memset(&msg, 0, sizeof(msg));
 	EFA_SETUP_MSG_RMA(msg, iov, desc, iov_count, dest_addr, &rma_iov, 1, context, 0);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	err = efa_rdm_rma_generic_writemsg(efa_rdm_ep, &msg, 0, 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return err;
 }
 
@@ -603,9 +600,8 @@ ssize_t efa_rdm_rma_write(struct fid_ep *ep, const void *buf, size_t len, void *
 
 	memset(&msg, 0, sizeof(msg));
 	EFA_SETUP_MSG_RMA(msg, &iov, &desc, 1, dest_addr, &rma_iov, 1, context, 0);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	err = efa_rdm_rma_generic_writemsg(efa_rdm_ep, &msg, 0, 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return err;
 }
 
@@ -646,9 +642,8 @@ ssize_t efa_rdm_rma_writedata(struct fid_ep *ep, const void *buf, size_t len,
 
 	memset(&msg, 0, sizeof(msg));
 	EFA_SETUP_MSG_RMA(msg, &iov, &desc, 1, dest_addr, &rma_iov, 1, context, data);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	err = efa_rdm_rma_generic_writemsg(efa_rdm_ep, &msg, FI_REMOTE_CQ_DATA, 0);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return err;
 }
 
@@ -682,9 +677,8 @@ ssize_t efa_rdm_rma_inject_write(struct fid_ep *ep, const void *buf, size_t len,
 
 	memset(&msg, 0, sizeof(msg));
 	EFA_SETUP_MSG_RMA(msg, &iov, NULL, 1, dest_addr, &rma_iov, 1, NULL, 0);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	err = efa_rdm_rma_generic_writemsg(efa_rdm_ep, &msg, FI_INJECT, EFA_RDM_TXE_NO_COMPLETION);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return err;
 }
 
@@ -719,10 +713,9 @@ ssize_t efa_rdm_rma_inject_writedata(struct fid_ep *ep, const void *buf, size_t 
 
 	memset(&msg, 0, sizeof(msg));
 	EFA_SETUP_MSG_RMA(msg, &iov, NULL, 1, dest_addr, &rma_iov, 1, NULL, data);
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	
 	err = efa_rdm_rma_generic_writemsg(efa_rdm_ep, &msg, FI_INJECT | FI_REMOTE_CQ_DATA,
 					   EFA_RDM_TXE_NO_COMPLETION);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
 	return err;
 }
 

--- a/prov/efa/src/rdm/efa_rdm_srx.c
+++ b/prov/efa/src/rdm/efa_rdm_srx.c
@@ -166,7 +166,7 @@ int efa_rdm_peer_srx_construct(struct efa_rdm_ep *ep)
 				ep->base_ep.info->rx_attr->size, EFA_RDM_IOV_LIMIT,
 				ep->min_multi_recv_size,
 				&efa_rdm_srx_update_mr,
-				&efa_rdm_ep_rdm_domain(ep)->srx_lock,
+				&ep->srx_lock,
 				&ep->peer_srx_ep);
 	if (ret) {
 		EFA_WARN(FI_LOG_EP_CTRL, "util_ep_srx_context failed, err: %d\n", ret);

--- a/prov/efa/test/efa_unit_test_data_path_direct.c
+++ b/prov/efa/test/efa_unit_test_data_path_direct.c
@@ -139,7 +139,9 @@ void test_efa_data_path_direct_dev_req_id_roundtrip(void **state)
 	pool_next_before = sq_wq->wrid_idx_pool_next;
 
 	/* Get a dev_req_id — should have gen bits set */
+	ofi_genlock_lock(sq_wq->wqlock);
 	dev_req_id = efa_wq_get_dev_req_id(sq_wq, test_wr_id);
+	ofi_genlock_unlock(sq_wq->wqlock);
 
 	/* The generation bits should be present */
 	assert_int_equal(dev_req_id & sq_wq->gen_mask, sq_wq->shifted_gen);

--- a/prov/efa/test/efa_unit_test_ep.c
+++ b/prov/efa/test/efa_unit_test_ep.c
@@ -1482,6 +1482,7 @@ void test_efa_rdm_ep_rx_refill_impl(void **state, int threshold, int rx_size)
 	assert_int_equal(efa_base_ep_get_rx_pool_size(&efa_rdm_ep->base_ep), rx_size);
 
 	/* Grow the rx pool and post rx pkts */
+	ofi_genlock_lock(&efa_rdm_ep->srx_lock);
 	efa_rdm_ep_post_internal_rx_pkts(efa_rdm_ep);
 	assert_int_equal(efa_rdm_ep->efa_rx_pkts_posted, efa_base_ep_get_rx_pool_size(&efa_rdm_ep->base_ep));
 
@@ -1517,7 +1518,7 @@ void test_efa_rdm_ep_rx_refill_impl(void **state, int threshold, int rx_size)
 	assert_int_equal(efa_rdm_ep->efa_rx_pkts_posted, rx_size - MIN(rx_size, threshold));
 
 	efa_rdm_ep_bulk_post_internal_rx_pkts(efa_rdm_ep);
-
+	ofi_genlock_unlock(&efa_rdm_ep->srx_lock);
 	/**
 	 * efa_rx_pkts_to_post == min(FI_EFA_RX_REFILL_THRESHOLD, FI_EFA_RX_SIZE)
 	 * pkts should be refilled

--- a/prov/efa/test/efa_unit_test_ope.c
+++ b/prov/efa/test/efa_unit_test_ope.c
@@ -1167,18 +1167,20 @@ void test_efa_rdm_ope_ack_packet_tracking_wait_send_common(void **state, int pkt
 	struct efa_resource *resource = *state;
 	struct efa_rdm_ope *rxe;
 	struct efa_rdm_ep *efa_rdm_ep;
+	struct efa_cq *efa_cq;
 
 	test_efa_rdm_ope_ack_packet_tracking_common(resource, pkt_type, 0, IBV_WC_SUCCESS, 0, &rxe);
 
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	efa_cq = container_of(resource->cq, struct efa_cq, util_cq.cq_fid);
 
 	/* It should post a RECEIPT packet and add the rxe to the list */
 	assert_false(dlist_empty(&efa_rdm_ep->ope_posted_ack_list));
 
 	/* Poll the cq via wait_send */
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	ofi_genlock_lock(&efa_cq->util_cq.ep_list_lock);
 	efa_rdm_ep_wait_send(efa_rdm_ep);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	ofi_genlock_unlock(&efa_cq->util_cq.ep_list_lock);
 
 	/* The cq poll should remove the rxe from the list */
 	assert_true(dlist_empty(&efa_rdm_ep->ope_posted_ack_list));
@@ -1219,10 +1221,12 @@ void test_efa_rdm_ope_ack_packet_tracking_unresponsive_wait_send_common(void **s
 	struct efa_resource *resource = *state;
 	struct efa_rdm_ep *efa_rdm_ep;
 	struct efa_rdm_ope *rxe, *rxe2;
+	struct efa_cq *efa_cq;
 
 	test_efa_rdm_ope_ack_packet_tracking_common(resource, pkt_type, 0, IBV_WC_GENERAL_ERR, EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE, &rxe);
 
 	efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	efa_cq = container_of(resource->cq, struct efa_cq, util_cq.cq_fid);
 
 	/*
 	 * Call the 1st efa_rdm_ep_wait_send.
@@ -1230,9 +1234,9 @@ void test_efa_rdm_ope_ack_packet_tracking_unresponsive_wait_send_common(void **s
 	 * Then it will not try to poll the cq again because of the peer becomes
 	 * unresponsive. See logic in efa_rdm_ep_close_should_wait_send()
 	 */
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	ofi_genlock_lock(&efa_cq->util_cq.ep_list_lock);
 	efa_rdm_ep_wait_send(efa_rdm_ep);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	ofi_genlock_unlock(&efa_cq->util_cq.ep_list_lock);
 	assert_true(!!(rxe->peer->flags & EFA_RDM_PEER_UNRESP));
 
 	/* Now posting another ctrl packet against the same unresponsive peer */
@@ -1248,9 +1252,9 @@ void test_efa_rdm_ope_ack_packet_tracking_unresponsive_wait_send_common(void **s
 	will_return_int_maybe(efa_mock_efa_ibv_cq_start_poll_return_mock, ENOENT);
 
 	/* Kick off the second wait_send, which should NOT try to progress more because of the unresp peer */
-	ofi_genlock_lock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	ofi_genlock_lock(&efa_cq->util_cq.ep_list_lock);
 	efa_rdm_ep_wait_send(efa_rdm_ep);
-	ofi_genlock_unlock(&efa_rdm_ep_rdm_domain(efa_rdm_ep)->srx_lock);
+	ofi_genlock_unlock(&efa_cq->util_cq.ep_list_lock);
 	assert_int_equal(efa_unit_test_get_dlist_length(&efa_rdm_ep->ope_posted_ack_list), 1);
 }
 

--- a/prov/efa/test/efa_unit_test_srx.c
+++ b/prov/efa/test/efa_unit_test_srx.c
@@ -52,21 +52,18 @@ void test_efa_srx_cq(void **state)
         assert_true((void *) &srx_ctx->cq->cq_fid == (void *) resource->cq);
 }
 
-/* This test verified that srx_lock created in efa_domain is correctly passed to srx */
+/* This test verified that the per-ep util_ep lock is correctly passed to srx */
 void test_efa_srx_lock(void **state)
 {
         struct efa_resource *resource = *state;
         struct efa_rdm_ep *efa_rdm_ep;
         struct util_srx_ctx *srx_ctx;
-        struct efa_domain *efa_domain;
 
         efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
 
         efa_rdm_ep = container_of(resource->ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
         srx_ctx = efa_rdm_ep_get_peer_srx_ctx(efa_rdm_ep);
-        efa_domain = container_of(resource->domain, struct efa_domain,
-				  util_domain.domain_fid.fid);
-        assert_true(((void *) srx_ctx->lock == (void *) &((struct efa_rdm_domain *) efa_domain)->srx_lock));
+        assert_true(((void *) srx_ctx->lock == (void *) &efa_rdm_ep->srx_lock));
 }
 
 

--- a/prov/shm/src/smr.h
+++ b/prov/shm/src/smr.h
@@ -45,6 +45,7 @@ struct smr_ep {
 	uint64_t		msg_id;
 	struct smr_region	*volatile region;
 	struct fid_peer_srx	*srx;
+	struct ofi_genlock	*srx_lock;
 	struct smr_map		*map;
 	struct ofi_bufpool	*cmd_ctx_pool;
 	struct ofi_bufpool	*unexp_buf_pool;

--- a/prov/shm/src/smr_atomic.c
+++ b/prov/shm/src/smr_atomic.c
@@ -225,7 +225,7 @@ static ssize_t smr_generic_atomic(
 	rx_id = smr_peer_data(ep->region)[tx_id].id;
 	peer_smr = smr_peer_region(ep, tx_id);
 
-	ofi_genlock_lock(&ep->util_ep.lock);
+	ofi_genlock_lock(ep->srx_lock);
 	if (smr_peer_data(ep->region)[tx_id].sar_status) {
 		ret = -FI_EAGAIN;
 		goto unlock;
@@ -315,7 +315,7 @@ static ssize_t smr_generic_atomic(
 			"unable to process tx completion\n");
 
 unlock:
-	ofi_genlock_unlock(&ep->util_ep.lock);
+	ofi_genlock_unlock(ep->srx_lock);
 	return ret;
 }
 
@@ -411,7 +411,7 @@ static ssize_t smr_atomic_inject(
 	peer_id = smr_peer_data(ep->region)[id].id;
 	peer_smr = smr_peer_region(ep, id);
 
-	ofi_genlock_lock(&ep->util_ep.lock);
+	ofi_genlock_lock(ep->srx_lock);
 	if (smr_peer_data(ep->region)[id].sar_status) {
 		ret = -FI_EAGAIN;
 		goto unlock;
@@ -452,7 +452,7 @@ static ssize_t smr_atomic_inject(
 	smr_cmd_queue_commit(ce, pos);
 	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_atomic);
 unlock:
-	ofi_genlock_unlock(&ep->util_ep.lock);
+	ofi_genlock_unlock(ep->srx_lock);
 	return ret;
 }
 

--- a/prov/shm/src/smr_ep.c
+++ b/prov/shm/src/smr_ep.c
@@ -886,6 +886,12 @@ create_shm:
 			ep->util_ep.ep_fid.msg = &smr_no_recv_msg_ops;
 			ep->util_ep.ep_fid.tagged = &smr_no_recv_tag_ops;
 		}
+
+		if (ep->srx->ep_fid.fid.fclass == FI_CLASS_SRX_CTX &&
+		    ep->srx->ep_fid.fid.context)
+			ep->srx_lock = ((struct util_srx_ctx *)
+						ep->srx->ep_fid.fid.context)->lock;
+
 		smr_ep_map_all_peers(ep);
 
 		if (smr_env.use_dsa_sar)
@@ -1022,6 +1028,10 @@ int smr_endpoint(struct fid_domain *domain, struct fi_info *info,
 
 	ep->util_ep.ep_fid.msg = &smr_msg_ops;
 	ep->util_ep.ep_fid.tagged = &smr_tag_ops;
+
+	/* Default the serialization lock to the endpoint's own lock. It is
+	 * updated to the SRX context lock at FI_ENABLE once ep->srx is set. */
+	ep->srx_lock = &ep->util_ep.lock;
 
 	ret = smr_create_pools(ep, info);
 	if (ret)

--- a/prov/shm/src/smr_msg.c
+++ b/prov/shm/src/smr_msg.c
@@ -95,7 +95,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	rx_id = smr_peer_data(ep->region)[tx_id].id;
 	peer_smr = smr_peer_region(ep, tx_id);
 
-	ofi_genlock_lock(&ep->util_ep.lock);
+	ofi_genlock_lock(ep->srx_lock);
 	if (smr_peer_data(ep->region)[tx_id].sar_status)
 		goto unlock;
 
@@ -149,7 +149,7 @@ static ssize_t smr_generic_sendmsg(struct smr_ep *ep, const struct iovec *iov,
 	}
 
 unlock:
-	ofi_genlock_unlock(&ep->util_ep.lock);
+	ofi_genlock_unlock(ep->srx_lock);
 	return ret;
 }
 
@@ -220,7 +220,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	rx_id = smr_peer_data(ep->region)[tx_id].id;
 	peer_smr = smr_peer_region(ep, tx_id);
 
-	ofi_genlock_lock(&ep->util_ep.lock);
+	ofi_genlock_lock(ep->srx_lock);
 	if (smr_peer_data(ep->region)[tx_id].sar_status) {
 		ret = -FI_EAGAIN;
 		goto unlock;
@@ -248,7 +248,7 @@ static ssize_t smr_generic_inject(struct fid_ep *ep_fid, const void *buf,
 	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, op);
 
 unlock:
-	ofi_genlock_unlock(&ep->util_ep.lock);
+	ofi_genlock_unlock(ep->srx_lock);
 	return ret;
 }
 

--- a/prov/shm/src/smr_progress.c
+++ b/prov/shm/src/smr_progress.c
@@ -1506,10 +1506,17 @@ void smr_ep_progress(struct util_ep *util_ep)
 	if (!ep->region)
 		return;
 
-	/* ep->util_ep.lock is used to serialize the message/tag matching.
+	/* ep->srx_lock is used to serialize the message/tag matching.
 	 * We keep the lock until the matching is complete. This will
 	 * ensure that commands are matched in the order they are
 	 * received, if there are multiple progress threads.
+	 *
+	 * This is the SRX context's lock. When shm owns the SRX it is
+	 * shm's own endpoint lock; when shm is a peer provider it is the
+	 * owner-provided lock. Locking it here satisfies the util_srx
+	 * owner ops (get/queue/free_entry) which assert this lock is held,
+	 * and lets shm self-serialize without the owner needing to hold
+	 * shm's endpoint lock across fi_cq_read().
 	 *
 	 * This lock should be low cost because it's only used by this
 	 * single process. It is also optimized to be a noop if
@@ -1518,7 +1525,7 @@ void smr_ep_progress(struct util_ep *util_ep)
 	 * Other processes are free to post on the queue without the need
 	 * for locking the queue.
 	 */
-	ofi_genlock_lock(&ep->util_ep.lock);
+	ofi_genlock_lock(ep->srx_lock);
 
 	if (smr_env.use_dsa_sar)
 		smr_dsa_progress(ep);
@@ -1534,5 +1541,5 @@ void smr_ep_progress(struct util_ep *util_ep)
 	 * independent of any action by the provider */
 	ep->smr_progress_async(ep);
 
-	ofi_genlock_unlock(&ep->util_ep.lock);
+	ofi_genlock_unlock(ep->srx_lock);
 }

--- a/prov/shm/src/smr_rma.c
+++ b/prov/shm/src/smr_rma.c
@@ -146,7 +146,7 @@ static ssize_t smr_generic_rma(
 	rx_id = smr_peer_data(ep->region)[tx_id].id;
 	peer_smr = smr_peer_region(ep, tx_id);
 
-	ofi_genlock_lock(&ep->util_ep.lock);
+	ofi_genlock_lock(ep->srx_lock);
 	if (smr_peer_data(ep->region)[tx_id].sar_status)
 		goto unlock;
 
@@ -206,7 +206,7 @@ static ssize_t smr_generic_rma(
 	}
 
 unlock:
-	ofi_genlock_unlock(&ep->util_ep.lock);
+	ofi_genlock_unlock(ep->srx_lock);
 	return ret;
 }
 
@@ -343,7 +343,7 @@ static ssize_t smr_generic_rma_inject(
 	rx_id = smr_peer_data(ep->region)[tx_id].id;
 	peer_smr = smr_peer_region(ep, tx_id);
 
-	ofi_genlock_lock(&ep->util_ep.lock);
+	ofi_genlock_lock(ep->srx_lock);
 	if (smr_peer_data(ep->region)[tx_id].sar_status)
 		goto unlock;
 
@@ -375,7 +375,7 @@ static ssize_t smr_generic_rma_inject(
 
 	ofi_ep_peer_tx_cntr_inc(&ep->util_ep, ofi_op_write);
 unlock:
-	ofi_genlock_unlock(&ep->util_ep.lock);
+	ofi_genlock_unlock(ep->srx_lock);
 	return ret;
 }
 


### PR DESCRIPTION
FI_THREAD_SAFE applications contend on the domain srx lock. Move it to ep level so the send path is fully parallel across threads.
Use srx lock to serialize SHM's datapath and rx matching.