### PR TITLE
fabtests/pytest: Only run device_to_device memory types in PR CI

### DIFF
--- a/fabtests/pytest/common.py
+++ b/fabtests/pytest/common.py
@@ -929,6 +929,34 @@ def test_selected_by_marker(config, test_markers, name):
     return with_marker and not without_marker
 
 
+def filter_memory_types_for_pr_ci(candidates):
+    """
+    Reduce a memory type candidate list to what the PR CI suite runs.
+
+    PR CI only needs the symmetric permutations: the device_to_device flavors
+    (cuda_to_cuda, neuron_to_neuron, ...) plus host_to_host as the fallback for
+    endpoints without an accelerator.  The mixed host<->device permutations
+    (host_to_cuda, cuda_to_host, ...) exercise the same hmem paths with one
+    endpoint on host memory and are covered by the default (non PR CI) runs.
+
+    host_to_host is kept here regardless of what the endpoints have; dropping
+    it when an accelerator is present is left to
+    pick_preferred_memory_flavor(), which is the only place with device
+    detection results.
+
+    Returns the input unchanged when no symmetric permutation exists, so a
+    test declaring only mixed memory types keeps its coverage instead of
+    being parametrized with an empty list.
+    """
+    symmetric = []
+    for param in candidates:
+        source, destination = param.values[0].split("_to_")
+        if source == destination:
+            symmetric.append(param)
+
+    return symmetric or candidates
+
+
 def client_server_have_device(memory_token, server_id, client_id):
     """
     Return True if both client and server endpoints named in a memory-type

--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -5,6 +5,7 @@ import time
 from retrying import retry
 from common import (
     client_server_have_device,
+    filter_memory_types_for_pr_ci,
     num_hmem_devices,
     test_selected_by_marker,
     has_ssh_connection_err_msg,
@@ -127,7 +128,7 @@ def pick_preferred_memory_flavor(candidates, detected):
     return accelerator or host_only
 
 
-def add_memory_type_parametrization(metafunc, memory_type_marker):
+def add_memory_type_parametrization(metafunc, memory_type_marker, test_type):
     """
     Parametrize the memory_type fixture at collection time from the test's
     @pytest.mark.memory_type(...) declaration, dropping any permutation whose
@@ -136,6 +137,12 @@ def add_memory_type_parametrization(metafunc, memory_type_marker):
     Fallback (no coverage regression): if --server-id/--client-id are not
     provided or device detection fails, every candidate memory type is
     included and the runtime skip in common.py remains the safety net.
+
+    For test_type "pr_ci" only the symmetric permutations are kept
+    (host_to_host, cuda_to_cuda, neuron_to_neuron, ...); see
+    filter_memory_types_for_pr_ci().  PR CI also implies
+    prefer_accelerator=True, so host_to_host runs only on endpoints without
+    an accelerator.
 
     prefer_accelerator=True picks one memory flavor at generation time to
     reduce the test count; see pick_preferred_memory_flavor().
@@ -154,6 +161,13 @@ def add_memory_type_parametrization(metafunc, memory_type_marker):
 
     candidates = memory_type_marker.args[0]
     prefer_accelerator = memory_type_marker.kwargs.get("prefer_accelerator", False)
+
+    # PR CI runs device_to_device only, so drop the mixed permutations before
+    # the (SSH based) device detection below, and fall back to host_to_host
+    # only when the endpoints have no accelerator.
+    if test_type == "pr_ci":
+        candidates = filter_memory_types_for_pr_ci(candidates)
+        prefer_accelerator = True
 
     server_id = metafunc.config.getoption("--server-id", default=None)
     client_id = metafunc.config.getoption("--client-id", default=None)
@@ -201,7 +215,7 @@ def pytest_generate_tests(metafunc):
 
     # parametrize memory_type from its marker, dropping permutations
     # whose device is absent on the owning endpoint
-    add_memory_type_parametrization(metafunc, memory_type_marker)
+    add_memory_type_parametrization(metafunc, memory_type_marker, test_type)
 
 hmem_type_list = [
     pytest.param("cuda", marks=pytest.mark.cuda_memory),

--- a/fabtests/pytest/efa/test_unexpected_msg.py
+++ b/fabtests/pytest/efa/test_unexpected_msg.py
@@ -12,8 +12,8 @@ SHM_DEFAULT_RX_SIZE = 1024
 @pytest.mark.parametrize("msg_size", [1, 512, 9000, 1048576]) # cover various switch points of shm/efa protocols
 @pytest.mark.parametrize("msg_count", [1, 1024, 2048]) # below and above shm's default rx size
 @pytest.mark.memory_type(memory_type_list_all)
-def test_unexpected_msg(cmdline_args, msg_size, msg_count, memory_type, completion_semantic):
-    from common import ClientServerTest
+def test_unexpected_msg(cmdline_args, msg_size, msg_count, memory_type, completion_semantic, request):
+    from common import ClientServerTest, test_selected_by_marker
     if cmdline_args.server_id == cmdline_args.client_id:
         if (msg_size > SHM_DEFAULT_MAX_INJECT_SIZE or memory_type != "host_to_host" or completion_semantic == "delivery_complete") and msg_count > SHM_DEFAULT_RX_SIZE:
             pytest.skip("SHM's CMA/IPC protocol currently cannot handle > rx size number of unexpected messages")
@@ -28,6 +28,18 @@ def test_unexpected_msg(cmdline_args, msg_size, msg_count, memory_type, completi
     maximal_mr_size = 2**32
     if allocated_memory >= maximal_mr_size:
         pytest.skip("Cannot hit EFA MR limit")
+
+    # A 2GB working set (1MB x 1024) costs 0.8 to 1.6 min per case on device
+    # memory, because every transfer bounces through a host buffer on instances
+    # without GPUDirect RDMA. The protocol under test does not change with the
+    # working set size, so skip it in PR CI. host_to_host still covers every
+    # size and the nightly runs keep the full matrix.
+    pr_ci_maximal_hmem_size = 2**30
+    is_pr_ci = test_selected_by_marker(request.config,
+                                       {m.name for m in request.node.iter_markers()},
+                                       "pr_ci")
+    if is_pr_ci and memory_type != "host_to_host" and allocated_memory >= pr_ci_maximal_hmem_size:
+        pytest.skip("Device memory working set is too slow for PR CI")
 
     efa_run_client_server_test(cmdline_args, f"fi_unexpected_msg -e rdm -M {msg_count}", iteration_type="short",
                                completion_semantic=completion_semantic, memory_type=memory_type,


### PR DESCRIPTION
PR CI parametrizes every memory type permutation an EFA test declares, including the mixed host<->device ones (host_to_cuda, cuda_to_host, ...), and host_to_host. If a GPU exists on the instance, only run device_to_device tests, and drop all other permutations. This is done as a time savings optimization.