### PR TITLE
prov/efa: Add domain ops for endpoint modification

### DIFF
--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -271,6 +271,8 @@ int fi_open_ops(struct fid *domain, const char *name, uint64_t flags,
     void **ops, void *context);
 ```
 
+### FI_EFA_DOMAIN_OPS
+
 Requesting `FI_EFA_DOMAIN_OPS` in `name` returns `ops` as
 the pointer to the function table `fi_efa_ops_domain` defined as follows:
 
@@ -319,8 +321,10 @@ struct fi_efa_mr_attr {
 (which indicates the failure reason).
 
 
-To enable GPU Direct Async (GDA), which allows the GPU to interact directly with the NIC, 
-request `FI_EFA_GDA_OPS` in the `name` parameter with efa-direct fabirc.
+### FI_EFA_GDA_OPS
+
+To enable GPU Direct Async (GDA), which allows the GPU to interact directly with the NIC,
+request `FI_EFA_GDA_OPS` in the `name` parameter with efa-direct fabric.
 This returns `ops` as a pointer to the function table `fi_efa_ops_gda` defined as follows:
 
 ```c

--- a/man/fi_efa.7.md
+++ b/man/fi_efa.7.md
@@ -572,6 +572,62 @@ struct fi_efa_comp_cntr_init_attr {
 **cntr_open_ext()** returns 0 on success, or a negative value on failure.
 
 
+### FI_EFA_MODIFY_EP_OPS
+
+To modify endpoint attributes at runtime, request `FI_EFA_MODIFY_EP_OPS` in the
+`name` parameter. This is only supported on the `efa-direct` fabric; on any
+other fabric `fi_open_ops` returns `-FI_EOPNOTSUPP`. This returns `ops` as a
+pointer to the function table `fi_efa_ops_modify_ep` defined as follows:
+
+```c
+struct fi_efa_ops_modify_ep {
+	int (*modify_ep)(struct fid_ep *ep, struct fi_efa_ep_attr *ep_attr,
+			 uint64_t attr_mask);
+};
+```
+
+#### modify_ep
+This op modifies attributes on the endpoint. The `attr_mask` parameter specifies
+which attributes to modify. The endpoint must already be enabled.
+
+```c
+enum {
+	FI_EFA_EP_ATTR_QKEY = 1 << 0,
+};
+
+struct fi_efa_ep_attr {
+	uint32_t qkey;
+};
+```
+
+*attr_mask*
+:	A bitwise OR of the attributes to modify. An `attr_mask` of 0 is a
+	successful no-op. Currently supported:
+
+	FI_EFA_EP_ATTR_QKEY:
+		Modify the queue key. The new value is taken from `ep_attr->qkey`
+		and must be less than 0x80000000, since 0x80000000 and above is
+		the privileged queue key range. On success, `fi_getname` reports
+		the new queue key. The application is responsible for re-exchanging
+		addresses with its peers after a successful call. Only supported
+		by the efa-direct fabric.
+
+		A concurrent call to fi_getname may return an incorrect adresss.
+		Applications are responsible for serializing any fi_getname calls
+		with the modify_ep call.
+
+Unsupported flags in `attr_mask` will cause the call to return `-FI_EOPNOTSUPP`.
+
+#### Return value
+**modify_ep()** returns 0 on success, or a negative error code on failure:
+
+- `-FI_EINVAL`: NULL endpoint or ep_attr, fid is not an endpoint, endpoint not
+  enabled, or a queue key in the privileged range.
+- `-FI_EOPNOTSUPP`: Unsupported flags in `attr_mask`, or the endpoint does not
+  belong to an `efa-direct` domain.
+
+On failure, no attribute is modified.
+
 ## Fabric Operation Extension
 
 Fabric operation extension is obtained by calling `fi_open_ops`

--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -307,7 +307,9 @@ nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
 	prov/efa/test/gtest/efa_gtest_rma.cc \
 	prov/efa/test/gtest/efa_gtest_hmem.cc \
 	prov/efa/test/gtest/efa_gtest_tclass_utils.c \
-	prov/efa/test/gtest/efa_gtest_tclass.cc
+	prov/efa/test/gtest/efa_gtest_tclass.cc \
+	prov/efa/test/gtest/efa_gtest_domain_utils.c \
+	prov/efa/test/gtest/efa_gtest_domain.cc
 
 prov_efa_test_gtest_efa_gtest_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
@@ -352,6 +354,7 @@ prov_efa_test_gtest_efa_gtest_LDFLAGS = \
 	-Wl,--wrap=efa_rdm_ep_post_queued_pkts \
 	-Wl,--wrap=efa_rdm_pke_fill_data \
 	-Wl,--wrap=efa_rdm_pke_read \
+	-Wl,--wrap=ibv_modify_qp \
 	-Wl,--wrap=malloc
 
 prov_efa_test_gtest_efa_gtest_LIBS = $(linkback)

--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -194,7 +194,7 @@ static uint32_t efa_generate_qkey(struct efa_device *device)
 	}
 
 	/* 0x80000000 and up is privileged Q Key range. */
