### PR TITLE
prov/efa: grow the readcopy packet pool from 256 to 8192 entries

### DIFF
--- a/prov/efa/src/efa_env.c
+++ b/prov/efa/src/efa_env.c
@@ -18,7 +18,7 @@ struct efa_env efa_env = {
 	.recvwin_size = EFA_RDM_PEER_DEFAULT_REORDER_BUFFER_SIZE,
 	.ooo_pool_chunk_size = 64,
 	.unexp_pool_chunk_size = 1024,
-	.readcopy_pool_size = 256,
+	.readcopy_pool_size = 8192,
 	.atomrsp_pool_size = 1024,
 	.cq_size = 8192,
 	.max_memcpy_size = 4096,
@@ -189,7 +189,8 @@ void efa_env_define()
 	fi_param_define(&efa_prov, "recvwin_size", FI_PARAM_INT,
 			"Defines the size of sliding receive window. (Default: 16384)");
 	fi_param_define(&efa_prov, "readcopy_pool_size", FI_PARAM_INT,
-			"Defines the size of readcopy packet pool size. (Default: 256)");
+			"Defines the size of readcopy packet pool size. (Default: %d)",
+			efa_env.readcopy_pool_size);
 	fi_param_define(&efa_prov, "cq_size", FI_PARAM_INT,
 			"Define the size of completion queue. (Default: 8192)");
 	fi_param_define(&efa_prov, "mr_cache_enable", FI_PARAM_BOOL,

--- a/prov/efa/src/rdm/efa_rdm_ep.h
+++ b/prov/efa/src/rdm/efa_rdm_ep.h
@@ -35,6 +35,11 @@ struct efa_rdm_ep_queued_copy {
 #define EFA_RDM_MAX_QUEUED_COPY (8)
 
 /*
+ * Entries the readcopy packet pool starts at and grows by.
+ */
+#define EFA_RDM_READCOPY_POOL_CHUNK_SIZE (256)
+
+/*
  * The default memory alignment
  */
 #define EFA_RDM_EP_DEFAULT_MEMORY_ALIGNMENT (8)

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -214,8 +214,9 @@ int efa_rdm_ep_create_buffer_pools(struct efa_rdm_ep *ep)
 		ret = efa_rdm_ep_create_pke_pool(
 			ep,
 			true, /* need memory registration */
-			efa_env.readcopy_pool_size,
-			efa_env.readcopy_pool_size, /* max_cnt==chunk_cnt means pool is not allowed to grow */
+			MIN(EFA_RDM_READCOPY_POOL_CHUNK_SIZE,
+			    efa_env.readcopy_pool_size),
+			efa_env.readcopy_pool_size, /* the pool grows a chunk at a time up to this cap */
 			EFA_RDM_EP_IN_ORDER_ALIGNMENT, /* support in-order aligned send/recv */
 			0,
 			&ep->rx_readcopy_pkt_pool);


### PR DESCRIPTION
Neuron receives always move the payload out of the bounce buffer with a local read instead of a CPU copy. An unexpected or out of order payload has already been staged into an unregistered pool by then, so its read must clone it into the readcopy pool first. Fixed at 256 entries that pool becomes a bottleneck.

Let it grow in 256 entry chunks up to FI_EFA_READCOPY_POOL_SIZE, now defaulting to 8192.