### PR TITLE
prov/efa: fix mis-stated vendor ID -> part ID

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_util.c
+++ b/prov/efa/src/rdm/efa_rdm_util.c
@@ -42,7 +42,7 @@ bool efa_rdm_get_use_device_rdma(uint32_t fabric_api_version)
 		}
 
 		if (default_val && !hw_support) {
-			fprintf(stderr, "EFA device with vendor id %x unexpectedly has "
+			fprintf(stderr, "EFA device with part id %x unexpectedly has "
 				"no RDMA support. Application will abort().\n",
 				vendor_part_id);
 			abort();


### PR DESCRIPTION
rdma-core calls the part ID `vendor_part_id`, a shortening of "vendor supplied part ID," which is quite easy to confuse with just "vendor ID," which we did here. The help message is really referring to a part ID, not a vendor ID.