### PR TITLE
prov/efa: keep an rxe alive while its local read copies

### DIFF
--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -146,7 +146,7 @@ int efa_rdm_ep_create_pke_pool(struct efa_rdm_ep *ep,
 int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 {
 	int ret;
-	size_t min_pool_size, max_pool_size, txe_pool_size;
+	size_t min_pool_size, max_pool_size, txe_pool_size, chunk_size;
 	uint64_t tx_pkt_pool_base_flags = OFI_BUFPOOL_NO_TRACK;
 	uint64_t rx_pkt_pool_base_flags = OFI_BUFPOOL_NO_TRACK;
 
@@ -269,10 +269,13 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 		txe_pool_size = max_pool_size;
 	}
 
+	chunk_size = MIN(MAX(EFA_RDM_TXE_POOL_CHUNK_SIZE, min_pool_size),
+			 txe_pool_size);
+
 	ret = ofi_bufpool_create(&ep->base_ep.txe_pool,
 				 sizeof(struct efa_rdm_ope),
 				 EFA_RDM_BUFPOOL_ALIGNMENT,
-				 txe_pool_size, min_pool_size, 0);
+				 txe_pool_size, chunk_size, 0);
 	if (ret)
 		goto err_free;
 

--- a/prov/efa/src/rdm/efa_rdm_ope.c
+++ b/prov/efa/src/rdm/efa_rdm_ope.c
@@ -2225,6 +2225,13 @@ int efa_rdm_rxe_post_local_read_or_queue(struct efa_rdm_ope *rxe,
 	} else {
 		/*Local RDMA read posted*/
 		efa_rdm_pke_mark_held(txe->local_read_pkt_entry);
+		/*
+		 * TODO: post the copy read on the rxe instead of an internal
+		 * txe, so the rxe's own WR accounting covers it and this
+		 * explicit reference is unnecessary.
+		 */
+		/* Keep the rxe alive until this copy lands in its buffer. */
+		rxe->efa_outstanding_tx_ops++;
 	}
 	return err;
 }

--- a/prov/efa/src/rdm/efa_rdm_ope.h
+++ b/prov/efa/src/rdm/efa_rdm_ope.h
@@ -251,7 +251,11 @@ struct efa_rdm_ope {
 	((size_t) 1 << EFA_RDM_TXE_ID_INDEX_BITS)
 
 /* Default cap on concurrent tx operations, see FI_EFA_RDM_TXE_POOL_SIZE. */
-#define EFA_RDM_TXE_POOL_SIZE_DEFAULT	(8192)
+/* TODO: lower this in the future. */
+#define EFA_RDM_TXE_POOL_SIZE_DEFAULT	EFA_RDM_TXE_POOL_MAX_CNT
+
+/* Entries the txe pool starts at and grows by. */
+#define EFA_RDM_TXE_POOL_CHUNK_SIZE	(8192)
 
 static_assert((EFA_RDM_OPE_ID_INVALID & EFA_RDM_OPE_ID_TAG) != 0,
 	      "the sentinel must be txe tagged so no rxe id can reach it");

--- a/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
+++ b/prov/efa/src/rdm/efa_rdm_pke_nonreq.c
@@ -626,10 +626,22 @@ void efa_rdm_pke_handle_rma_read_completion(struct efa_rdm_pke *context_pkt_entr
 				data_pkt_entry = txe->local_read_pkt_entry;
 				assert(data_pkt_entry->payload_size > 0);
 				efa_rdm_pke_assert_ope_valid(data_pkt_entry);
+				rxe = data_pkt_entry->ope;
 				efa_rdm_tracepoint(rx_pke_local_read_copy_payload_end, (size_t) data_pkt_entry, data_pkt_entry->payload_size, data_pkt_entry->ope->msg_id, (size_t) data_pkt_entry->ope->cq_entry.op_context, data_pkt_entry->ope->total_len);
-				efa_rdm_pke_handle_data_copied(data_pkt_entry);
-				/* Hand off pkt release to efa_rdm_pke_handle_data_copied() above. */
+				/* The copy landed, so drop its rxe reference. */
+				assert(rxe->efa_outstanding_tx_ops > 0);
+				rxe->efa_outstanding_tx_ops--;
 				txe->local_read_pkt_entry = NULL;
+				if (rxe->internal_flags &
+				    EFA_RDM_OPE_PEER_ABORT_PENDING) {
+					/* Canceled recv: the drain owns its
+					 * completion, so skip the success path. */
+					efa_rdm_pke_release_rx(data_pkt_entry);
+					efa_rdm_rxe_release_peer_abort_if_drained(rxe);
+				} else {
+					/* Hand off pkt release to efa_rdm_pke_handle_data_copied(). */
+					efa_rdm_pke_handle_data_copied(data_pkt_entry);
+				}
 			} else {
 				assert(txe && txe->cq_entry.flags & FI_READ);
 				/*

--- a/prov/efa/test/efa_unit_test_ope.c
+++ b/prov/efa/test/efa_unit_test_ope.c
@@ -902,11 +902,16 @@ void test_efa_rdm_ope_txe_pool_capped(void **state)
 	struct efa_resource *resource = *state;
 	struct efa_rdm_ep *ep;
 	struct efa_rdm_ope **txe;
-	size_t i, allocated, pool_size = efa_env.rdm_txe_pool_size;
+	size_t saved = efa_env.rdm_txe_pool_size;
+	size_t i, allocated, pool_size;
 
+	/* the default cap is too large to exhaust here */
+	efa_env.rdm_txe_pool_size = 1024;
 	efa_unit_test_resource_construct(resource, FI_EP_RDM, EFA_FABRIC_NAME);
+	efa_env.rdm_txe_pool_size = saved;
 	ep = container_of(resource->ep, struct efa_rdm_ep,
 			  base_ep.util_ep.ep_fid);
+	pool_size = ep->base_ep.txe_pool->attr.max_cnt;
 
 	txe = calloc(pool_size + 1, sizeof(*txe));
 	assert_non_null(txe);

--- a/prov/efa/test/gtest/efa_gtest_rdm_ope.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_ope.cc
@@ -394,3 +394,81 @@ INSTANTIATE_TEST_SUITE_P(QueuedFlags, EfaRdmOpeQueuedFlagDispatchTest,
 					 return "read";
 				 }
 			 });
