### PR TITLE
prov/cxi: allow FI_REMOTE_CQ_DATA on fi_writemsg

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -101,6 +101,7 @@
 					 FI_COMPLETION | \
 					 FI_MORE | \
 					 FI_FENCE | \
+					 FI_REMOTE_CQ_DATA | \
 					 CXIP_TX_COMP_MODES)
 #define CXIP_READMSG_ALLOWED_FLAGS	(FI_COMPLETION | \
 					 FI_MORE | \


### PR DESCRIPTION
fi_writemsg() validates its flags argument against CXIP_WRITEMSG_ALLOWED_FLAGS and rejects anything else with -FI_EBADFLAGS. That mask did not include FI_REMOTE_CQ_DATA, so any caller using fi_writemsg() the documented way -- populating struct fi_msg_rma.data and passing FI_REMOTE_CQ_DATA in flags to request a target-side completion with immediate data -- was rejected outright, even though the flag is otherwise fully supported by the provider.

fi_writedata() is a thin wrapper that calls the same underlying cxip_rma_common()/cxip_rma_writemsg() path and sets FI_REMOTE_CQ_DATA itself, bypassing this flags check entirely, which is why fi_writedata worked while the semantically equivalent fi_writemsg() call did not. cxip_rma_common(), cxip_rma_is_unrestricted(), and cxip_rma_is_idc() all already handle FI_REMOTE_CQ_DATA correctly (forcing unrestricted, DMA-based sends so the target NIC generates the completion event), confirming this was strictly a missing entry in the allowed-flags mask rather than a deeper functional gap.

Add FI_REMOTE_CQ_DATA to CXIP_WRITEMSG_ALLOWED_FLAGS so fi_writemsg() can be used with immediate data exactly as documented, including in combination with FI_INJECT and the various completion-level flags (FI_INJECT_COMPLETE, FI_TRANSMIT_COMPLETE, FI_DELIVERY_COMPLETE, FI_COMMIT_COMPLETE) already permitted by the mask.

Verified on real Slingshot/CXI hardware across two nodes: fi_writemsg() with FI_REMOTE_CQ_DATA previously failed immediately with "Flags not supported" (-FI_EBADFLAGS); after this change it completes successfully and the target reaps the expected fi_cq_data_entry with FI_REMOTE_CQ_DATA set and the correct immediate data value, matching fi_writedata()'s behavior. Also confirmed with FI_INJECT and FI_DELIVERY_COMPLETE combined with FI_REMOTE_CQ_DATA on the same hardware.