-	val &= 0x7fffffff;
+	val &= ~EFA_QKEY_PRIVILEGED_MASK;
 
 	return val;
 }

--- a/prov/efa/src/efa_base_ep.h
+++ b/prov/efa/src/efa_base_ep.h
@@ -19,6 +19,11 @@
 #define EFA_QP_LOW_LATENCY_SERVICE_LEVEL 8
 #define EFA_ERROR_MSG_BUFFER_LENGTH 1024
 
+/* 0x80000000 and up is the privileged Q Key range, which is not usable by
+ * unprivileged endpoints. Both the provider generated QKEYs and the ones
+ * supplied by the application must stay below it. */
+#define EFA_QKEY_PRIVILEGED_MASK 0x80000000
+
 /* Default rnr_retry for efa-rdm ep.
  * If first attempt to send a packet failed,
  * this value controls how many times firmware

--- a/prov/efa/src/efa_domain.c
+++ b/prov/efa/src/efa_domain.c
@@ -697,6 +697,98 @@ static struct fi_efa_ops_gda efa_ops_gda = {
 	.cntr_open_ext = efa_domain_cntr_open_ext,
 };
 
+/**
+ * @brief Modify attributes of an enabled endpoint
+ *
+ * Only the efa-direct path is supported. On efa-rdm the QKEY doubles as the
+ * connection ID that is embedded in every packet header and cached by peers,
+ * so it cannot be changed once the endpoint is enabled.
+ *
+ * The caller is responsible for serializing this call against data path
+ * operations and fi_close() on @p ep_fid. This function does not take the
+ * endpoint lock, so a concurrent fi_send()/fi_close() on the same endpoint is
+ * undefined behavior.
+ *
+ * @param[in]	ep_fid		Endpoint fid
+ * @param[in]	ep_attr		New attribute values
+ * @param[in]	attr_mask	Bitwise OR of the FI_EFA_EP_ATTR_* attributes to
+ *				modify
+ * @return 0 on success, negative FI error code on failure
+ */
+static int efa_domain_modify_ep(struct fid_ep *ep_fid,
+				struct fi_efa_ep_attr *ep_attr, uint64_t attr_mask)
+{
+	struct efa_base_ep *base_ep;
+	struct efa_domain *domain;
+	struct ibv_qp_attr ibv_attr = {0};
+	int ibv_mask = 0;
+	int ret;
+	uint32_t old_qkey;
+
+	if (!ep_fid || !ep_attr)
+		return -FI_EINVAL;
+
+	if (ep_fid->fid.fclass != FI_CLASS_EP) {
+		EFA_WARN(FI_LOG_DOMAIN, "fid is not an endpoint\n");
+		return -FI_EINVAL;
+	}
+
+	if (attr_mask & ~FI_EFA_EP_ATTR_SUPPORTED_FLAGS) {
+		EFA_WARN(FI_LOG_DOMAIN,
+			 "Unsupported attr_mask: %ld\n", attr_mask);
+		return -FI_EOPNOTSUPP;
+	}
+
+	if (!attr_mask)
+		return FI_SUCCESS;
+
+	base_ep = container_of(ep_fid, struct efa_base_ep, util_ep.ep_fid);
+	domain = base_ep->domain;
+
+	if (!base_ep->efa_qp_enabled || !base_ep->qp || !base_ep->qp->ibv_qp) {
+		EFA_WARN(FI_LOG_DOMAIN, "Endpoint is not enabled\n");
+		return -FI_EINVAL;
+	}
+
+	if (attr_mask & FI_EFA_EP_ATTR_QKEY) {
+		if (domain->info_type != EFA_INFO_DIRECT) {
+			EFA_WARN(FI_LOG_DOMAIN, "Only efa direct supports "
+						"FI_EFA_MODIFY_EP_OPS\n");
+			return -FI_EOPNOTSUPP;
+		}
+
+		if (ep_attr->qkey & EFA_QKEY_PRIVILEGED_MASK) {
+			EFA_WARN(FI_LOG_DOMAIN,
+				 "QKEY 0x%x is in the privileged range and "
+				 "cannot be used\n",
+				 ep_attr->qkey);
+			return -FI_EINVAL;
+		}
+
+		ibv_attr.qkey = ep_attr->qkey;
+		ibv_mask |= IBV_QP_QKEY;
+
+		ret = -ibv_modify_qp(base_ep->qp->ibv_qp, &ibv_attr, ibv_mask);
+		if (ret) {
+			EFA_WARN(FI_LOG_DOMAIN, "ibv_modify_qp failed: %d\n",
+				 ret);
+			return ret;
+		}
+
+		old_qkey = base_ep->qp->qkey;
+		base_ep->qp->qkey = ep_attr->qkey;
+		base_ep->src_addr.qkey = ep_attr->qkey;
+		EFA_INFO(FI_LOG_DOMAIN, "EP qkey updated: 0x%x -> 0x%x\n",
+			 old_qkey, ep_attr->qkey);
+	}
+
+	return FI_SUCCESS;
+}
+
+static struct fi_efa_ops_modify_ep efa_ops_modify_ep = {
+	.modify_ep = efa_domain_modify_ep,
+};
+
 static int
 efa_domain_ops_open(struct fid *fid, const char *ops_name, uint64_t flags,
 		     void **ops, void *context)