+
+class EfaRdmOpeLocalReadAbortTest : public Test
+{
+	protected:
+	struct efa_resource resource = {};
+	StrictMock<MockEfa> mock_efa;
+
+	void SetUp() override
+	{
+		memset(&resource, 0, sizeof(resource));
+
+		ASSERT_NO_FATAL_FAILURE(efa_test_resource_construct(
+			&resource, efa_test_alloc_default_hints(
+					   FI_EP_RDM, EFA_FABRIC_NAME)));
+		ASSERT_NE(resource.ep, nullptr);
+
+		/* Checked after construct: the device list is only populated
+		 * by fi_getinfo. */
+		if (!efa_test_device_supports_rma())
+			GTEST_SKIP()
+				<< "device does not support RDMA read+write";
+
+		MockEfa::set(&mock_efa);
+	}
+
+	void TearDown() override
+	{
+		MockEfa::set(nullptr);
+		efa_test_resource_destruct(&resource);
+	}
+};
+
+TEST_F(EfaRdmOpeLocalReadAbortTest, abort_waits_for_local_read_copy)
+{
+	struct efa_test_local_read_abort state = {};
+	struct fi_cq_err_entry err_entry = {};
+	void *op_context = (void *) 0xc0ffee;
+	struct efa_rdm_pke *ctx_pkt = nullptr;
+
+	EFA_EXPECT_CALL(mock_efa, efa_rdm_pke_read)
+		.WillOnce(DoAll(SaveArg<0>(&ctx_pkt), Return(0)));
+
+	ASSERT_EQ(efa_test_abort_waits_for_local_read_copy_setup(
+			  resource.ep, resource.av, op_context, &state),
+		  0);
+
+	EXPECT_EQ(efa_test_ope_list_rxe_count(resource.ep), 1);
+	EXPECT_EQ(fi_cq_readerr(resource.cq, &err_entry, 0), -FI_EAGAIN);
+
+	ASSERT_NE(ctx_pkt, nullptr);
+	efa_test_abort_waits_for_local_read_copy_retire(&state, ctx_pkt);
+
+	EXPECT_EQ(efa_test_ope_list_rxe_count(resource.ep), 0);
+	ASSERT_EQ(fi_cq_readerr(resource.cq, &err_entry, 0), 1);
+	EXPECT_EQ(err_entry.err, FI_ECANCELED);
+	EXPECT_EQ(err_entry.prov_errno, efa_test_peer_abort_prov_errno());
+	EXPECT_EQ(err_entry.op_context, op_context);
+	EXPECT_EQ(err_entry.flags, (uint64_t) (FI_RECV | FI_MSG));
+	EXPECT_EQ(fi_cq_readerr(resource.cq, &err_entry, 0), -FI_EAGAIN);
+}
+
+TEST_F(EfaRdmOpeLocalReadAbortTest, abort_without_local_read_copy_completes_now)
+{
+	struct efa_test_local_read_abort state = {};
+	struct fi_cq_err_entry err_entry = {};
+	void *op_context = (void *) 0xdecaf;
+
+	ASSERT_EQ(efa_test_abort_without_local_read_copy_completes_now(
+			  resource.ep, resource.av, op_context, &state),
+		  0);
+
+	EXPECT_EQ(efa_test_ope_list_rxe_count(resource.ep), 0);
+	ASSERT_EQ(fi_cq_readerr(resource.cq, &err_entry, 0), 1);
+	EXPECT_EQ(err_entry.err, FI_ECANCELED);
+	EXPECT_EQ(err_entry.prov_errno, efa_test_peer_abort_prov_errno());
+	EXPECT_EQ(err_entry.op_context, op_context);
+	EXPECT_EQ(err_entry.flags, (uint64_t) (FI_RECV | FI_MSG));
+}

