### PR TITLE
fabtests/efa: Skip the slowest device memory unexpected_msg case in PR CI

### DIFF
--- a/fabtests/pytest/efa/test_unexpected_msg.py
+++ b/fabtests/pytest/efa/test_unexpected_msg.py
@@ -12,8 +12,8 @@ SHM_DEFAULT_RX_SIZE = 1024
 @pytest.mark.parametrize("msg_size", [1, 512, 9000, 1048576]) # cover various switch points of shm/efa protocols
 @pytest.mark.parametrize("msg_count", [1, 1024, 2048]) # below and above shm's default rx size
 @pytest.mark.memory_type(memory_type_list_all)
-def test_unexpected_msg(cmdline_args, msg_size, msg_count, memory_type, completion_semantic):
-    from common import ClientServerTest
+def test_unexpected_msg(cmdline_args, msg_size, msg_count, memory_type, completion_semantic, request):
+    from common import ClientServerTest, test_selected_by_marker
     if cmdline_args.server_id == cmdline_args.client_id:
         if (msg_size > SHM_DEFAULT_MAX_INJECT_SIZE or memory_type != "host_to_host" or completion_semantic == "delivery_complete") and msg_count > SHM_DEFAULT_RX_SIZE:
             pytest.skip("SHM's CMA/IPC protocol currently cannot handle > rx size number of unexpected messages")
@@ -28,6 +28,18 @@ def test_unexpected_msg(cmdline_args, msg_size, msg_count, memory_type, completi
     maximal_mr_size = 2**32
     if allocated_memory >= maximal_mr_size:
         pytest.skip("Cannot hit EFA MR limit")
+
+    # A 2GB working set (1MB x 1024) costs 0.8 to 1.6 min per case on device
+    # memory, because every transfer bounces through a host buffer on instances
+    # without GPUDirect RDMA. The protocol under test does not change with the
+    # working set size, so skip it in PR CI. host_to_host still covers every
+    # size and the nightly runs keep the full matrix.
+    pr_ci_maximal_hmem_size = 2**30
+    is_pr_ci = test_selected_by_marker(request.config,
+                                       {m.name for m in request.node.iter_markers()},
+                                       "pr_ci")
+    if is_pr_ci and memory_type != "host_to_host" and allocated_memory >= pr_ci_maximal_hmem_size:
+        pytest.skip("Device memory working set is too slow for PR CI")
 
     efa_run_client_server_test(cmdline_args, f"fi_unexpected_msg -e rdm -M {msg_count}", iteration_type="short",
                                completion_semantic=completion_semantic, memory_type=memory_type,


### PR DESCRIPTION
test_unexpected_msg allocates msg_size * 2 * msg_count, so 1MB x 1024 is a 2GB working set costing 0.8 to 1.6 min per case on device memory, 9.7 min of the 64.1 min of test time in a g4dn12xlarge PR CI run. The protocol under test does not change with the working set size, so skip it in PR CI for the accelerator memory types. host_to_host still covers every size and the nightly runs keep the full matrix.