### PR TITLE
prov/efa: move FI_EFA_MR_RELAXED_ORDERING to bit 61

### DIFF
--- a/prov/efa/src/fi_ext_efa.h
+++ b/prov/efa/src/fi_ext_efa.h
@@ -154,7 +154,7 @@ struct fi_efa_feature_ops {
  * endpoint appear at the target after it. When FI_EFA_MR_RELAXED_ORDERING is
  * set, that ordering guarantee is lost.
  */
-#define FI_EFA_MR_RELAXED_ORDERING (1ULL << 60)
+#define FI_EFA_MR_RELAXED_ORDERING (1ULL << 61)
 
 enum {
 	FI_EFA_EP_ATTR_QKEY = 1 << 0,

--- a/prov/efa/src/rdm/efa_rdm_mr.c
+++ b/prov/efa/src/rdm/efa_rdm_mr.c
@@ -774,6 +774,41 @@ int efa_rdm_mr_cache_regv(struct fid_domain *domain_fid, const struct iovec *iov
 }
 
 
+/**
+ * @brief Derive the flags to use for the shm MR registration from the flags
+ * stored on the efa_rdm_mr.
+ *
+ * The shm provider does not understand EFA-device-specific hints, so any such
+ * hint (e.g. FI_EFA_MR_RELAXED_ORDERING) is stripped here. Device memory is
+ * marked with FI_HMEM_DEVICE_ONLY so shm can handle it correctly.
+ *
+ * This is factored out (rather than inlined in efa_rdm_mr_regattr) so the flag
+ * derivation can be unit tested directly. In particular it guards against a
+ * regression where stripping an EFA-specific bit would also clear an unrelated
+ * internal bit such as OFI_HMEM_DATA_DEV_REG_HANDLE (the gdrcopy handle flag)
+ * if the two ever shared a bit position.
+ *
+ * @param[in] mr_flags	the flags stored on efa_rdm_mr->flags
+ * @param[in] iface	the memory interface of the region
+ * @return the flags to pass to fi_mr_regattr for the shm MR
+ */
+uint64_t efa_rdm_mr_shm_flags(uint64_t mr_flags, enum fi_hmem_iface iface)
+{
+	uint64_t shm_flags = mr_flags;
+
+	if (iface != FI_HMEM_SYSTEM)
+		shm_flags |= FI_HMEM_DEVICE_ONLY;
+
+	/*
+	 * FI_EFA_MR_RELAXED_ORDERING is an EFA-device-specific hint; the shm
+	 * provider does not understand it, so strip it from the shm MR
+	 * registration.
+	 */
+	shm_flags &= ~FI_EFA_MR_RELAXED_ORDERING;
+
+	return shm_flags;
+}
+
 /* RDM MR registration - handles SHM integration and advanced features */
 static int efa_rdm_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 			      uint64_t flags, struct fid_mr **mr_fid)
@@ -818,18 +853,9 @@ static int efa_rdm_mr_regattr(struct fid *fid, const struct fi_mr_attr *attr,
 
 	/* RDM-specific: SHM MR registration */
 	if (rdm_domain->shm_domain) {
-		uint64_t shm_flags = efa_rdm_mr->flags;
+		uint64_t shm_flags = efa_rdm_mr_shm_flags(efa_rdm_mr->flags,
+							  mr_attr.iface);
 		struct fi_mr_attr shm_attr = mr_attr;
-
-		if (mr_attr.iface != FI_HMEM_SYSTEM)
-			shm_flags |= FI_HMEM_DEVICE_ONLY;
-
-		/*
-		 * FI_EFA_MR_RELAXED_ORDERING is an EFA-device-specific hint; the
-		 * shm provider does not understand it, so strip it from the shm
-		 * MR registration.
-		 */
-		shm_flags &= ~FI_EFA_MR_RELAXED_ORDERING;
 
 		shm_attr.hmem_data = efa_rdm_mr->hmem_data;
 		ret = fi_mr_regattr(rdm_domain->shm_domain,

--- a/prov/efa/src/rdm/efa_rdm_mr.h
+++ b/prov/efa/src/rdm/efa_rdm_mr.h
@@ -61,6 +61,12 @@ int efa_rdm_mr_cache_regv(struct fid_domain *domain_fid, const struct iovec *iov
 			  struct fid_mr **mr, void *context);
 
 /**
+ * @brief Derive the flags to use for the shm MR registration from the flags
+ * stored on an efa_rdm_mr. Exposed for unit testing.
+ */
+uint64_t efa_rdm_mr_shm_flags(uint64_t mr_flags, enum fi_hmem_iface iface);
+
+/**
  * @brief Advance the MR generation counter, skipping EFA_RDM_MR_INVALID_GEN_VALUE.
  *
  * EFA_RDM_MR_INVALID_GEN_VALUE is reserved as a sentinel in ope->desc_gen[]

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.c
@@ -7,6 +7,8 @@
 #include "efa_mr.h"
 #include "efa_device.h"
 #include "rdm/efa_rdm_ep.h"
+#include "rdm/efa_rdm_mr.h"
+#include "ofi_mr.h"
 #include "efa_gtest_common_helpers.h"
 
 void efa_test_fabricate_addr(struct fid_ep *ep, struct efa_ep_addr *addr)
@@ -220,4 +222,19 @@ void efa_test_util_domain_unlock(struct fid_domain *domain)
 		domain, struct efa_domain, util_domain.domain_fid);
 
 	ofi_genlock_unlock(&efa_domain->util_domain.lock);
+}
+
+/*
+ * The gdrcopy device-registration handle bit (OFI_HMEM_DATA_DEV_REG_HANDLE) is
+ * defined in ofi_mr.h, which cannot be included from C++ (it transitively pulls
+ * in _Complex types). Expose it to the C++ tests via this C helper.
+ */
+uint64_t efa_test_ofi_hmem_data_dev_reg_handle(void)
+{
+	return OFI_HMEM_DATA_DEV_REG_HANDLE;
+}
+
+uint64_t efa_test_rdm_mr_shm_flags(uint64_t mr_flags, enum fi_hmem_iface iface)
+{
+	return efa_rdm_mr_shm_flags(mr_flags, iface);
 }

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.h
@@ -144,6 +144,18 @@ int efa_test_util_domain_trylock(struct fid_domain *domain);
  */
 void efa_test_util_domain_unlock(struct fid_domain *domain);
 
+/**
+ * @brief Value of OFI_HMEM_DATA_DEV_REG_HANDLE (the gdrcopy handle bit), which
+ * lives in ofi_mr.h and is not includable from C++.
+ */
+uint64_t efa_test_ofi_hmem_data_dev_reg_handle(void);
+
+/**
+ * @brief Wrapper around the product efa_rdm_mr_shm_flags() so the shm MR flag
+ * derivation can be exercised from C++ tests.
+ */
+uint64_t efa_test_rdm_mr_shm_flags(uint64_t mr_flags, enum fi_hmem_iface iface);
+
 #ifdef __cplusplus
 }
 #endif

--- a/prov/efa/test/gtest/efa_gtest_rdm_mr.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_mr.cc
@@ -4,6 +4,7 @@
 #include "efa_gtest_common_helpers.h"
 #include "efa_gtest_common_mocks.h"
 #include "efa_gtest_common_resource.h"
+#include "fi_ext_efa.h"
 #include <gtest/gtest.h>
 
 using testing::Return;
@@ -67,4 +68,79 @@ TEST_F(EfaRdmMrTest, reg_map_insert_failure_propagates_error)
 
 	if (mr)
 		fi_close(&mr->fid);
+}
+
+
+/*
+ * Regression coverage for the FI_EFA_MR_RELAXED_ORDERING bit assignment.
+ *
+ * FI_EFA_MR_RELAXED_ORDERING (an EFA-specific hint stripped before the shm MR
+ * registration) must not share a bit with OFI_HMEM_DATA_DEV_REG_HANDLE (the
+ * gdrcopy device-registration handle flag stored in efa_rdm_mr->flags). If they
+ * ever alias, deriving the shm flags would clear the gdrcopy handle bit, which
+ * on the intra-node (shm) CUDA path silently drops the fast GDRCopy copy in
+ * favor of the slower cudaMemcpy fallback.
+ */
+
+/**
+ * @brief The two flags must occupy distinct bits. This is the root-cause guard.
+ */
+TEST_F(EfaRdmMrTest, relaxed_ordering_bit_distinct_from_gdrcopy_handle_bit)
+{
+	EXPECT_EQ(FI_EFA_MR_RELAXED_ORDERING &
+			  efa_test_ofi_hmem_data_dev_reg_handle(),
+		  0u)
+		<< "FI_EFA_MR_RELAXED_ORDERING aliases the gdrcopy handle bit "
+		   "OFI_HMEM_DATA_DEV_REG_HANDLE";
+}
+
+/**
+ * @brief Deriving the shm MR flags for a CUDA region that has the gdrcopy
+ * handle bit set must strip FI_EFA_MR_RELAXED_ORDERING while preserving the
+ * gdrcopy handle bit (and adding FI_HMEM_DEVICE_ONLY for device memory).
+ */
+TEST_F(EfaRdmMrTest, shm_flags_preserve_gdrcopy_handle_when_relaxed_ordering_set)
+{
+	uint64_t gdrcopy_bit = efa_test_ofi_hmem_data_dev_reg_handle();
+	uint64_t mr_flags = gdrcopy_bit | FI_EFA_MR_RELAXED_ORDERING;
+
+	uint64_t shm_flags =
+		efa_test_rdm_mr_shm_flags(mr_flags, FI_HMEM_CUDA);
+
+	/* The gdrcopy handle bit survives into the shm flags. */
+	EXPECT_NE(shm_flags & gdrcopy_bit, 0u)
+		<< "shm flag derivation erased the gdrcopy handle bit";
+	/* The EFA-specific relaxed-ordering hint is stripped. */
+	EXPECT_EQ(shm_flags & FI_EFA_MR_RELAXED_ORDERING, 0u)
+		<< "FI_EFA_MR_RELAXED_ORDERING leaked into shm flags";
+	/* Device memory is marked device-only for shm. */
+	EXPECT_NE(shm_flags & FI_HMEM_DEVICE_ONLY, 0u);
+}
+
+/**
+ * @brief Without the gdrcopy handle bit, deriving shm flags must not
+ * spuriously introduce it, and must still strip the relaxed-ordering hint.
+ */
+TEST_F(EfaRdmMrTest, shm_flags_no_gdrcopy_handle_when_bit_absent)
+{
+	uint64_t gdrcopy_bit = efa_test_ofi_hmem_data_dev_reg_handle();
+
+	uint64_t shm_flags = efa_test_rdm_mr_shm_flags(
+		FI_EFA_MR_RELAXED_ORDERING, FI_HMEM_CUDA);
+
+	EXPECT_EQ(shm_flags & gdrcopy_bit, 0u);
+	EXPECT_EQ(shm_flags & FI_EFA_MR_RELAXED_ORDERING, 0u);
+}
+
+/**
+ * @brief For host (system) memory, shm flags must not set FI_HMEM_DEVICE_ONLY
+ * and must still strip the relaxed-ordering hint.
+ */
+TEST_F(EfaRdmMrTest, shm_flags_host_memory_not_device_only)
+{
+	uint64_t shm_flags = efa_test_rdm_mr_shm_flags(
+		FI_EFA_MR_RELAXED_ORDERING, FI_HMEM_SYSTEM);
+
+	EXPECT_EQ(shm_flags & FI_HMEM_DEVICE_ONLY, 0u);
+	EXPECT_EQ(shm_flags & FI_EFA_MR_RELAXED_ORDERING, 0u);
 }


### PR DESCRIPTION
Bit 60 collided with OFI_HMEM_DATA_DEV_REG_HANDLE (ofi_mr.h), which tracks the GDRCopy handle state in efa_rdm_mr->flags. Registering a CUDA buffer with FI_EFA_MR_RELAXED_ORDERING corrupted that state, causing the shm intra-node path to fall back from GDRCopy to cudaMemcpy and regressing small-message CUDA pingpong latency. Move the flag to the unused bit 61.