### PR TITLE
fabtests/efa: Only build efa tests if libfabric has the efa provider

### DIFF
--- a/fabtests/configure.ac
+++ b/fabtests/configure.ac
@@ -66,7 +66,9 @@ AS_IF([test x"$enable_efa" = x"yes"],
              [enable_efa=no
              AC_MSG_NOTICE([EFA fabtests are disabled: require 64-bit Linux])])])
 
-AM_CONDITIONAL([ENABLE_EFA], [test x"$enable_efa" = x"yes"])
+dnl ENABLE_EFA is defined in prov/efa/configure.m4, included at the end of this
+dnl file, so that the check for the libfabric efa extension header runs after
+dnl --with-libfabric has been processed.
 
 AC_ARG_ENABLE([lpp],
 	[AS_HELP_STRING([--enable-lpp],

--- a/fabtests/prov/efa/configure.m4
+++ b/fabtests/prov/efa/configure.m4
@@ -4,6 +4,16 @@ dnl SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All ri
 dnl
 dnl Configure specific to the fabtests Amazon EFA provider
 
+dnl The efa fabtests are only usable, and only buildable, when libfabric was
+dnl built with the efa provider: the efa extension header is installed with it.
+AS_IF([test x"$enable_efa" = x"yes"],
+      [AC_CHECK_HEADER([rdma/fi_ext_efa.h], [],
+              [enable_efa=no
+               AC_MSG_NOTICE([EFA fabtests are disabled: <rdma/fi_ext_efa.h> dnl
+not found, libfabric was built without the efa provider])])])
+
+AM_CONDITIONAL([ENABLE_EFA], [test x"$enable_efa" = x"yes"])
+
 
 dnl Checks for presence of efadv verbs. Needed for building tests that calls efadv verbs.
 have_efadv=0


### PR DESCRIPTION
libfabric installs rdma/fi_ext_efa.h only when it is built with the efa provider, but the efa fabtests are enabled by default, so building against a libfabric without efa fails on mr_abort.c with a fatal missing-header error. The efa tests cannot run against such an installation anyway, so probe for the extension header and clear enable_efa when it is absent.