### PR TITLE
[v2.6.x]prov/efa: Backport PR CI HMEM Mark Fixes 

### DIFF
--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -4,16 +4,18 @@ import subprocess
 import time
 from retrying import retry
 from common import (
+    num_hmem_devices,
     test_selected_by_marker,
     has_ssh_connection_err_msg,
     is_ssh_connection_error,
     SshConnectionError,
 )
 from efa_common import (
-    has_rdma, 
+    has_rdma,
     support_cq_interrupts,
     CudaMemorySupport,
     get_cuda_memory_support,
+    memory_type_list_bi_dir,
 )
 
 # Message size lists are defined in efa_common.py and imported by test files directly.
@@ -101,16 +103,80 @@ def add_fabric_and_message_size_parametrization(metafunc, fabric_marker, sizes_m
     metafunc.parametrize("message_sizes", sizes)
 
 
+def client_server_have_device(memory_token, server_id, client_id):
+    """
+    Return True if both client and server endpoints named in a memory-type
+    token have the hmem device that token requires.
+
+    Any SSH/detection failure propagates to the caller,
+    which falls back to including all candidate memory types.
+    """
+    client_memory_type, server_memory_type = memory_token.split("_to_")
+    for memory_type_name, ip in ((client_memory_type, client_id),
+                                 (server_memory_type, server_id)):
+        if memory_type_name == "host":
+            # host memory needs no accelerator device
+            continue
+        if num_hmem_devices(ip, memory_type_name) <= 0:
+            return False
+    return True
+
+
+def add_memory_type_parametrization(metafunc, memory_type_marker):
+    """
+    Parametrize the memory_type fixture at collection time from the test's
+    @pytest.mark.memory_type(...) declaration, dropping any permutation whose
+    device is absent on the owning endpoint.
+
+    Fallback (no coverage regression): if --server-id/--client-id are not
+    provided or device detection fails, every candidate memory type is
+    included and the runtime skip in common.py remains the safety net.
+    """
+
+    if "memory_type" not in metafunc.fixturenames:
+        return
+
+    # A test consuming the memory_type fixture must declare a memory_type marker
+    # whose argument is a memory_type_list_* from efa_common.
+    if memory_type_marker is None:
+        raise ValueError(
+            f"{metafunc.definition.nodeid} consumes the memory_type fixture "
+            f"but is missing @pytest.mark.memory_type(...)"
+        )
+
+    candidates = memory_type_marker.args[0]
+
+    server_id = metafunc.config.getoption("--server-id", default=None)
+    client_id = metafunc.config.getoption("--client-id", default=None)
+
+    if not server_id or not client_id:
+        params = candidates
+    else:
+        try:
+            params = [
+                param for param in candidates
+                if client_server_have_device(param.values[0], server_id, client_id)
+            ]
+        except Exception:
+            # Fallback to all memory types when detection/SSH fails
+            params = candidates
+
+    metafunc.parametrize("memory_type", params, scope="module")
+
+
 def pytest_generate_tests(metafunc):
     """
     Derive parametrization from markers
       - @pytest.mark.pr_ci
       - @pytest.mark.fabric(params=[...])
       - @pytest.mark.message_sizes(<test_type>_<fabric>=..., ...)
+      - @pytest.mark.memory_type(memory_type_list_*)
+    the last also filtering by endpoint device availability.
     """
     # get all markers
     fabric_marker = next(metafunc.definition.iter_markers("fabric"), None)
     sizes_marker  = next(metafunc.definition.iter_markers("message_sizes"), None)
+    memory_type_marker = next(metafunc.definition.iter_markers("memory_type"), None)
 
     # find out the test type running from markers (currently pr_ci or default)
     test_markers = {m.name for m in metafunc.definition.iter_markers()}
@@ -119,23 +185,9 @@ def pytest_generate_tests(metafunc):
     # generate parametrization based on found markers and test type
     add_fabric_and_message_size_parametrization(metafunc, fabric_marker, sizes_marker, test_type)
 
-# The memory types for bi-directional tests.
-memory_type_list_bi_dir = [
-    pytest.param("host_to_host"),
-    pytest.param("host_to_cuda", marks=pytest.mark.cuda_memory),
-    pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
-    pytest.param("host_to_neuron", marks=pytest.mark.neuron_memory),
-    pytest.param("neuron_to_neuron", marks=pytest.mark.neuron_memory),
-    pytest.param("host_to_rocr", marks=pytest.mark.rocr_memory),
-    pytest.param("rocr_to_rocr", marks=pytest.mark.rocr_memory),
-]
-
-# Add more memory types that are useful for uni-directional tests.
-memory_type_list_all = memory_type_list_bi_dir + [
-    pytest.param("cuda_to_host", marks=pytest.mark.cuda_memory),
-    pytest.param("neuron_to_host", marks=pytest.mark.neuron_memory),
-    pytest.param("rocr_to_host", marks=pytest.mark.rocr_memory),
-]
+    # parametrize memory_type from its marker, dropping permutations
+    # whose device is absent on the owning endpoint
+    add_memory_type_parametrization(metafunc, memory_type_marker)
 
 hmem_type_list = [
     pytest.param("cuda", marks=pytest.mark.cuda_memory),
@@ -144,14 +196,6 @@ hmem_type_list = [
 
 @pytest.fixture(scope="module", params=hmem_type_list)
 def hmem_type(request):
-    return request.param
-
-@pytest.fixture(scope="module", params=memory_type_list_all)
-def memory_type(request):
-    return request.param
-
-@pytest.fixture(scope="module", params=memory_type_list_bi_dir)
-def memory_type_bi_dir(request):
     return request.param
 
 @pytest.fixture(scope="module", params=["read", "writedata", "write"])

--- a/fabtests/pytest/efa/conftest.py
+++ b/fabtests/pytest/efa/conftest.py
@@ -34,29 +34,69 @@ def fabric_present(string, fabric):
     raise ValueError(f"Unknown fabric: {fabric!r}")
 
 
+# PR CI test types, most specific first. A per test type marker kwarg
+# (memory_type(pr_ci_hmem=...), message_sizes(pr_ci_hmem_efa=...)) is looked up
+# in this order, so an HMEM run falls back to the plain PR CI declaration when a
+# test does not need a different HMEM matrix.
+TEST_TYPE_FALLBACKS = {
+    "pr_ci_hmem": ("pr_ci_hmem", "pr_ci"),
+    "pr_ci": ("pr_ci",),
+    "default": ("default",),
+}
+
+
 def get_test_type(test_markers, config):
     """
-    Return 'pr_ci' if this test is being collected because of the pr_ci marker,
-    else 'default'.
+    Return the test type the current run selected this test with:
+    'pr_ci_hmem' for the PR CI suite on an accelerator instance, 'pr_ci' for the
+    PR CI suite elsewhere, else 'default'.
+
+    The type is decided by which marker caused the test to be selected, so the
+    harness controls it with -t (runfabtests) / -m (pytest) and no hardware
+    detection is involved.
     """
+    if test_selected_by_marker(config, test_markers, "pr_ci_hmem"):
+        return "pr_ci_hmem"
     if test_selected_by_marker(config, test_markers, "pr_ci"):
         return "pr_ci"
     return "default"
 
 
+def marker_kwarg_for_test_type(marker, test_type, suffix=""):
+    """
+    Return (kwarg_name, value) for the most specific test type a marker declares,
+    or (None, None). suffix lets the message_sizes marker key on fabric too, e.g.
+    test_type 'pr_ci_hmem' + suffix '_efa' looks up 'pr_ci_hmem_efa' then
+    'pr_ci_efa'.
+    """
+    for candidate in TEST_TYPE_FALLBACKS.get(test_type, (test_type,)):
+        name = candidate + suffix
+        if name in marker.kwargs:
+            return name, marker.kwargs[name]
+    return None, None
+
+
+FABRIC_KWARG_SUFFIX = {"efa": "_efa", "efa-direct": "_efa_direct"}
+
+
 def choose_message_sizes_for_fabric_test_type(fabric, test_type, sizes_marker, nodeid):
     """
-    Return all matching message-size lists for (fabric, test_type) from a
+    Return the message-size list for (fabric, test_type) from a
     @pytest.mark.message_sizes marker.
     example:
     @pytest.mark.message_sizes(default_efa=PERF_SIZES, pr_ci_efa=DIRECT_RMA_SIZES)
                    ^sizes marker   ^kwarg_name   ^kwarg_sizes
+
+    A kwarg name is <test_type>_<fabric>, matched exactly, walking the test type
+    fallback chain: an HMEM PR CI run uses the pr_ci_* sizes unless the test
+    declares pr_ci_hmem_* ones. Matching the whole name matters because
+    'pr_ci' is a prefix of 'pr_ci_hmem'.
     """
-    sizes = []
-    for kwarg_name, kwarg_sizes in sizes_marker.kwargs.items():
-        # add message sizes if they match both the fabric and the test type
-        if fabric_present(kwarg_name, fabric) and test_type in kwarg_name:
-            sizes.extend(kwarg_sizes)
+    suffix = FABRIC_KWARG_SUFFIX.get(fabric)
+    if suffix is None:
+        raise ValueError(f"Unknown fabric: {fabric!r}")
+
+    _, sizes = marker_kwarg_for_test_type(sizes_marker, test_type, suffix)
     if not sizes:
         raise ValueError(
             f"@pytest.mark.message_sizes on {nodeid} is missing a kwarg for "
@@ -64,6 +104,40 @@ def choose_message_sizes_for_fabric_test_type(fabric, test_type, sizes_marker, n
             f"(have {sorted(sizes_marker.kwargs)})"
         )
     return sizes
+
+
+def kwarg_test_type(kwarg_name):
+    """
+    Return the test type part of a message_sizes kwarg name, i.e. the name with
+    its trailing _<fabric> stripped: 'pr_ci_hmem_efa_direct' -> 'pr_ci_hmem'.
+    """
+    for suffix in sorted(FABRIC_KWARG_SUFFIX.values(), key=len, reverse=True):
+        if kwarg_name.endswith(suffix):
+            return kwarg_name[: -len(suffix)]
+    return kwarg_name
+
+
+def choose_message_sizes_for_test_type(test_type, sizes_marker, nodeid):
+    """
+    Return the message-size list for test_type from a @pytest.mark.message_sizes
+    marker on a test with no fabric parametrization.
+
+    The test type part of each kwarg name is compared exactly, walking the
+    fallback chain, so an HMEM PR CI run uses the pr_ci_* sizes unless the test
+    declares pr_ci_hmem_* ones, and 'pr_ci' never matches a 'pr_ci_hmem_*'
+    kwarg by prefix.
+    """
+    for candidate in TEST_TYPE_FALLBACKS.get(test_type, (test_type,)):
+        sizes = []
+        for kwarg_name, kwarg_sizes in sizes_marker.kwargs.items():
+            if kwarg_test_type(kwarg_name) == candidate:
+                sizes.extend(kwarg_sizes)
+        if sizes:
+            return sizes
+    raise ValueError(
+        f"@pytest.mark.message_sizes on {nodeid} has "
+        f"no kwarg naming {test_type!r} (have {sorted(sizes_marker.kwargs)})"
+    )
 
 
 def add_fabric_and_message_size_parametrization(metafunc, fabric_marker, sizes_marker, test_type):
@@ -91,16 +165,9 @@ def add_fabric_and_message_size_parametrization(metafunc, fabric_marker, sizes_m
         return
 
     # no fabric param, just add message sizes parametrization based on test type
-    sizes = []
-    for k, kwarg_sizes in sizes_marker.kwargs.items():
-        if test_type in k:
-            sizes.extend(kwarg_sizes)
-    if not sizes:
-        raise ValueError(
-            f"@pytest.mark.message_sizes on {metafunc.definition.nodeid} has "
-            f"no kwarg naming {test_type!r} (have {sorted(sizes_marker.kwargs)})"
-        )
-    metafunc.parametrize("message_sizes", sizes)
+    metafunc.parametrize("message_sizes",
+                         choose_message_sizes_for_test_type(test_type, sizes_marker,
+                                                            metafunc.definition.nodeid))
 
 
 def client_server_have_device(memory_token, server_id, client_id):
@@ -122,11 +189,22 @@ def client_server_have_device(memory_token, server_id, client_id):
     return True
 
 
-def add_memory_type_parametrization(metafunc, memory_type_marker):
+def add_memory_type_parametrization(metafunc, memory_type_marker, test_type):
     """
     Parametrize the memory_type fixture at collection time from the test's
     @pytest.mark.memory_type(...) declaration, dropping any permutation whose
     device is absent on the owning endpoint.
+
+    The candidate list is the one the marker declares for the running test type,
+    most specific first:
+
+        @pytest.mark.memory_type(memory_type_list_all,             # default runs
+                                 pr_ci=memory_type_list_symm,      # PR CI
+                                 pr_ci_hmem=memory_type_list_all)  # PR CI, GPU
+
+    A missing kwarg falls back to the less specific one and finally to the
+    positional list, so forgetting a kwarg widens coverage rather than silently
+    dropping it.
 
     Fallback (no coverage regression): if --server-id/--client-id are not
     provided or device detection fails, every candidate memory type is
@@ -144,7 +222,10 @@ def add_memory_type_parametrization(metafunc, memory_type_marker):
             f"but is missing @pytest.mark.memory_type(...)"
         )
 
-    candidates = memory_type_marker.args[0]
+
+    _, candidates = marker_kwarg_for_test_type(memory_type_marker, test_type)
+    if candidates is None:
+        candidates = memory_type_marker.args[0]
 
     server_id = metafunc.config.getoption("--server-id", default=None)
     client_id = metafunc.config.getoption("--client-id", default=None)
@@ -187,7 +268,7 @@ def pytest_generate_tests(metafunc):
 
     # parametrize memory_type from its marker, dropping permutations
     # whose device is absent on the owning endpoint
-    add_memory_type_parametrization(metafunc, memory_type_marker)
+    add_memory_type_parametrization(metafunc, memory_type_marker, test_type)
 
 hmem_type_list = [
     pytest.param("cuda", marks=pytest.mark.cuda_memory),

--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -9,6 +9,31 @@ from collections import deque
 from common import SshConnectionError, is_ssh_connection_error, has_ssh_connection_err_msg, ClientServerTest
 from retrying import retry
 
+# EFA-specific memory type lists for the @pytest.mark.memory_type decorator.
+# The bi-directional set; uni-directional tests add the *_to_host entries.
+memory_type_list_bi_dir = [
+    pytest.param("host_to_host"),
+    pytest.param("host_to_cuda", marks=pytest.mark.cuda_memory),
+    pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
+    pytest.param("host_to_neuron", marks=pytest.mark.neuron_memory),
+    pytest.param("neuron_to_neuron", marks=pytest.mark.neuron_memory),
+    pytest.param("host_to_rocr", marks=pytest.mark.rocr_memory),
+    pytest.param("rocr_to_rocr", marks=pytest.mark.rocr_memory),
+]
+
+memory_type_list_all = memory_type_list_bi_dir + [
+    pytest.param("cuda_to_host", marks=pytest.mark.cuda_memory),
+    pytest.param("neuron_to_host", marks=pytest.mark.neuron_memory),
+    pytest.param("rocr_to_host", marks=pytest.mark.rocr_memory),
+]
+
+memory_type_list_symm = [
+    pytest.param("host_to_host"),
+    pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
+    pytest.param("neuron_to_neuron", marks=pytest.mark.neuron_memory),
+    pytest.param("rocr_to_rocr", marks=pytest.mark.rocr_memory),
+]
+
 # EFA-specific message size lists for @pytest.mark.message_sizes decorator.
 # Generic (shared) size lists live in fabtests/pytest/common.py.
 DIRECT_SIZES = ["r:0,4,32", "r:0,1024,8192"]

--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -34,6 +34,15 @@ memory_type_list_symm = [
     pytest.param("rocr_to_rocr", marks=pytest.mark.rocr_memory),
 ]
 
+# Device memory only, no host_to_host. The PR CI default for an accelerator
+# instance: host memory is covered by the accelerator free instances in the PR
+# CI matrix, so an accelerator instance only needs the device permutations.
+memory_type_list_device_to_device = [
+    pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
+    pytest.param("neuron_to_neuron", marks=pytest.mark.neuron_memory),
+    pytest.param("rocr_to_rocr", marks=pytest.mark.rocr_memory),
+]
+
 # Single memory type lists for tests that run only one.
 memory_type_list_cuda_to_cuda = [
     pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),

--- a/fabtests/pytest/efa/efa_common.py
+++ b/fabtests/pytest/efa/efa_common.py
@@ -34,6 +34,15 @@ memory_type_list_symm = [
     pytest.param("rocr_to_rocr", marks=pytest.mark.rocr_memory),
 ]
 
+# Single memory type lists for tests that run only one.
+memory_type_list_cuda_to_cuda = [
+    pytest.param("cuda_to_cuda", marks=pytest.mark.cuda_memory),
+]
+
+memory_type_list_neuron_to_neuron = [
+    pytest.param("neuron_to_neuron", marks=pytest.mark.neuron_memory),
+]
+
 # EFA-specific message size lists for @pytest.mark.message_sizes decorator.
 # Generic (shared) size lists live in fabtests/pytest/common.py.
 DIRECT_SIZES = ["r:0,4,32", "r:0,1024,8192"]

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -1,5 +1,5 @@
 from efa.efa_common import (efa_run_client_server_test, DIRECT_SIZES,
-                            memory_type_list_all, memory_type_list_bi_dir)
+                            memory_type_list_all, memory_type_list_bi_dir, memory_type_list_device_to_device)
 from common import (perf_progress_model_cli,
                     PERF_SIZES, PERF_PR_CI, RANGE_SIZES, INJECT_SIZES)
 
@@ -39,7 +39,8 @@ def test_rdm_bw_functional_efa(cmdline_args, completion_semantic):
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
-@pytest.mark.memory_type(memory_type_list_bi_dir)
+@pytest.mark.pr_ci_hmem
+@pytest.mark.memory_type(memory_type_list_bi_dir, pr_ci_hmem=memory_type_list_all)
 def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic,
                       memory_type, completion_type, fabric, message_sizes):
     command = "fi_rdm_pingpong"  + " " + perf_progress_model_cli
@@ -71,7 +72,8 @@ def test_rdm_pingpong_no_inject_range(cmdline_args, completion_semantic, message
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
-@pytest.mark.memory_type(memory_type_list_bi_dir)
+@pytest.mark.pr_ci_hmem
+@pytest.mark.memory_type(memory_type_list_bi_dir, pr_ci_hmem=memory_type_list_device_to_device)
 def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type, message_sizes):
     command = "fi_rdm_tagged_pingpong"  + " " + perf_progress_model_cli
     efa_run_client_server_test(cmdline_args, command, iteration_type,
@@ -144,7 +146,8 @@ def test_rdm_tagged_bw_use_fi_more(cmdline_args, completion_semantic, memory_typ
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
-@pytest.mark.memory_type(memory_type_list_all)
+@pytest.mark.pr_ci_hmem
+@pytest.mark.memory_type(memory_type_list_all, pr_ci_hmem=memory_type_list_device_to_device)
 def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic, memory_type):
     from copy import copy
 
@@ -221,7 +224,8 @@ def test_mr_exhaustion_rdm_pingpong(cmdline_args, completion_semantic):
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
-@pytest.mark.memory_type(memory_type_list_bi_dir)
+@pytest.mark.pr_ci_hmem
+@pytest.mark.memory_type(memory_type_list_bi_dir, pr_ci_hmem=memory_type_list_device_to_device)
 def test_rdm_pingpong_no_mr_local(cmdline_args, iteration_type, completion_semantic,
                       memory_type, completion_type, mr_cache, message_sizes):
     command = "fi_rdm_pingpong -M mr_local"  + " " + perf_progress_model_cli
@@ -241,7 +245,8 @@ def test_rdm_pingpong_no_mr_local(cmdline_args, iteration_type, completion_seman
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
-@pytest.mark.memory_type(memory_type_list_bi_dir)
+@pytest.mark.pr_ci_hmem
+@pytest.mark.memory_type(memory_type_list_bi_dir, pr_ci_hmem=memory_type_list_device_to_device)
 def test_rma_pingpong_no_mr_local(cmdline_args, iteration_type, completion_semantic,
                       memory_type, mr_cache, message_sizes):
     command = "fi_rma_pingpong -o writedata -M mr_local"  + " " + perf_progress_model_cli

--- a/fabtests/pytest/efa/test_rdm.py
+++ b/fabtests/pytest/efa/test_rdm.py
@@ -1,4 +1,5 @@
-from efa.efa_common import efa_run_client_server_test, DIRECT_SIZES
+from efa.efa_common import (efa_run_client_server_test, DIRECT_SIZES,
+                            memory_type_list_all, memory_type_list_bi_dir)
 from common import (perf_progress_model_cli,
                     PERF_SIZES, PERF_PR_CI, RANGE_SIZES, INJECT_SIZES)
 
@@ -38,20 +39,22 @@ def test_rdm_bw_functional_efa(cmdline_args, completion_semantic):
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
+@pytest.mark.memory_type(memory_type_list_bi_dir)
 def test_rdm_pingpong(cmdline_args, iteration_type, completion_semantic,
-                      memory_type_bi_dir, completion_type, fabric, message_sizes):
+                      memory_type, completion_type, fabric, message_sizes):
     command = "fi_rdm_pingpong"  + " " + perf_progress_model_cli
     efa_run_client_server_test(cmdline_args, command, iteration_type,
-                               completion_semantic, memory_type_bi_dir,
+                               completion_semantic, memory_type,
                                message_sizes,
                                completion_type=completion_type, fabric=fabric)
 
 @pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.message_sizes(default_efa=RANGE_SIZES, default_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
-def test_rdm_pingpong_range(cmdline_args, completion_semantic, memory_type_bi_dir, message_sizes, fabric):
+@pytest.mark.memory_type(memory_type_list_bi_dir)
+def test_rdm_pingpong_range(cmdline_args, completion_semantic, memory_type, message_sizes, fabric):
     efa_run_client_server_test(cmdline_args, "fi_rdm_pingpong", "short",
-                               completion_semantic, memory_type_bi_dir,
+                               completion_semantic, memory_type,
                                message_sizes, fabric=fabric)
 
 @pytest.mark.fabric(params=["efa", "efa-direct"])
@@ -68,23 +71,26 @@ def test_rdm_pingpong_no_inject_range(cmdline_args, completion_semantic, message
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
-def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type_bi_dir, completion_type, message_sizes):
+@pytest.mark.memory_type(memory_type_list_bi_dir)
+def test_rdm_tagged_pingpong(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type, message_sizes):
     command = "fi_rdm_tagged_pingpong"  + " " + perf_progress_model_cli
     efa_run_client_server_test(cmdline_args, command, iteration_type,
-                               completion_semantic, memory_type_bi_dir, message_sizes, completion_type=completion_type,
+                               completion_semantic, memory_type, message_sizes, completion_type=completion_type,
                                fabric="efa")
 
 @pytest.mark.message_sizes(default_efa=RANGE_SIZES)
 @pytest.mark.functional
-def test_rdm_tagged_pingpong_range(cmdline_args, completion_semantic, memory_type_bi_dir, message_sizes):
+@pytest.mark.memory_type(memory_type_list_bi_dir)
+def test_rdm_tagged_pingpong_range(cmdline_args, completion_semantic, memory_type, message_sizes):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_pingpong", "short",
-                               completion_semantic, memory_type_bi_dir, message_sizes,
+                               completion_semantic, memory_type, message_sizes,
                                fabric="efa")
 
 @pytest.mark.message_sizes(default_efa=PERF_SIZES)
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory_type, completion_type, message_sizes):
     command = "fi_rdm_tagged_bw"  + " " + perf_progress_model_cli
     efa_run_client_server_test(cmdline_args, command, iteration_type,
@@ -93,6 +99,7 @@ def test_rdm_tagged_bw(cmdline_args, iteration_type, completion_semantic, memory
 
 @pytest.mark.message_sizes(default_efa=RANGE_SIZES)
 @pytest.mark.functional
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_tagged_bw_range(cmdline_args, completion_semantic, memory_type, message_sizes):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw", "short",
                                completion_semantic, memory_type, message_sizes, fabric="efa")
@@ -106,6 +113,7 @@ def test_rdm_tagged_bw_no_inject_range(cmdline_args, completion_semantic, messag
 # Testing both power-2 and non-power-2 sizes
 @pytest.mark.functional
 @pytest.mark.parametrize("env_vars", [["FI_EFA_TX_SIZE=64"], ["FI_EFA_RX_SIZE=64"], ["FI_EFA_TX_SIZE=64", "FI_EFA_RX_SIZE=64"], ["FI_EFA_TX_SIZE=43", "FI_EFA_RX_SIZE=51"]])
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_tagged_bw_small_tx_rx(cmdline_args, completion_semantic, memory_type, completion_type, env_vars):
     cmdline_args_copy = copy.copy(cmdline_args)
     for env_var in env_vars:
@@ -116,6 +124,7 @@ def test_rdm_tagged_bw_small_tx_rx(cmdline_args, completion_semantic, memory_typ
                                fabric="efa")
 
 @pytest.mark.functional
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_tagged_bw_small_recv_window(cmdline_args, completion_semantic, memory_type, completion_type):
     cmdline_args_copy = copy.copy(cmdline_args)
     cmdline_args_copy.append_environ("FI_EFA_RECVWIN_SIZE=1")
@@ -125,6 +134,7 @@ def test_rdm_tagged_bw_small_recv_window(cmdline_args, completion_semantic, memo
 
 @pytest.mark.message_sizes(default_efa=RANGE_SIZES)
 @pytest.mark.functional
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_tagged_bw_use_fi_more(cmdline_args, completion_semantic, memory_type, message_sizes):
     efa_run_client_server_test(cmdline_args, "fi_rdm_tagged_bw --use-fi-more",
                                "short", completion_semantic, memory_type, message_sizes, fabric="efa")
@@ -134,6 +144,7 @@ def test_rdm_tagged_bw_use_fi_more(cmdline_args, completion_semantic, memory_typ
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rdm_atomic(cmdline_args, iteration_type, completion_semantic, memory_type):
     from copy import copy
 
@@ -176,7 +187,8 @@ def test_rdm_pingpong_1G(cmdline_args, completion_semantic):
 @pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("comp_method", ["sread", "fd"])
-def test_rdm_pingpong_sread(cmdline_args, completion_semantic, memory_type_bi_dir,
+@pytest.mark.memory_type(memory_type_list_bi_dir)
+def test_rdm_pingpong_sread(cmdline_args, completion_semantic, memory_type,
                             support_sread, comp_method, fabric, message_sizes):
     if not support_sread:
         pytest.skip("sread not supported by efa device.")
@@ -186,7 +198,7 @@ def test_rdm_pingpong_sread(cmdline_args, completion_semantic, memory_type_bi_di
             pytest.skip("FI_WAIT_FD not supported for EFA protocol with SHM enabled")
         additional_env = "FI_EFA_ENABLE_SHM_TRANSFER=0"
     efa_run_client_server_test(cmdline_args, f"fi_rdm_pingpong -c {comp_method}", "short",
-                               completion_semantic, memory_type_bi_dir,
+                               completion_semantic, memory_type,
                                message_sizes,
                                fabric=fabric, additional_env=additional_env)
 
@@ -209,8 +221,9 @@ def test_mr_exhaustion_rdm_pingpong(cmdline_args, completion_semantic):
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
+@pytest.mark.memory_type(memory_type_list_bi_dir)
 def test_rdm_pingpong_no_mr_local(cmdline_args, iteration_type, completion_semantic,
-                      memory_type_bi_dir, completion_type, mr_cache, message_sizes):
+                      memory_type, completion_type, mr_cache, message_sizes):
     command = "fi_rdm_pingpong -M mr_local"  + " " + perf_progress_model_cli
 
     additional_env = ''
@@ -218,7 +231,7 @@ def test_rdm_pingpong_no_mr_local(cmdline_args, iteration_type, completion_seman
         additional_env = 'FI_EFA_MR_CACHE_ENABLE=0'
 
     efa_run_client_server_test(cmdline_args, command, iteration_type,
-                               completion_semantic, memory_type_bi_dir, message_sizes,
+                               completion_semantic, memory_type, message_sizes,
                                completion_type=completion_type, fabric="efa",
                                additional_env=additional_env)
 
@@ -228,8 +241,9 @@ def test_rdm_pingpong_no_mr_local(cmdline_args, iteration_type, completion_seman
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
 @pytest.mark.pr_ci
+@pytest.mark.memory_type(memory_type_list_bi_dir)
 def test_rma_pingpong_no_mr_local(cmdline_args, iteration_type, completion_semantic,
-                      memory_type_bi_dir, mr_cache, message_sizes):
+                      memory_type, mr_cache, message_sizes):
     command = "fi_rma_pingpong -o writedata -M mr_local"  + " " + perf_progress_model_cli
 
     additional_env = ''
@@ -237,7 +251,7 @@ def test_rma_pingpong_no_mr_local(cmdline_args, iteration_type, completion_seman
         additional_env = 'FI_EFA_MR_CACHE_ENABLE=0'
 
     efa_run_client_server_test(cmdline_args, command, iteration_type,
-                               completion_semantic, memory_type_bi_dir, message_sizes,
+                               completion_semantic, memory_type, message_sizes,
                                completion_type="queue", fabric="efa",
                                additional_env=additional_env)
 

--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -1,4 +1,5 @@
-from efa.efa_common import efa_run_client_server_test, DIRECT_RMA_SIZES
+from efa.efa_common import (efa_run_client_server_test, DIRECT_RMA_SIZES,
+                            memory_type_list_all)
 from common import (perf_progress_model_cli, ClientServerTest,
                     PERF_SIZES, PERF_PR_CI, RANGE_SIZES, INJECT_SIZES)
 import pytest
@@ -12,6 +13,7 @@ import copy
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rma_bw(cmdline_args, iteration_type, rma_operation_type, rma_bw_completion_semantic, rma_bw_memory_type, rma_fabric, rx_cq_data_cli, message_sizes):
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + rma_operation_type + " " + perf_progress_model_cli + rx_cq_data_cli
@@ -24,6 +26,7 @@ def test_rma_bw(cmdline_args, iteration_type, rma_operation_type, rma_bw_complet
 @pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_RMA_SIZES)
 @pytest.mark.parametrize("env_vars", [["FI_EFA_TX_SIZE=64"], ["FI_EFA_RX_SIZE=64"], ["FI_EFA_TX_SIZE=64", "FI_EFA_RX_SIZE=64"]])
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, rma_bw_completion_semantic, rma_bw_memory_type, env_vars, rma_fabric, message_sizes):
     cmdline_args_copy = copy.copy(cmdline_args)
     for env_var in env_vars:
@@ -40,6 +43,7 @@ def test_rma_bw_small_tx_rx(cmdline_args, rma_operation_type, rma_bw_completion_
 @pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.message_sizes(default_efa=RANGE_SIZES, default_efa_direct=DIRECT_RMA_SIZES)
 @pytest.mark.functional
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rma_bw_range(cmdline_args, rma_operation_type, rma_bw_completion_semantic, message_sizes, rma_bw_memory_type, rma_fabric, completion_type):
     if completion_type == "counter" and rma_operation_type == "writedata":
         pytest.skip("writedata target cannot track remote-write completions with counters")
@@ -126,6 +130,7 @@ def test_rma_bw_use_fi_more(cmdline_args, operation_type, iteration_type, rma_bw
                            pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_RMA_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("comp_method", ["sread", "fd"])
+@pytest.mark.memory_type(memory_type_list_all)
 def test_rma_bw_sread(cmdline_args, rma_operation_type, rma_bw_completion_semantic,
                       rma_bw_memory_type, support_sread, comp_method,
                       rma_fabric, message_sizes):

--- a/fabtests/pytest/efa/test_rma_bw.py
+++ b/fabtests/pytest/efa/test_rma_bw.py
@@ -1,5 +1,5 @@
 from efa.efa_common import (efa_run_client_server_test, DIRECT_RMA_SIZES,
-                            memory_type_list_all)
+                            memory_type_list_all, memory_type_list_device_to_device)
 from common import (perf_progress_model_cli, ClientServerTest,
                     PERF_SIZES, PERF_PR_CI, RANGE_SIZES, INJECT_SIZES)
 import pytest
@@ -7,13 +7,14 @@ import copy
 
 
 @pytest.mark.pr_ci
+@pytest.mark.pr_ci_hmem
 @pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_RMA_SIZES,
                            pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_RMA_SIZES)
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-@pytest.mark.memory_type(memory_type_list_all)
+@pytest.mark.memory_type(memory_type_list_all, pr_ci_hmem=memory_type_list_device_to_device)
 def test_rma_bw(cmdline_args, iteration_type, rma_operation_type, rma_bw_completion_semantic, rma_bw_memory_type, rma_fabric, rx_cq_data_cli, message_sizes):
     command = "fi_rma_bw -e rdm"
     command = command + " -o " + rma_operation_type + " " + perf_progress_model_cli + rx_cq_data_cli

--- a/fabtests/pytest/efa/test_rma_pingpong.py
+++ b/fabtests/pytest/efa/test_rma_pingpong.py
@@ -1,4 +1,5 @@
-from efa.efa_common import efa_run_client_server_test, DIRECT_RMA_SIZES
+from efa.efa_common import (efa_run_client_server_test, DIRECT_RMA_SIZES,
+                            memory_type_list_bi_dir)
 from common import perf_progress_model_cli, PERF_SIZES, PERF_PR_CI, RMA_PINGPONG_SIZES
 import pytest
 
@@ -11,34 +12,37 @@ import pytest
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-def test_rma_pingpong(cmdline_args, iteration_type, operation_type, rma_bw_completion_semantic, memory_type_bi_dir, rma_fabric, message_sizes):
+@pytest.mark.memory_type(memory_type_list_bi_dir)
+def test_rma_pingpong(cmdline_args, iteration_type, operation_type, rma_bw_completion_semantic, memory_type, rma_fabric, message_sizes):
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type + " " + perf_progress_model_cli
     efa_run_client_server_test(cmdline_args, command, iteration_type, rma_bw_completion_semantic,
-                                memory_type_bi_dir, message_sizes, fabric=rma_fabric)
+                                memory_type, message_sizes, fabric=rma_fabric)
 
 
 @pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.message_sizes(default_efa=RMA_PINGPONG_SIZES, default_efa_direct=DIRECT_RMA_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata"])
+@pytest.mark.memory_type(memory_type_list_bi_dir)
 def test_rma_pingpong_range(cmdline_args, operation_type, rma_bw_completion_semantic, message_sizes,
-                            memory_type_bi_dir, rma_fabric):
+                            memory_type, rma_fabric):
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type
     efa_run_client_server_test(cmdline_args, command, "short", rma_bw_completion_semantic,
-                               memory_type_bi_dir, message_sizes, fabric=rma_fabric)
+                               memory_type, message_sizes, fabric=rma_fabric)
 
 
 @pytest.mark.fabric(params=["efa"])
 @pytest.mark.message_sizes(default_efa=RMA_PINGPONG_SIZES)
 @pytest.mark.functional
 @pytest.mark.parametrize("operation_type", ["writedata"])
-def test_rma_pingpong_range_no_inject(cmdline_args, operation_type, rma_bw_completion_semantic, message_sizes, memory_type_bi_dir, rma_fabric):
+@pytest.mark.memory_type(memory_type_list_bi_dir)
+def test_rma_pingpong_range_no_inject(cmdline_args, operation_type, rma_bw_completion_semantic, message_sizes, memory_type, rma_fabric):
     command = "fi_rma_pingpong -e rdm -j 0"
     command = command + " -o " + operation_type
     efa_run_client_server_test(cmdline_args, command, "short", rma_bw_completion_semantic,
-                                memory_type_bi_dir, message_sizes, fabric=rma_fabric)
+                                memory_type, message_sizes, fabric=rma_fabric)
 
 
 @pytest.mark.fabric(params=["efa-direct"])

--- a/fabtests/pytest/efa/test_rma_pingpong.py
+++ b/fabtests/pytest/efa/test_rma_pingpong.py
@@ -1,10 +1,11 @@
 from efa.efa_common import (efa_run_client_server_test, DIRECT_RMA_SIZES,
-                            memory_type_list_bi_dir)
+                            memory_type_list_all, memory_type_list_bi_dir)
 from common import perf_progress_model_cli, PERF_SIZES, PERF_PR_CI, RMA_PINGPONG_SIZES
 import pytest
 
 
 @pytest.mark.pr_ci
+@pytest.mark.pr_ci_hmem
 @pytest.mark.fabric(params=["efa", "efa-direct"])
 @pytest.mark.message_sizes(default_efa=PERF_SIZES, default_efa_direct=DIRECT_RMA_SIZES,
                            pr_ci_efa=PERF_PR_CI, pr_ci_efa_direct=DIRECT_RMA_SIZES)
@@ -12,7 +13,7 @@ import pytest
 @pytest.mark.parametrize("iteration_type",
                          [pytest.param("short", marks=pytest.mark.short),
                           pytest.param("standard", marks=pytest.mark.standard)])
-@pytest.mark.memory_type(memory_type_list_bi_dir)
+@pytest.mark.memory_type(memory_type_list_bi_dir, pr_ci_hmem=memory_type_list_all)
 def test_rma_pingpong(cmdline_args, iteration_type, operation_type, rma_bw_completion_semantic, memory_type, rma_fabric, message_sizes):
     command = "fi_rma_pingpong -e rdm"
     command = command + " -o " + operation_type + " " + perf_progress_model_cli

--- a/fabtests/pytest/efa/test_runt.py
+++ b/fabtests/pytest/efa/test_runt.py
@@ -103,16 +103,18 @@ def run_runt_read_functional(cmdline_args, memory_type, copy_method):
 # efa-direct does not have runt read so skip this test
 @pytest.mark.serial
 @pytest.mark.functional
-@pytest.mark.memory_type(memory_type_list_cuda_to_cuda)
+@pytest.mark.memory_type(memory_type_list_cuda_to_cuda, pr_ci_hmem=memory_type_list_cuda_to_cuda)
 @pytest.mark.parametrize("copy_method", ["gdrcopy", "localread"])
 @pytest.mark.pr_ci
+@pytest.mark.pr_ci_hmem
 def test_runt_read_functional_cuda(cmdline_args, memory_type, copy_method):
     run_runt_read_functional(cmdline_args, memory_type, copy_method)
 
 
 @pytest.mark.serial
 @pytest.mark.functional
-@pytest.mark.memory_type(memory_type_list_neuron_to_neuron)
+@pytest.mark.memory_type(memory_type_list_neuron_to_neuron, pr_ci_hmem=memory_type_list_neuron_to_neuron)
 @pytest.mark.pr_ci
+@pytest.mark.pr_ci_hmem
 def test_runt_read_functional_neuron(cmdline_args, memory_type):
     run_runt_read_functional(cmdline_args, memory_type, copy_method=None)

--- a/fabtests/pytest/efa/test_runt.py
+++ b/fabtests/pytest/efa/test_runt.py
@@ -1,19 +1,12 @@
 from efa.efa_common import (efa_retrieve_hw_counter_value,
-                            efa_run_client_server_test, has_gdrcopy)
+                            efa_run_client_server_test, has_gdrcopy,
+                            memory_type_list_cuda_to_cuda,
+                            memory_type_list_neuron_to_neuron)
 
 import pytest
 
 
-# this test must be run in serial mode because it check hw counter
-# efa-direct does not have runt read so skip this test
-@pytest.mark.serial
-@pytest.mark.functional
-@pytest.mark.parametrize("memory_type,copy_method", [
-    pytest.param("cuda_to_cuda", "gdrcopy", marks=pytest.mark.cuda_memory),
-    pytest.param("cuda_to_cuda", "localread", marks=pytest.mark.cuda_memory),
-    pytest.param("neuron_to_neuron", None, marks=pytest.mark.neuron_memory)])
-@pytest.mark.pr_ci
-def test_runt_read_functional(cmdline_args, memory_type, copy_method):
+def run_runt_read_functional(cmdline_args, memory_type, copy_method):
     """
     Verify runt read protocol works with FI_OPT_EFA_HOMOGENEOUS_PEERS set,
     which skips the handshake. This sends 1 message of 256 KB using
@@ -104,3 +97,22 @@ def test_runt_read_functional(cmdline_args, memory_type, copy_method):
         # for which the server (receiver) will issue 1 read request.
         assert server_read_wrs == 1
         assert server_read_bytes == 196608
+
+
+# this test must be run in serial mode because it checks hw counters
+# efa-direct does not have runt read so skip this test
+@pytest.mark.serial
+@pytest.mark.functional
+@pytest.mark.memory_type(memory_type_list_cuda_to_cuda)
+@pytest.mark.parametrize("copy_method", ["gdrcopy", "localread"])
+@pytest.mark.pr_ci
+def test_runt_read_functional_cuda(cmdline_args, memory_type, copy_method):
+    run_runt_read_functional(cmdline_args, memory_type, copy_method)
+
+
+@pytest.mark.serial
+@pytest.mark.functional
+@pytest.mark.memory_type(memory_type_list_neuron_to_neuron)
+@pytest.mark.pr_ci
+def test_runt_read_functional_neuron(cmdline_args, memory_type):
+    run_runt_read_functional(cmdline_args, memory_type, copy_method=None)

--- a/fabtests/pytest/efa/test_unexpected_msg.py
+++ b/fabtests/pytest/efa/test_unexpected_msg.py
@@ -1,5 +1,5 @@
 import pytest
-from efa.efa_common import efa_run_client_server_test, memory_type_list_all
+from efa.efa_common import efa_run_client_server_test, memory_type_list_all, memory_type_list_device_to_device
 
 
 SHM_DEFAULT_MAX_INJECT_SIZE = 4096
@@ -8,10 +8,11 @@ SHM_DEFAULT_RX_SIZE = 1024
 
 # This test skips efa-direct because it does not have unexpected message
 @pytest.mark.pr_ci
+@pytest.mark.pr_ci_hmem
 @pytest.mark.functional
 @pytest.mark.parametrize("msg_size", [1, 512, 9000, 1048576]) # cover various switch points of shm/efa protocols
 @pytest.mark.parametrize("msg_count", [1, 1024, 2048]) # below and above shm's default rx size
-@pytest.mark.memory_type(memory_type_list_all)
+@pytest.mark.memory_type(memory_type_list_all, pr_ci_hmem=memory_type_list_device_to_device)
 def test_unexpected_msg(cmdline_args, msg_size, msg_count, memory_type, completion_semantic):
     from common import ClientServerTest
     if cmdline_args.server_id == cmdline_args.client_id:

--- a/fabtests/pytest/efa/test_unexpected_msg.py
+++ b/fabtests/pytest/efa/test_unexpected_msg.py
@@ -1,5 +1,5 @@
 import pytest
-from efa.efa_common import efa_run_client_server_test
+from efa.efa_common import efa_run_client_server_test, memory_type_list_all
 
 
 SHM_DEFAULT_MAX_INJECT_SIZE = 4096
@@ -11,6 +11,7 @@ SHM_DEFAULT_RX_SIZE = 1024
 @pytest.mark.functional
 @pytest.mark.parametrize("msg_size", [1, 512, 9000, 1048576]) # cover various switch points of shm/efa protocols
 @pytest.mark.parametrize("msg_count", [1, 1024, 2048]) # below and above shm's default rx size
+@pytest.mark.memory_type(memory_type_list_all)
 def test_unexpected_msg(cmdline_args, msg_size, msg_count, memory_type, completion_semantic):
     from common import ClientServerTest
     if cmdline_args.server_id == cmdline_args.client_id:

--- a/fabtests/pytest/pytest.ini
+++ b/fabtests/pytest/pytest.ini
@@ -16,6 +16,7 @@ markers =
     pr_ci: test is included in the PR CI suite
     message_sizes: decorator specifying default and pr_ci message size lists
     fabric: decorator declaring the set of libfabric fabric values a test runs on
+    memory_type: decorator declaring the memory type a test runs on (a memory_type_list_* from efa_common)
     hw_cntr: test requires fi_efa_hw_cntr binary (built with efadv_create_comp_cntr)
     gda: test requires fi_efa_gda binary (built with --enable-efagda)
 junit_suite_name = fabtests

--- a/fabtests/pytest/pytest.ini
+++ b/fabtests/pytest/pytest.ini
@@ -14,6 +14,7 @@ markers =
     serial: test must be run in seria mode
     unstable: test is unstable and only run when the marker is specified.
     pr_ci: test is included in the PR CI suite
+    pr_ci_hmem: test is included in the PR CI suite on accelerator (HMEM) instances
     message_sizes: decorator specifying default and pr_ci message size lists
     fabric: decorator declaring the set of libfabric fabric values a test runs on
     memory_type: decorator declaring the memory type a test runs on (a memory_type_list_* from efa_common)


### PR DESCRIPTION
* f9e4be97 [v2.6.x]fabtests/efa: Declare the PR CI HMEM memory type matrix per test
* fd30ced4 [v2.6.x]fabtests/pytest: Add a pr_ci_hmem test type for the PR CI HMEM matrix
* 1beff0bf [v2.6.x]fabtests/efa: decouple memory type from copy_method in runt read test
* 331e1277 [v2.6.x]fabtests/efa: annotate tests with memory_type markers
* 0cb883fc [v2.6.x]fabtests/efa: add memory_type marker to filter cases at collection
* 566f275a (upstream/v2.6.x) prov/efa: use RDMA read to copy Neuron RX payload into HBM