--- a/prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.c
@@ -13,6 +13,10 @@
 #include "rdm/efa_rdm_cq.h"
 #include "rdm/efa_rdm_peer.h"
 #include "rdm/efa_rdm_protocol.h"
+#include "rdm/efa_rdm_pke_nonreq.h"
+#include "rdm/efa_rdm_rma.h"
+#include "rdm/efa_rdm_srx.h"
+#include "ofi_util.h"
 
 int efa_test_drive_rxe_unexp_handle_error(struct fid_ep *ep, void *op_context,
 					  int err, int *prov_errno_out)
@@ -340,4 +344,197 @@ void efa_test_simulate_source_mr_canceled(struct efa_test_queued_op *qop)
 int efa_test_peer_abort_prov_errno(void)
 {
 	return FI_EFA_ERR_PEER_ABORTED;
+}
+
+/**
+ * @brief Build a recv matched through the SRX, so the abort path has a
+ * peer_rxe to return and the caller's op_context to report.
+ */
+static int efa_test_alloc_matched_rxe(struct efa_rdm_ep *ep, struct fid_av *av,
+				      char *buf, size_t len, void *op_context,
+				      struct efa_rdm_ope **rxe_out)
+{
+	struct util_srx_ctx *srx_ctx = efa_rdm_ep_get_peer_srx_ctx(ep);
+	struct fid_peer_srx *peer_srx = util_get_peer_srx(ep->peer_srx_ep);
+	struct fi_peer_match_attr match_attr = {0};
+	struct fi_peer_rx_entry *peer_rxe = NULL;
+	struct efa_rdm_ope *rxe;
+	struct efa_rdm_peer *peer;
+	fi_addr_t peer_addr = 0;
+	struct iovec iov;
+	void *desc = NULL;
+	int ret;
+
+	ret = efa_test_av_insert_self(&ep->base_ep.util_ep.ep_fid, av,
+				      &peer_addr);
+	if (ret != 1)
+		return -FI_EINVAL;
+
+	peer = efa_rdm_ep_get_peer_explicit(ep, peer_addr);
+	if (!peer)
+		return -FI_EINVAL;
+
+	iov.iov_base = buf;
+	iov.iov_len = len;
+	ret = util_srx_generic_recv(ep->peer_srx_ep, &iov, &desc, 1,
+				    FI_ADDR_UNSPEC, op_context, 0);
+	if (ret)
+		return ret;
+
+	match_attr.addr = FI_ADDR_UNSPEC;
+	match_attr.msg_size = len;
+
+	ofi_genlock_lock(srx_ctx->lock);
+	ret = peer_srx->owner_ops->get_msg(peer_srx, &match_attr, &peer_rxe);
+	if (ret || !peer_rxe) {
+		ofi_genlock_unlock(srx_ctx->lock);
+		return ret ? ret : -FI_EINVAL;
+	}
+
+	rxe = efa_rdm_ep_alloc_rxe(ep, peer, ofi_op_msg);
+	if (!rxe) {
+		ofi_genlock_unlock(srx_ctx->lock);
+		return -FI_ENOMEM;
+	}
+
+	rxe->state = EFA_RDM_RXE_MATCHED;
+	rxe->peer_rxe = peer_rxe;
+	rxe->cq_entry.op_context = peer_rxe->context;
+	rxe->cq_entry.flags = FI_RECV | FI_MSG;
+	rxe->cq_entry.len = len;
+	rxe->total_len = len;
+	rxe->iov_count = 1;
+	rxe->iov[0] = iov;
+	ofi_genlock_unlock(srx_ctx->lock);
+
+	*rxe_out = rxe;
+	return 0;
+}
+
+static void efa_test_mark_and_drain(struct efa_rdm_ep *ep,
+				    struct efa_rdm_ope *rxe)
+{
+	struct util_srx_ctx *srx_ctx = efa_rdm_ep_get_peer_srx_ctx(ep);
+
+	ofi_genlock_lock(srx_ctx->lock);
+	efa_rdm_rxe_mark_peer_aborted_if_needed(
+		rxe, EFA_IO_COMP_STATUS_REMOTE_ERROR_BAD_ADDRESS);
+	efa_rdm_rxe_release_peer_abort_if_drained(rxe);
+	ofi_genlock_unlock(srx_ctx->lock);
+}
+
+static struct efa_rdm_ope *efa_test_find_local_read_txe(struct efa_rdm_ep *ep,
+						       struct efa_rdm_pke *pke)
+{
+	struct efa_rdm_ope *ope;
+	struct dlist_entry *item;
+
+	dlist_foreach(&ep->base_ep.ope_list, item) {
+		ope = container_of(item, struct efa_rdm_ope, ep_entry);
+		if (ope->type == EFA_RDM_TXE &&
+		    ope->local_read_pkt_entry == pke)
+			return ope;
+	}
+
+	return NULL;
+}
+
+int efa_test_ope_list_rxe_count(struct fid_ep *ep)
+{
+	struct efa_rdm_ep *efa_rdm_ep =
+		container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	struct efa_rdm_ope *ope;
+	struct dlist_entry *item;
+	int count = 0;
+
+	dlist_foreach(&efa_rdm_ep->base_ep.ope_list, item) {
+		ope = container_of(item, struct efa_rdm_ope, ep_entry);
+		if (ope->type == EFA_RDM_RXE)
+			count++;
+	}
+
+	return count;
+}
+
+int efa_test_abort_waits_for_local_read_copy_setup(
+	struct fid_ep *ep, struct fid_av *av, void *op_context,
+	struct efa_test_local_read_abort *state)
+{
+	struct efa_rdm_ep *efa_rdm_ep =
+		container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	static struct efa_rdm_mr hmem_mr;
+	int ret;
+
+	state->ep = ep;
+	ret = efa_test_alloc_matched_rxe(efa_rdm_ep, av, state->buf,
+					 sizeof(state->buf), op_context,
+					 &state->rxe);
+	if (ret)
+		return ret;
+
+	/* An rx pool packet is registered, so the copy read needs no read-copy
+	 * clone (which would require an FI_HMEM domain). */
+	state->data_pkt_entry = efa_rdm_pke_alloc(efa_rdm_ep,
+						  efa_rdm_ep->efa_rx_pkt_pool,
+						  EFA_RDM_PKE_FROM_EFA_RX_POOL);
+	if (!state->data_pkt_entry)
+		return -FI_ENOMEM;
+
+	state->data_pkt_entry->payload = state->data_pkt_entry->wiredata;
+	state->data_pkt_entry->payload_size = sizeof(state->buf);
+	efa_rdm_pke_set_ope(state->data_pkt_entry, state->rxe);
+
+	/* The copy read is only taken for device memory. */
+	hmem_mr.efa_mr.iface = FI_HMEM_CUDA;
+	state->rxe->desc[0] = &hmem_mr;
+
+	ret = efa_rdm_rxe_post_local_read_or_queue(state->rxe, 0,
+						   state->data_pkt_entry,
+						   state->data_pkt_entry->payload,
+						   sizeof(state->buf));
+	if (ret)
+		return ret;
+
+	state->read_txe = efa_test_find_local_read_txe(efa_rdm_ep,
+						      state->data_pkt_entry);
+	if (!state->read_txe)
+		return -FI_EINVAL;
+
+	efa_test_mark_and_drain(efa_rdm_ep, state->rxe);
+	return 0;
+}
+
+void efa_test_abort_waits_for_local_read_copy_retire(
+	struct efa_test_local_read_abort *state,
+	struct efa_rdm_pke *ctx_pkt_entry)
+{
+	struct efa_rdm_ep *ep = container_of(state->ep, struct efa_rdm_ep,
+					     base_ep.util_ep.ep_fid);
+	struct util_srx_ctx *srx_ctx = efa_rdm_ep_get_peer_srx_ctx(ep);
+
+	/* efa_rdm_pke_read() would have set this when it posted the WR. */
+	ctx_pkt_entry->flags |= EFA_RDM_PKE_LOCAL_READ;
+
+	ofi_genlock_lock(srx_ctx->lock);
+	efa_rdm_pke_handle_rma_completion(ctx_pkt_entry);
+	ofi_genlock_unlock(srx_ctx->lock);
+}
+
+int efa_test_abort_without_local_read_copy_completes_now(
+	struct fid_ep *ep, struct fid_av *av, void *op_context,
+	struct efa_test_local_read_abort *state)
+{
+	struct efa_rdm_ep *efa_rdm_ep =
+		container_of(ep, struct efa_rdm_ep, base_ep.util_ep.ep_fid);
+	int ret;
+
+	state->ep = ep;
+	ret = efa_test_alloc_matched_rxe(efa_rdm_ep, av, state->buf,
+					 sizeof(state->buf), op_context,
+					 &state->rxe);
+	if (ret)
+		return ret;
+
+	efa_test_mark_and_drain(efa_rdm_ep, state->rxe);
+	return 0;
 }

