### PR TITLE
make double-sure error message make it to user

### DIFF
--- a/prov/cxi/include/cxip.h
+++ b/prov/cxi/include/cxip.h
@@ -3774,6 +3774,7 @@ static inline bool cxip_coll_prod_trace_true(void)
 #define CXIP_FATAL(fmt, ...)					\
 	do {							\
 		CXIP_LOG(fmt, ##__VA_ARGS__);			\
+		fflush(stderr);					\
 		abort();					\
 	} while (0)
 


### PR DESCRIPTION
CXIP_FATAL output should always show up no matter what FI_LOG_LEVEL has been set.  Normally, stderr is unbuffered, so CXIP_FATAL didn't think it had to flush stderr before aborting.

On Argonne's Aurora system I'm observing CXIP_FATAL guidance not showing up in PBS logs.  I don't know which layer of the job scheduler or software stack is messing around with stderr, but I do know that an extra fflush here makes the message show up.