@@ -716,6 +808,16 @@ efa_domain_ops_open(struct fid *fid, const char *ops_name, uint64_t flags,
 		}
 
 		*ops = &efa_ops_gda;
+		return ret;
+	}
+	if (strcmp(ops_name, FI_EFA_MODIFY_EP_OPS) == 0) {
+		efa_domain = container_of(fid, struct efa_domain, util_domain.domain_fid.fid);
+		if (efa_domain->info_type != EFA_INFO_DIRECT) {
+			EFA_WARN(FI_LOG_DOMAIN, "Only efa direct supports FI_EFA_MODIFY_EP_OPS\n");
+			return -FI_EOPNOTSUPP;
+		}
+
+		*ops = &efa_ops_modify_ep;
 		return ret;
 	}
 

--- a/prov/efa/src/fi_ext_efa.h
+++ b/prov/efa/src/fi_ext_efa.h
@@ -10,6 +10,7 @@
 #define FI_EFA_DOMAIN_OPS "efa domain ops"
 #define FI_EFA_GDA_OPS "efa gda ops"
 #define FI_EFA_FEATURE_OPS "efa feature ops"
+#define FI_EFA_MODIFY_EP_OPS "efa modify ep ops"
 
 struct fi_efa_mr_attr {
     uint16_t ic_id_validity;
@@ -142,5 +143,20 @@ struct fi_efa_feature_ops {
  * such as fi_writemsg().
  */
 #define FI_EFA_WR_HIGH_PPS (1ULL << 60)
+
+enum {
+	FI_EFA_EP_ATTR_QKEY = 1 << 0,
+};
+
+#define FI_EFA_EP_ATTR_SUPPORTED_FLAGS (FI_EFA_EP_ATTR_QKEY)
+
+struct fi_efa_ep_attr {
+	uint32_t qkey;
+};
+
+struct fi_efa_ops_modify_ep {
+	int (*modify_ep)(struct fid_ep *ep, struct fi_efa_ep_attr *ep_attr,
+			 uint64_t attr_mask);
+};
 
 #endif /* _FI_EXT_EFA_H_ */

--- a/prov/efa/src/rdm/efa_rdm_domain.c
+++ b/prov/efa/src/rdm/efa_rdm_domain.c
@@ -249,6 +249,15 @@ efa_rdm_domain_ops_open(struct fid *fid, const char *ops_name, uint64_t flags,
 		EFA_WARN(FI_LOG_DOMAIN, "Only efa direct supports FI_EFA_GDA_OPS\n");
 		return -FI_EOPNOTSUPP;
 	}
+	if (strcmp(ops_name, FI_EFA_MODIFY_EP_OPS) == 0) {
+		/*
+		 * On efa-rdm the QKEY doubles as the connection ID that is
+		 * embedded in every packet header and cached by peers, so it
+		 * cannot be modified after the endpoint is enabled.
+		 */
+		EFA_WARN(FI_LOG_DOMAIN, "Only efa direct supports FI_EFA_MODIFY_EP_OPS\n");
+		return -FI_EOPNOTSUPP;
+	}
 
 	EFA_WARN(FI_LOG_DOMAIN, "Unknown ops name: %s\n", ops_name);
 	ret = -FI_EINVAL;

--- a/prov/efa/test/gtest/efa_gtest_common_mocks.h
+++ b/prov/efa/test/gtest/efa_gtest_common_mocks.h
@@ -117,7 +117,10 @@ struct dlist_entry;
 	X(int, efa_rdm_pke_read,                                               \
 	  (struct efa_rdm_pke * pkt_entry, void *local_buf, size_t len,        \
 	   void *desc, uint64_t remote_buf, size_t remote_key),                \
-	  (pkt_entry, local_buf, len, desc, remote_buf, remote_key))
+	  (pkt_entry, local_buf, len, desc, remote_buf, remote_key))           \
+	X(int, ibv_modify_qp,                                                  \
+	  (struct ibv_qp * qp, struct ibv_qp_attr * attr, int attr_mask),      \
+	  (qp, attr, attr_mask))
 
 /* --- Generator macros --- */
 

--- a/prov/efa/test/gtest/efa_gtest_domain.cc
+++ b/prov/efa/test/gtest/efa_gtest_domain.cc
@@ -1,0 +1,229 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All
+ * rights reserved. */
+
+#include "efa_gtest_common_mocks.h"
+#include "efa_gtest_common_resource.h"
+#include "efa_gtest_domain_utils.h"
+#include "fi_ext_efa.h"
+#include <gtest/gtest.h>
+
+using testing::_;
+using testing::Return;
+using testing::StrictMock;
+using testing::Test;
+using testing::Truly;
+using testing::Values;
+using testing::WithParamInterface;
+
+/* fi_efa.7: ep_attr->qkey must be below the privileged queue key range */
+static const uint32_t kPrivilegedQkey = 0x80000000;
+static const uint32_t kTestQkey = 0x0badf00d;
+
+class EfaModifyEpTest : public Test
+{
+	protected:
+	struct efa_resource resource = {};
+	StrictMock<MockEfa> mock_efa;
+	struct fi_efa_ops_modify_ep *modify_ep_ops = nullptr;
+
+	void construct(enum fi_ep_type ep_type, const char *fabric_name,
+		       bool enable)
+	{
+		struct fi_info *hints =
+			efa_test_alloc_default_hints(ep_type, fabric_name);
+		ASSERT_NE(hints, nullptr);
+
+		if (enable)
+			efa_test_resource_construct(&resource, hints);
+		else
+			efa_test_resource_construct_no_enable(&resource, hints);
+		ASSERT_NE(resource.ep, nullptr);
+	}
+
+	void open_ops()
+	{
+		ASSERT_EQ(fi_open_ops(&resource.domain->fid,
+				      FI_EFA_MODIFY_EP_OPS, 0,
+				      (void **) &modify_ep_ops, nullptr),
+			  0);
+		ASSERT_NE(modify_ep_ops, nullptr);
+		ASSERT_NE(modify_ep_ops->modify_ep, nullptr);
+	}
+
+	void construct_direct()
+	{
+		ASSERT_NO_FATAL_FAILURE(
+			construct(FI_EP_RDM, EFA_DIRECT_FABRIC_NAME, true));
+		ASSERT_NO_FATAL_FAILURE(open_ops());
+		MockEfa::set(&mock_efa);
+	}
+
+	void SetUp() override
+	{
+		memset(&resource, 0, sizeof(resource));
+	}
+
+	void TearDown() override
+	{
+		MockEfa::set(nullptr);
+		efa_test_resource_destruct(&resource);
+	}
+};
+
+TEST_F(EfaModifyEpTest, qkey_updates_qp_and_ep_addr)
+{
+	struct fi_efa_ep_attr ep_attr = {};
+	uint32_t old_qkey, new_qkey, name_qkey = 0;
+
+	ASSERT_NO_FATAL_FAILURE(construct_direct());
+
+	old_qkey = efa_test_get_qp_qkey(resource.ep);
+	new_qkey = (old_qkey + 1) & ~kPrivilegedQkey;
+	ep_attr.qkey = new_qkey;
+
+	auto sets_qkey = Truly([new_qkey](const struct ibv_qp_attr *attr) {
+		return attr->qkey == new_qkey;
+	});
+	EFA_EXPECT_CALL(mock_efa, ibv_modify_qp, _, sets_qkey,
+			(int) IBV_QP_QKEY)
+		.WillOnce(Return(0));
+
+	EXPECT_EQ(modify_ep_ops->modify_ep(resource.ep, &ep_attr,
+					   FI_EFA_EP_ATTR_QKEY),
+		  0);
+
+	EXPECT_EQ(efa_test_get_qp_qkey(resource.ep), new_qkey);
+	EXPECT_EQ(efa_test_getname_qkey(resource.ep, &name_qkey), 0);
+	EXPECT_EQ(name_qkey, new_qkey);
+}
+
+TEST_F(EfaModifyEpTest, qkey_ibv_failure_leaves_qkey_unchanged)
+{
+	struct fi_efa_ep_attr ep_attr = {};
+	uint32_t old_qkey, name_qkey = 0;
+
+	ASSERT_NO_FATAL_FAILURE(construct_direct());
+
+	old_qkey = efa_test_get_qp_qkey(resource.ep);
+	ep_attr.qkey = (old_qkey + 1) & ~kPrivilegedQkey;
+
+	EFA_EXPECT_CALL(mock_efa, ibv_modify_qp, _, _, _)
+		.WillOnce(Return(EPERM));
+
+	EXPECT_EQ(modify_ep_ops->modify_ep(resource.ep, &ep_attr,
+					   FI_EFA_EP_ATTR_QKEY),
+		  -FI_EPERM);
+
+	EXPECT_EQ(efa_test_get_qp_qkey(resource.ep), old_qkey);
+	EXPECT_EQ(efa_test_getname_qkey(resource.ep, &name_qkey), 0);
+	EXPECT_EQ(name_qkey, old_qkey);
+}
+
+TEST_F(EfaModifyEpTest, invalid_args_rejected)
+{
+	struct fi_efa_ep_attr ep_attr = {};
+	uint32_t old_qkey, name_qkey = 0;
+
+	ASSERT_NO_FATAL_FAILURE(construct_direct());
+
+	old_qkey = efa_test_get_qp_qkey(resource.ep);
+	ep_attr.qkey = (old_qkey + 1) & ~kPrivilegedQkey;
+
+	EFA_EXPECT_CALL(mock_efa, ibv_modify_qp).Times(0);
+
+	EXPECT_EQ(modify_ep_ops->modify_ep(nullptr, &ep_attr,
+					   FI_EFA_EP_ATTR_QKEY),
+		  -FI_EINVAL);
+	EXPECT_EQ(modify_ep_ops->modify_ep(resource.ep, nullptr,
+					   FI_EFA_EP_ATTR_QKEY),
+		  -FI_EINVAL);
+	EXPECT_EQ(modify_ep_ops->modify_ep((struct fid_ep *) resource.domain,
+					   &ep_attr, FI_EFA_EP_ATTR_QKEY),
+		  -FI_EINVAL);
+
+	EXPECT_EQ(efa_test_get_qp_qkey(resource.ep), old_qkey);
+	EXPECT_EQ(efa_test_getname_qkey(resource.ep, &name_qkey), 0);
+	EXPECT_EQ(name_qkey, old_qkey);
+}
+
+TEST_F(EfaModifyEpTest, qkey_rejected_before_ep_enabled)
+{
+	struct fi_efa_ep_attr ep_attr = {};
+
+	ASSERT_NO_FATAL_FAILURE(
+		construct(FI_EP_RDM, EFA_DIRECT_FABRIC_NAME, false));
+	ASSERT_NO_FATAL_FAILURE(open_ops());
+	MockEfa::set(&mock_efa);
+
+	ep_attr.qkey = kTestQkey;
+
+	EFA_EXPECT_CALL(mock_efa, ibv_modify_qp).Times(0);
+
+	EXPECT_EQ(modify_ep_ops->modify_ep(resource.ep, &ep_attr,
+					   FI_EFA_EP_ATTR_QKEY),
+		  -FI_EINVAL);
+}
+
+TEST_F(EfaModifyEpTest, ops_rejected_for_rdm)
+{
+	ASSERT_NO_FATAL_FAILURE(construct(FI_EP_RDM, EFA_FABRIC_NAME, true));
+
+	EXPECT_EQ(fi_open_ops(&resource.domain->fid, FI_EFA_MODIFY_EP_OPS, 0,
+			      (void **) &modify_ep_ops, nullptr),
+		  -FI_EOPNOTSUPP);
+}
+
+TEST_F(EfaModifyEpTest, ops_rejected_for_dgram)
+{
+	ASSERT_NO_FATAL_FAILURE(construct(FI_EP_DGRAM, EFA_FABRIC_NAME, true));
+
+	EXPECT_EQ(fi_open_ops(&resource.domain->fid, FI_EFA_MODIFY_EP_OPS, 0,
+			      (void **) &modify_ep_ops, nullptr),
+		  -FI_EOPNOTSUPP);
+}
+
+struct ModifyEpNoDeviceCase {
+	const char *name;
+	uint32_t qkey;
+	int attr_mask;
+	int expected_ret;
+};
+
+class EfaModifyEpNoDeviceTest : public EfaModifyEpTest,
+				public WithParamInterface<ModifyEpNoDeviceCase>
+{
+};
+
+TEST_P(EfaModifyEpNoDeviceTest, leaves_qkey_unchanged)
+{
+	const ModifyEpNoDeviceCase &param = GetParam();
+	struct fi_efa_ep_attr ep_attr = {};
+	uint32_t old_qkey, name_qkey = 0;
+
+	ASSERT_NO_FATAL_FAILURE(construct_direct());
+
+	old_qkey = efa_test_get_qp_qkey(resource.ep);
+	ep_attr.qkey = param.qkey;
+
+	EFA_EXPECT_CALL(mock_efa, ibv_modify_qp).Times(0);
+
+	EXPECT_EQ(modify_ep_ops->modify_ep(resource.ep, &ep_attr,
+					   param.attr_mask),
+		  param.expected_ret);
+
+	EXPECT_EQ(efa_test_get_qp_qkey(resource.ep), old_qkey);
+	EXPECT_EQ(efa_test_getname_qkey(resource.ep, &name_qkey), 0);
+	EXPECT_EQ(name_qkey, old_qkey);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+	, EfaModifyEpNoDeviceTest,
+	Values(ModifyEpNoDeviceCase{"privileged_qkey", kPrivilegedQkey,
+				    FI_EFA_EP_ATTR_QKEY, -FI_EINVAL},
+	       ModifyEpNoDeviceCase{"unsupported_flag", kTestQkey,
+				    FI_EFA_EP_ATTR_QKEY << 1, -FI_EOPNOTSUPP},
+	       ModifyEpNoDeviceCase{"empty_mask", kTestQkey, 0, 0}),
+	[](const testing::TestParamInfo<ModifyEpNoDeviceCase> &info) {
+		return std::string(info.param.name);
+	});

--- a/prov/efa/test/gtest/efa_gtest_domain_utils.c
+++ b/prov/efa/test/gtest/efa_gtest_domain_utils.c
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#include "efa.h"
+#include "efa_gtest_domain_utils.h"
+
+uint32_t efa_test_get_qp_qkey(struct fid_ep *ep)
+{
+	struct efa_base_ep *base_ep =
+		container_of(ep, struct efa_base_ep, util_ep.ep_fid);
+
+	return base_ep->qp->qkey;
+}
+
+int efa_test_getname_qkey(struct fid_ep *ep, uint32_t *qkey)
+{
+	struct efa_ep_addr addr = {0};
+	size_t addrlen = sizeof(addr);
+	int ret;
+
+	ret = fi_getname(&ep->fid, &addr, &addrlen);
+	if (!ret)
+		*qkey = addr.qkey;
+
+	return ret;
+}

--- a/prov/efa/test/gtest/efa_gtest_domain_utils.h
+++ b/prov/efa/test/gtest/efa_gtest_domain_utils.h
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All rights reserved. */
+
+#ifndef EFA_GTEST_DOMAIN_UTILS_H
+#define EFA_GTEST_DOMAIN_UTILS_H
+
+#include <stdint.h>
+#include <rdma/fabric.h>
+#include <rdma/fi_domain.h>
+#include <rdma/fi_endpoint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Read the QKEY the provider recorded on the endpoint's EFA QP. The
+ * endpoint must be enabled.
+ */
+uint32_t efa_test_get_qp_qkey(struct fid_ep *ep);
+
+/**
+ * @brief Read the QKEY fi_getname() reports for @p ep, i.e. the one peers
+ * insert into their AV. struct efa_ep_addr is opaque from C++.
+ *
+ * @return the fi_getname() return code; @p qkey is only set on success.
+ */
+int efa_test_getname_qkey(struct fid_ep *ep, uint32_t *qkey);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EFA_GTEST_DOMAIN_UTILS_H */


### PR DESCRIPTION
Implement FI_EFA_MODIFY_EP_OPS domain ops that allows modifying
endpoint attributes at runtime. Currently supports FI_EFA_EP_ATTR_QKEY
which modifies the queue key on the endpoint's underlying QP.

The interface is intentionally rdma-core agnostic: FI_EFA_EP_ATTR_QKEY
is defined as a provider-specific flag (not tied to IBV_QP_QKEY), and
the implementation maps it internally to the appropriate ibv call.

On success both the QP and base_ep->src_addr are updated, so
fi_getname() reports the new QKEY