### PR TITLE
fabtests: add check for fi_close return value

### DIFF
--- a/fabtests/component/dmabuf-rdma/fi-mr-reg-xe.c
+++ b/fabtests/component/dmabuf-rdma/fi-mr-reg-xe.c
@@ -132,8 +132,7 @@ err_out:
 
 void dereg_dmabuf_mr(struct nic *nic)
 {
-	if (nic->bufs.dmabuf_mr[0])
-		fi_close(&nic->bufs.dmabuf_mr[0]->fid);
+	DMABUF_CLOSE_FID(nic->bufs.dmabuf_mr[0]);
 }
 
 static void print_opts()

--- a/fabtests/component/dmabuf-rdma/shared.c
+++ b/fabtests/component/dmabuf-rdma/shared.c
@@ -875,37 +875,20 @@ void finalize_ofi(void)
 
 skip_raw_key_cleanup:
 	for (i = 0; i < me.num_nics; i++) {
-		if (nics[i].sync_buf.mr[0])
-			fi_close((fid_t)nics[i].sync_buf.mr[0]);
+		DMABUF_CLOSE_FID(nics[i].sync_buf.mr[0]);
 
 		for (j = 0; j < options.max_ranks; j++) {
-			if (nics[i].proxy_bufs.mr[j])
-				fi_close((fid_t)nics[i].proxy_bufs.mr[j]);
-
-			if (nics[i].bufs.mr[j])
-				fi_close((fid_t)nics[i].bufs.mr[j]);
+			DMABUF_CLOSE_FID(nics[i].proxy_bufs.mr[j]);
+			DMABUF_CLOSE_FID(nics[i].bufs.mr[j]);
 		}
 
-		if (nics[i].ep)
-			fi_close((fid_t)nics[i].ep);
-
-		if (nics[i].av)
-			fi_close((fid_t)nics[i].av);
-
-		if (nics[i].cq)
-			fi_close((fid_t)nics[i].cq);
-
-		if (nics[i].domain)
-			fi_close((fid_t)nics[i].domain);
-
-		if (nics[i].pep)
-			fi_close((fid_t)nics[i].pep);
-
-		if(nics[i].eq)
-			fi_close((fid_t)nics[i].eq);
-
-		if (nics[i].fabric)
-			fi_close((fid_t)nics[i].fabric);
+		DMABUF_CLOSE_FID(nics[i].ep);
+		DMABUF_CLOSE_FID(nics[i].av);
+		DMABUF_CLOSE_FID(nics[i].cq);
+		DMABUF_CLOSE_FID(nics[i].domain);
+		DMABUF_CLOSE_FID(nics[i].pep);
+		DMABUF_CLOSE_FID(nics[i].eq);
+		DMABUF_CLOSE_FID(nics[i].fabric);
 
 		if (nics[i].fi)
 			fi_freeinfo(nics[i].fi);

--- a/fabtests/component/dmabuf-rdma/shared.h
+++ b/fabtests/component/dmabuf-rdma/shared.h
@@ -35,6 +35,19 @@
 #include "util.h"
 #include "ofi_ctx_pool.h"
 
+#define DMABUF_CLOSE_FID(fd)						\
+	do {								\
+		int ret;						\
+		if ((fd)) {						\
+			ret = fi_close(&(fd)->fid);			\
+			if (ret)					\
+				fprintf(stderr,				\
+					"fi_close(%s): %s (%d)\n",	\
+					#fd, fi_strerror(-ret), ret);	\
+			(fd) = NULL;					\
+		}							\
+	} while (0)
+
 #define MAX_NICS		8
 #define MAX_SIZE		(4 * 1024 * 1024)
 #define MIN_PROXY_BLOCK		(131072)

--- a/fabtests/prov/efa/src/efa_gda.c
+++ b/fabtests/prov/efa/src/efa_gda.c
@@ -162,7 +162,7 @@ int create_ext_cq(void **cq_buffer, struct fid_cq **cq_ext,
 	return ret;
 
 close_cq:
-	fi_close(&(*cq_ext)->fid);
+	FT_CLOSE_FID(*cq_ext);
 free_buf:
 	ft_hmem_free(opts.iface, *cq_buffer);
 	*cq_buffer = NULL;
@@ -636,10 +636,8 @@ int main(int argc, char **argv)
 		efa_cuda_destroy_qp(gda_qp);
 	// qp need to be destroyed before closing cq
 	FT_CLOSE_FID(gda_ep);
-	if (txcq_ext)
-		fi_close(&txcq_ext->fid);
-	if (rxcq_ext)
-		fi_close(&rxcq_ext->fid);
+	FT_CLOSE_FID(txcq_ext);
+	FT_CLOSE_FID(rxcq_ext);
 
 	cleanup_ret = ft_free_res();
 	return ft_exit_code(ret ? ret : cleanup_ret);

--- a/fabtests/prov/efa/src/efa_mr_test.c
+++ b/fabtests/prov/efa/src/efa_mr_test.c
@@ -99,7 +99,7 @@ static int test_unaligned_mr(uint64_t offset)
 	} else if (should_fail && !ret) {
 		printf("FAIL: unaligned VA offset=%" PRIu64 " - passed unexpectedly (nrt_get_dmabuf_fd() v1)\n",
 		       offset);
-		fi_close(&mr->fid);
+		FT_CLOSE_FID(mr);
 		return -FI_EINVAL;
 	} else if (!should_fail && ret) {
 		printf("FAIL: unaligned VA offset=%" PRIu64 " - ft_reg_mr failed: %s\n",

--- a/fabtests/prov/efa/src/efa_rma_bw.c
+++ b/fabtests/prov/efa/src/efa_rma_bw.c
@@ -519,10 +519,8 @@ static int run(void)
 
 	ret = ft_finalize();
 out:
-	for (i = 1; i < num_eps; i++) {
-		if (eps[i])
-			fi_close(&eps[i]->fid);
-	}
+	for (i = 1; i < num_eps; i++)
+		FT_CLOSE_FID(eps[i]);
 	return ret;
 }
 

--- a/fabtests/prov/efa/src/mr_abort.c
+++ b/fabtests/prov/efa/src/mr_abort.c
@@ -2477,10 +2477,7 @@ static void teardown_eps(void)
 	int d, i;
 
 	for (i = 1; i < n_local_eps; i++) {
-		if (eps[i]) {
-			fi_close(&eps[i]->fid);
-			eps[i] = NULL;
-		}
+		FT_CLOSE_FID(eps[i]);
 	}
 
 	for (d = 0; d < n_domains; d++) {

--- a/fabtests/prov/lpp/src/test_util.c
+++ b/fabtests/prov/lpp/src/test_util.c
@@ -172,13 +172,13 @@ void util_teardown(struct rank_info *ri, struct rank_info *pri)
 	for (int i = 0; i < MAX_EP_INFO; i++) {
 		struct ep_info *ep_info = &ri->ep_info[i];
 		if (ep_info->valid) {
-			fi_close(&ep_info->fid->fid);
-			fi_close(&ep_info->stx->fid);
-			fi_close(&ep_info->tx_cq_fid->fid);
-			fi_close(&ep_info->rx_cq_fid->fid);
-			fi_close(&ep_info->tx_cntr_fid->fid);
-			fi_close(&ep_info->rx_cntr_fid->fid);
-			fi_close(&ep_info->av->fid);
+			FT_CLOSE_FID(ep_info->fid);
+			FT_CLOSE_FID(ep_info->stx);
+			FT_CLOSE_FID(ep_info->tx_cq_fid);
+			FT_CLOSE_FID(ep_info->rx_cq_fid);
+			FT_CLOSE_FID(ep_info->tx_cntr_fid);
+			FT_CLOSE_FID(ep_info->rx_cntr_fid);
+			FT_CLOSE_FID(ep_info->av);
 		}
 		ep_info->valid = 0;
 	}
@@ -187,7 +187,7 @@ void util_teardown(struct rank_info *ri, struct rank_info *pri)
 		struct mr_info *mr_info = &ri->mr_info[i];
 		if (mr_info->valid) {
 			if (!mr_info->skip_reg) {
-				fi_close(&mr_info->fid->fid);
+				FT_CLOSE_FID(mr_info->fid);
 			}
 			if (mr_info->uaddr != NULL) {
 				free_mr_uaddr(mr_info);
@@ -195,8 +195,8 @@ void util_teardown(struct rank_info *ri, struct rank_info *pri)
 		}
 		mr_info->valid = 0;
 	}
-	fi_close(&ri->domain->fid);
-	fi_close(&ri->fabric->fid);
+	FT_CLOSE_FID(ri->domain);
+	FT_CLOSE_FID(ri->fabric);
 	fi_freeinfo(ri->fi);
 	if (pri != NULL) {
 		put_peer_rank_info(pri);

--- a/fabtests/regression/pep_close_eq_read.c
+++ b/fabtests/regression/pep_close_eq_read.c
@@ -76,18 +76,12 @@ static int report(const char *call, int ret)
 
 static void close_resources(struct test_resources *r)
 {
-	if (r->ep)
-		fi_close(&r->ep->fid);
-	if (r->cq)
-		fi_close(&r->cq->fid);
-	if (r->pep)
-		fi_close(&r->pep->fid);
-	if (r->domain)
-		fi_close(&r->domain->fid);
-	if (r->eq)
-		fi_close(&r->eq->fid);
-	if (r->fabric)
-		fi_close(&r->fabric->fid);
+	FT_CLOSE_FID(r->ep);
+	FT_CLOSE_FID(r->cq);
+	FT_CLOSE_FID(r->pep);
+	FT_CLOSE_FID(r->domain);
+	FT_CLOSE_FID(r->eq);
+	FT_CLOSE_FID(r->fabric);
 	if (r->info)
 		fi_freeinfo(r->info);
 	memset(r, 0, sizeof(*r));


### PR DESCRIPTION
When calling fi_close we need to handle the return value. Replace unchecked fi_close calls with FT_CLOSE_FID macro in fabtests, and add a local DMABUF_CLOSE_FID macro in the dmabuf-rdma component for the same purpose.

Fixes coverity CID 505736