### PR TITLE
fabtests,prov/tcp: Fix memory leaks and a SEGV found by ASan/LSan

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -2092,9 +2092,11 @@ static int getaddr(char *node, char *service,
 	hints->addr_format = fi->addr_format;
 
 	if (flags & FI_SOURCE) {
+		free(hints->src_addr);
 		ret = dupaddr(&hints->src_addr, &hints->src_addrlen,
 				fi->src_addr, fi->src_addrlen);
 	} else {
+		free(hints->dest_addr);
 		ret = dupaddr(&hints->dest_addr, &hints->dest_addrlen,
 				fi->dest_addr, fi->dest_addrlen);
 	}

--- a/fabtests/functional/multi_ep.c
+++ b/fabtests/functional/multi_ep.c
@@ -424,6 +424,7 @@ static int setup_client_ep(int idx)
 static int setup_server_ep(int idx)
 {
 	int ret, av_bind_idx = idx, cq_bind_idx = idx;
+	struct fi_info *prev_fi = fi;
 
 	if (shared_cq)
 		cq_bind_idx = 0;
@@ -434,6 +435,9 @@ static int setup_server_ep(int idx)
 	ret = ft_retrieve_conn_req(eq, &fi);
 	if (ret)
 		goto failed_accept;
+
+	if (prev_fi)
+		fi_freeinfo(prev_fi);
 
 	ret = fi_endpoint(domain, fi, &eps[idx], NULL);
 	if (ret) {

--- a/fabtests/functional/multi_ep.c
+++ b/fabtests/functional/multi_ep.c
@@ -72,10 +72,7 @@ static void free_ep_res()
 	int i;
 
 	for (i = 0; i < num_eps; i++) {
-		if (!fi)
-			continue;
-
-		if (fi->domain_attr->mr_mode & FI_MR_RAW)
+		if (fi && fi->domain_attr->mr_mode & FI_MR_RAW)
 			(void) fi_mr_unmap_key(domain, peer_iovs[i].key);
 
 		FT_CLOSE_FID(send_mrs[i]);

--- a/prov/tcp/src/xnet_domain.c
+++ b/prov/tcp/src/xnet_domain.c
@@ -177,8 +177,9 @@ xnet_mplex_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 {
 	struct xnet_domain *domain;
 	struct fid_list_entry *item;
-	struct fid_mr *sub_mr_fid;
+	struct xnet_domain *subdomain;
 	struct ofi_mr *mr;
+	uint64_t sub_key;
 	int ret;
 
 	domain = container_of(fid, struct xnet_domain,
@@ -190,10 +191,23 @@ xnet_mplex_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 	mr = container_of(*mr_fid, struct ofi_mr, mr_fid.fid);
 	mr->mr_fid.fid.ops = &xnet_mplex_mr_fi_ops;
 
+	/* Register directly into each subdomain's mr map, rather than
+	 * creating a separate fid_mr per subdomain (as done for a normal
+	 * fi_mr_regattr()).  The subdomain only needs the mr map entry to
+	 * translate keys; there's no fid to expose to the application, and
+	 * no fid means nothing to leak -- the mr map entries are freed when
+	 * the subdomain's mr map is destroyed or when the entry is removed
+	 * from xnet_subdomains_mr_close().
+	 */
 	ofi_genlock_lock(&domain->subdomain_list_lock);
 	dlist_foreach_container(&domain->subdomain_list,
 				struct fid_list_entry, item, entry) {
-		ret = xnet_mr_regattr(item->fid, attr, flags, &sub_mr_fid);
+		subdomain = container_of(item->fid, struct xnet_domain,
+					 util_domain.domain_fid.fid);
+		ofi_genlock_lock(&subdomain->util_domain.lock);
+		ret = ofi_mr_map_insert(&subdomain->util_domain.mr_map, attr,
+					&sub_key, mr, flags);
+		ofi_genlock_unlock(&subdomain->util_domain.lock);
 		if (ret) {
 			FI_WARN(&xnet_prov, FI_LOG_MR,
 				"Failed to reg mr (%" PRIu64 ") from subdomain (%p)\n",
@@ -203,6 +217,8 @@ xnet_mplex_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 			(void) ofi_mr_close(&(*mr_fid)->fid);
 			break;
 		}
+
+		ofi_atomic_inc32(&subdomain->util_domain.ref);
 	}
 
 	ofi_genlock_unlock(&domain->subdomain_list_lock);

--- a/prov/tcp/src/xnet_domain.c
+++ b/prov/tcp/src/xnet_domain.c
@@ -311,6 +311,7 @@ static int xnet_mplex_domain_close(fid_t fid)
 
 	ofi_genlock_destroy(&domain->subdomain_list_lock);
 	xnet_close_progress(&domain->progress);
+	fi_freeinfo(domain->subdomain_info);
 	ofi_domain_close(&domain->util_domain);
 	free(domain);
 	return FI_SUCCESS;

--- a/prov/tcp/src/xnet_domain.c
+++ b/prov/tcp/src/xnet_domain.c
@@ -310,6 +310,7 @@ static int xnet_mplex_domain_close(fid_t fid)
 	ofi_genlock_unlock(&domain->subdomain_list_lock);
 
 	ofi_genlock_destroy(&domain->subdomain_list_lock);
+	xnet_close_progress(&domain->progress);
 	ofi_domain_close(&domain->util_domain);
 	free(domain);
 	return FI_SUCCESS;
@@ -370,10 +371,21 @@ static int xnet_domain_mplex_open(struct fid_fabric *fabric_fid, struct fi_info 
 	if (ret)
 		goto close;
 
+	/* The mplex domain itself never runs a progress engine -- only its
+	 * subdomains do.  However, an srx context may be created against
+	 * this domain (and later closed) before it has been associated
+	 * with a subdomain (e.g. if endpoint enable fails or never
+	 * happens), so we still need a valid, initialized progress
+	 * instance to avoid dereferencing a NULL active_lock.
+	 */
+	ret = xnet_init_progress(&domain->progress, info);
+	if (ret)
+		goto free_subdomain_lock;
+
 	domain->subdomain_info = fi_dupinfo(info);
 	if (!domain->subdomain_info) {
 		ret = -FI_ENOMEM;
-		goto free_lock;
+		goto close_progress;
 	}
 
 	domain->subdomain_info->domain_attr->threading = FI_THREAD_DOMAIN;
@@ -386,7 +398,9 @@ static int xnet_domain_mplex_open(struct fid_fabric *fabric_fid, struct fi_info 
 	*domain_fid = &domain->util_domain.domain_fid;
 	return FI_SUCCESS;
 
-free_lock:
+close_progress:
+	xnet_close_progress(&domain->progress);
+free_subdomain_lock:
 	ofi_genlock_destroy(&domain->subdomain_list_lock);
 close:
 	ofi_domain_close(&domain->util_domain);


### PR DESCRIPTION
## Summary

Running `runfabtests.sh tcp -t quick` under AddressSanitizer/LeakSanitizer
surfaced 14 leak reports and 1 crash. This branch fixes all of them with 6
independently-verified commits: 3 in `fabtests` and 3 in the `tcp` (xnet)
provider. After these fixes, `runfabtests.sh tcp -t quick` under ASan/LSan
reports **0 leaks and 0 crashes**.

## Commits

### 1. `fabtests: fix memory leak of previously duplicated addr in getaddr()`
`getaddr()`/`dupaddr()` in `fabtests/common/shared.c` overwrote a
previously-allocated duplicated address without freeing it first, leaking
one allocation per call in tests that call `getaddr()` more than once
(e.g. `fi_rdm_multi_client`).

### 2. `fabtests/multi_ep: fix leak of tx/rx buffers when fi is NULL in free_ep_res()`
`free_ep_res()` in `fabtests/functional/multi_ep.c` skipped freeing the
tx/rx buffers when the associated `fi_info` was NULL, leaking those
buffers for endpoints that never obtained a valid `fi_info`.

### 3. `fabtests/multi_ep: free previous fi before overwriting in setup_server_ep()`
`setup_server_ep()` in `fabtests/functional/multi_ep.c` overwrote its `fi`
pointer with the result of a new `fi_getinfo()` call without freeing the
previous `fi_info`, leaking it.

### 4. `prov/tcp: fix SEGV in xnet_srx_close() for multiplexed rdm domains`
**Crash fix.** When `FI_THREAD_COMPLETION` is requested for an `FI_EP_RDM`
domain, xnet multiplexes the domain into per-endpoint subdomains
(`xnet_domain_mplex_open()`). The top-level multiplexed ("mplex") domain
itself never runs a progress engine — only its subdomains do — so
`xnet_domain_mplex_open()` never called `xnet_init_progress()`, leaving
`domain->progress` zero-initialized (from `calloc`), including a NULL
`active_lock`.

An SRX context is created against this mplex domain at rdm creation time
(`xnet_rdm.c`: `fi_srx_context(&rdm->util_ep.domain->domain_fid, ...)`),
before the rdm endpoint is enabled and its `srx->domain` is reassigned to
the appropriate subdomain (`xnet_rdm_resolve_domains()`). If the endpoint
is closed before that reassignment happens (e.g. the application fails to
enable it), `xnet_srx_close()` dereferences
`xnet_srx2_progress(srx)->active_lock`, which is NULL, causing a SEGV.

Fixed by initializing (and correspondingly tearing down) a real progress
instance for the mplex domain too, mirroring the non-multiplexed domain
path.

This crash was masking 4 of the original 14 leak reports (all
`fi_multi_ep -e rdm --threading completion` variants), since the client
process crashed before it could clean up.

### 5. `prov/tcp: free subdomain_info in xnet_mplex_domain_close()`
`xnet_domain_mplex_open()` duplicates the `fi_info` used to open
per-endpoint subdomains into `domain->subdomain_info` via `fi_dupinfo()`,
but `xnet_mplex_domain_close()` never freed it, leaking the duplicated
`fi_info` (and its nested allocations) every time a multiplexed
(`FI_THREAD_COMPLETION`) rdm domain was closed.

### 6. `prov/tcp: fix mr leak in xnet_mplex_mr_regattr()`
When registering an MR against a multiplexed (`FI_THREAD_COMPLETION`) rdm
domain, `xnet_mplex_mr_regattr()` propagated the registration to each
subdomain by calling `xnet_mr_regattr()`, which allocates a full
`struct ofi_mr` (`fid_mr`) per subdomain. That per-subdomain `fid_mr` was
immediately discarded without being stored or closed, leaking the
allocation.

Subdomains only need an mr map entry to translate keys during progress —
there's no fid to expose to the application. Fixed by registering directly
into each subdomain's mr map via `ofi_mr_map_insert()`, matching the
existing `xnet_reg_subdomain_mr()` pattern used when a new subdomain is
created after an MR is already registered.

## Testing

Verified with:
```
runfabtests.sh tcp -p <install>/bin -vv -T 10 -t quick
```
under ASan/LSan, run multiple times for stability, both incrementally
(one fix at a time) and with the final combined state:

- Before: 14 leak reports + 1 SEGV (masking 4 of the leak reports).
- After: 0 leak reports, 0 crashes.
- The 7 remaining "Fail" results (`fi_multi_ep -e rdm ...` variants) are a
  pre-existing, unrelated `fi_getinfo` `ENODATA` issue in the test itself,
  not a leak or crash, and are unaffected by this branch.