### PR TITLE
prov/efa: Make util_domain lock noop under FI_PROGRESS_CONTROL_UNIFIED

### DIFF
--- a/prov/efa/src/efa_domain_util.c
+++ b/prov/efa/src/efa_domain_util.c
@@ -55,6 +55,7 @@ int efa_domain_init_base(struct efa_domain *efa_domain,
 			 void *context)
 	OFI_TSA_NO_ANALYSIS
 {
+	enum ofi_lock_type lock_type;
 	int err;
 
 	/* This list_entry is not the head of the list. But we initialize it
@@ -66,8 +67,14 @@ int efa_domain_init_base(struct efa_domain *efa_domain,
 	efa_domain->fabric = container_of(fabric_fid, struct efa_fabric,
 					  util_fabric.fabric_fid);
 
+	lock_type = info->domain_attr->threading == FI_THREAD_DOMAIN &&
+			    info->domain_attr->control_progress ==
+				    FI_PROGRESS_CONTROL_UNIFIED ?
+			    OFI_LOCK_NOOP :
+			    OFI_LOCK_MUTEX;
+
 	err = ofi_domain_init(fabric_fid, info, &efa_domain->util_domain,
-			      context, OFI_LOCK_MUTEX);
+			      context, lock_type);
 	if (err)
 		return err;
 

--- a/prov/efa/test/efa_unit_test_domain.c
+++ b/prov/efa/test/efa_unit_test_domain.c
@@ -604,3 +604,43 @@ void test_efa_domain_gda_ops_rejected_for_dgram(void **state)
 			  (void **)&efa_gda_ops, NULL);
 	assert_int_equal(ret, -FI_EOPNOTSUPP);
 }
+
+/**
+ * @brief Verify util_domain.lock uses no-op locking with FI_THREAD_DOMAIN and
+ *        FI_PROGRESS_CONTROL_UNIFIED
+ *
+ * @param[in] state struct efa_resource managed by the framework
+ */
+void test_efa_domain_lock_type_no_op(void **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_domain *efa_domain;
+
+	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_FABRIC_NAME);
+	assert_non_null(resource->hints);
+	resource->hints->domain_attr->progress = FI_PROGRESS_CONTROL_UNIFIED;
+	resource->hints->domain_attr->threading = FI_THREAD_DOMAIN;
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(2, 0), resource->hints, false, true);
+
+	efa_domain = container_of(resource->domain, struct efa_domain, util_domain.domain_fid);
+	assert_int_equal(efa_domain->util_domain.lock.lock_type, OFI_LOCK_NOOP);
+}
+
+/**
+ * @brief Verify util_domain.lock uses mutex locking with just FI_THREAD_DOMAIN
+ *
+ * @param[in] state struct efa_resource managed by the framework
+ */
+void test_efa_domain_lock_type_mutex(void **state)
+{
+	struct efa_resource *resource = *state;
+	struct efa_domain *efa_domain;
+
+	resource->hints = efa_unit_test_alloc_hints(FI_EP_RDM, EFA_FABRIC_NAME);
+	assert_non_null(resource->hints);
+	resource->hints->domain_attr->threading = FI_THREAD_DOMAIN;
+	efa_unit_test_resource_construct_with_hints(resource, FI_EP_RDM, FI_VERSION(2, 0), resource->hints, false, true);
+
+	efa_domain = container_of(resource->domain, struct efa_domain, util_domain.domain_fid);
+	assert_int_equal(efa_domain->util_domain.lock.lock_type, OFI_LOCK_MUTEX);
+}

--- a/prov/efa/test/efa_unit_tests.c
+++ b/prov/efa/test/efa_unit_tests.c
@@ -600,6 +600,8 @@ int main(void)
 		cmocka_unit_test_setup_teardown(test_efa_domain_open_installs_base_domain_ops_efa_direct, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_domain_open_installs_base_domain_ops_dgram, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		cmocka_unit_test_setup_teardown(test_efa_domain_gda_ops_rejected_for_dgram, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_domain_lock_type_no_op, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
+		cmocka_unit_test_setup_teardown(test_efa_domain_lock_type_mutex, efa_unit_test_mocks_setup, efa_unit_test_mocks_teardown),
 		/* end efa_unit_test_domain.c */
 
 		/* begin efa_unit_test_rdm_domain.c */

--- a/prov/efa/test/efa_unit_tests.h
+++ b/prov/efa/test/efa_unit_tests.h
@@ -449,6 +449,8 @@ void test_efa_domain_dgram_mr_ops(void **state);
 void test_efa_domain_open_installs_base_domain_ops_efa_direct(void **state);
 void test_efa_domain_open_installs_base_domain_ops_dgram(void **state);
 void test_efa_domain_gda_ops_rejected_for_dgram(void **state);
+void test_efa_domain_lock_type_no_op(void **state);
+void test_efa_domain_lock_type_mutex(void **state);
 /* end efa_unit_test_domain.c */
 
 /* begin efa_unit_test_fabric.c */


### PR DESCRIPTION
Under FI_THREAD_DOMAIN, the application serializes all access to objects under the domain, and FI_PROGRESS_CONTROL_UNIFIED forbids progressing the control interface concurrently with data progress. Together they make the domain-wide lock redundant, make it noop similar to util_av lock.