--- a/prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_rdm_ope_helpers.h
@@ -33,6 +33,7 @@ enum efa_test_queued_flag_kind {
 
 struct efa_rdm_ope;
 struct efa_rdm_peer;
+struct efa_rdm_pke;
 
 struct efa_test_queued_op {
 	struct fid_ep *ep;
@@ -129,6 +130,50 @@ void efa_test_simulate_source_mr_canceled(struct efa_test_queued_op *qop);
  * from the packet-post failure code the other error paths use.
  */
 int efa_test_peer_abort_prov_errno(void);
+
+/**
+ * @brief State of a matched recv that is peer-aborting, so a test can retire
+ * its local-read payload copy after the abort has been decided.
+ */
+struct efa_test_local_read_abort {
+	struct fid_ep *ep;
+	struct efa_rdm_ope *rxe;
+	struct efa_rdm_ope *read_txe;
+	struct efa_rdm_pke *data_pkt_entry;
+	char buf[16];
+};
+
+/** @brief Count the rxes still on the endpoint's ope list. */
+int efa_test_ope_list_rxe_count(struct fid_ep *ep);
+
+/**
+ * @brief Peer-abort a matched recv whose local-read payload copy is still
+ * outstanding, and attempt the drain once. The caller must arm
+ * efa_rdm_pke_read so no WR reaches the device, and keep its packet argument
+ * for the retire call.
+ *
+ * @return 0 if @p state was filled, negative otherwise.
+ */
+int efa_test_abort_waits_for_local_read_copy_setup(
+	struct fid_ep *ep, struct fid_av *av, void *op_context,
+	struct efa_test_local_read_abort *state);
+
+/**
+ * @brief Complete the copy read through its read-context packet, which drops
+ * the copy's rxe reference and re-drives the abort drain.
+ */
+void efa_test_abort_waits_for_local_read_copy_retire(
+	struct efa_test_local_read_abort *state,
+	struct efa_rdm_pke *ctx_pkt_entry);
+
+/**
+ * @brief Peer-abort a matched recv that has no payload copy outstanding.
+ *
+ * @return 0 on success, negative otherwise.
+ */
+int efa_test_abort_without_local_read_copy_completes_now(
+	struct fid_ep *ep, struct fid_av *av, void *op_context,
+	struct efa_test_local_read_abort *state);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
A Neuron receive copies its payload into the application's buffer with a local RDMA read posted on its own internal txe, so the rxe's efa_outstanding_tx_ops stayed zero and a peer abort could free the rxe while that read was still writing to its buffer.

Count the copy on the rxe and drop it when the read completes, re-driving the abort drain. An aborting rxe skips the data-copied path so a canceled receive cannot complete successfully.