### PR TITLE
prov/efa: give the rdm cq ibv_cq_poll_list its own lock

### DIFF
--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -63,18 +63,20 @@ int efa_base_ep_destruct_qp_unsafe(struct efa_base_ep *base_ep)
 	assert(!rx_cq || ofi_genlock_held(&rx_cq->util_cq.ep_list_lock));
 	assert(ofi_genlock_held(&base_ep->domain->device->qp_table_lock));
 
-	if (qp) {
-		domain = qp->base_ep->domain;
-		qp_num = qp->qp_num;
-		efa_cq_invalidate_cur_wq(tx_cq, qp);
-		if (rx_cq != tx_cq)
-			efa_cq_invalidate_cur_wq(rx_cq, qp);
-		efa_qp_destruct(qp);
-		qp_table_slot = &domain->device->qp_table[qp_num & domain->device->qp_table_sz_m1];
-		assert(!*qp_table_slot || *qp_table_slot == qp);
-		*qp_table_slot = NULL;
-		base_ep->qp = NULL;
-	}
+	if (!qp)
+		return 0;
+
+	domain = qp->base_ep->domain;
+	qp_num = qp->qp_num;
+	efa_cq_invalidate_cur_wq(tx_cq, qp);
+	if (rx_cq != tx_cq)
+		efa_cq_invalidate_cur_wq(rx_cq, qp);
+	efa_qp_destruct(qp);
+	qp_table_slot = &domain->device->qp_table[qp_num & domain->device->qp_table_sz_m1];
+	assert(!*qp_table_slot || *qp_table_slot == qp);
+	*qp_table_slot = NULL;
+	base_ep->qp = NULL;
+	base_ep->efa_qp_enabled = false;
 
 	/* Drain the CQ after destroying the QP
 	 *
@@ -116,9 +118,9 @@ int efa_base_ep_destruct(struct efa_base_ep *base_ep)
 {
 	int err;
 
-	if (efa_env.track_mr && base_ep->efa_qp_enabled) {
+	if (efa_env.track_mr) {
 		ofi_genlock_lock(&base_ep->domain->util_domain.lock);
-		dlist_remove(&base_ep->base_ep_entry);
+		dlist_remove_init(&base_ep->base_ep_entry);
 		ofi_genlock_unlock(&base_ep->domain->util_domain.lock);
 	}
 
@@ -725,6 +727,7 @@ int efa_base_ep_construct(struct efa_base_ep *base_ep,
 	base_ep->txe_pool = NULL;
 	base_ep->rxe_pool = NULL;
 	dlist_init(&base_ep->ope_list);
+	dlist_init(&base_ep->base_ep_entry);
 	return 0;
 }
 

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -124,6 +124,7 @@ int efa_rdm_cq_close(struct fid *fid)
 	if (ret)
 		return ret;
 
+	ofi_genlock_destroy(&cq->ibv_cq_poll_list_lock);
 	ofi_genlock_destroy(&cq->progress_ep_list_lock);
 	free(cq);
 	return retv;
@@ -1019,7 +1020,7 @@ static int efa_rdm_cq_poll_events(struct efa_rdm_cq *cq, int timeout)
 		return ret;
 
 	/* Drain events and re-arm notifications */
-	ofi_genlock_lock(&cq->efa_cq.util_cq.ep_list_lock);
+	ofi_genlock_lock(&cq->ibv_cq_poll_list_lock);
 	dlist_foreach(&cq->ibv_cq_poll_list, item) {
 		poll_list_entry = container_of(item, struct efa_ibv_cq_poll_list_entry, entry);
 		if (!poll_list_entry->cq || !poll_list_entry->cq->channel)
@@ -1037,7 +1038,7 @@ static int efa_rdm_cq_poll_events(struct efa_rdm_cq *cq, int timeout)
 			break;
 		}
 	}
-	ofi_genlock_unlock(&cq->efa_cq.util_cq.ep_list_lock);
+	ofi_genlock_unlock(&cq->ibv_cq_poll_list_lock);
 
 	return ret;
 }
@@ -1167,19 +1168,21 @@ static void efa_rdm_cq_progress(struct util_cq *cq)
 		}
 		efa_rdm_cq->need_to_scan_ep_list = false;
 	}
+	ofi_genlock_unlock(&cq->ep_list_lock);
 
+	/* Taking cq->ep_list_lock would deadlock in two ways:
+	 * 1. efa_cq_lock_ep_list() always locks rx before tx.
+	 * 2. another thread reading the other cq takes the two locks in the opposite order.
+	 */
+	ofi_genlock_lock(&efa_rdm_cq->ibv_cq_poll_list_lock);
 	dlist_foreach(&efa_rdm_cq->ibv_cq_poll_list, item) {
 		poll_list_entry = container_of(item, struct efa_ibv_cq_poll_list_entry, entry);
 		efa_cq = container_of(poll_list_entry->cq, struct efa_cq, ibv_cq);
-		if (&efa_cq->util_cq.ep_list_lock != &cq->ep_list_lock) {
-			ofi_genlock_lock(&efa_cq->util_cq.ep_list_lock);
-			(void) efa_rdm_cq_poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
-			ofi_genlock_unlock(&efa_cq->util_cq.ep_list_lock);
-		} else {
-			(void) efa_rdm_cq_poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
-		}
+		ofi_genlock_lock(&efa_cq->util_cq.ep_list_lock);
+		(void) efa_rdm_cq_poll_ibv_cq(efa_env.efa_cq_read_size, poll_list_entry->cq);
+		ofi_genlock_unlock(&efa_cq->util_cq.ep_list_lock);
 	}
-	ofi_genlock_unlock(&cq->ep_list_lock);
+	ofi_genlock_unlock(&efa_rdm_cq->ibv_cq_poll_list_lock);
 }
 
 /**
@@ -1316,11 +1319,16 @@ int efa_rdm_cq_open(struct fid_domain *domain, struct fi_cq_attr *attr,
 	if (ret)
 		goto free;
 
+	ret = ofi_genlock_init(&cq->ibv_cq_poll_list_lock,
+			       efa_domain_data_progress_lock_type(&rdm_domain->efa_domain));
+	if (ret)
+		goto destroy_progress_lock;
+
 	ret = ofi_cq_init(&efa_prov, domain, attr, &cq->efa_cq.util_cq,
 			  &efa_rdm_cq_progress, context);
 
 	if (ret)
-		goto destroy_progress_lock;
+		goto destroy_poll_list_lock;
 
 	ret = efa_rdm_cq_init_entry_size(cq, attr->format);
 	if (ret)
@@ -1379,6 +1387,8 @@ close_util_cq:
 	if (retv)
 		EFA_WARN(FI_LOG_CQ, "Unable to close util cq: %s\n",
 			 fi_strerror(-retv));
+destroy_poll_list_lock:
+	ofi_genlock_destroy(&cq->ibv_cq_poll_list_lock);
 destroy_progress_lock:
 	ofi_genlock_destroy(&cq->progress_ep_list_lock);
 free:

--- a/prov/efa/src/rdm/efa_rdm_cq.c
+++ b/prov/efa/src/rdm/efa_rdm_cq.c
@@ -1160,11 +1160,10 @@ static void efa_rdm_cq_progress(struct util_cq *cq)
 		dlist_foreach(&cq->ep_list, item) {
 			fid_entry = container_of(item, struct fid_list_entry, entry);
 			efa_rdm_ep = container_of(fid_entry->fid, struct efa_rdm_ep, base_ep.util_ep.ep_fid.fid);
-			if (efa_rdm_ep->base_ep.efa_qp_enabled) {
-				ofi_genlock_lock(&efa_rdm_ep->srx_lock);
+			ofi_genlock_lock(&efa_rdm_ep->srx_lock);
+			if (efa_rdm_ep->base_ep.efa_qp_enabled)
 				efa_rdm_ep_post_internal_rx_pkts(efa_rdm_ep);
-				ofi_genlock_unlock(&efa_rdm_ep->srx_lock);
-			}
+			ofi_genlock_unlock(&efa_rdm_ep->srx_lock);
 		}
 		efa_rdm_cq->need_to_scan_ep_list = false;
 	}

--- a/prov/efa/src/rdm/efa_rdm_cq.h
+++ b/prov/efa/src/rdm/efa_rdm_cq.h
@@ -12,6 +12,7 @@ struct efa_rdm_cq {
 	struct efa_cq efa_cq;
 	struct fid_cq *shm_cq;
 	struct dlist_entry ibv_cq_poll_list;
+	struct ofi_genlock ibv_cq_poll_list_lock;
 	/* list of EPs that have queued work needing progress */
 	struct dlist_entry progress_ep_list;
 	struct ofi_genlock progress_ep_list_lock;

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -1052,21 +1052,21 @@ void efa_rdm_ep_deregister_ibv_cqs(struct efa_rdm_ep *ep)
 	 * so we have cq's reference counters updated.
 	 */
 	if (tx_cq && !ofi_atomic_get32(&tx_cq->efa_cq.util_cq.ref)) {
-		efa_ibv_cq_poll_list_remove(&tx_cq->ibv_cq_poll_list, &tx_cq->efa_cq.util_cq.ep_list_lock, &tx_cq->efa_cq.ibv_cq);
+		efa_ibv_cq_poll_list_remove(&tx_cq->ibv_cq_poll_list, &tx_cq->ibv_cq_poll_list_lock, &tx_cq->efa_cq.ibv_cq);
 		efa_rdm_cq_wait_del_ibv_cq(tx_cq, &tx_cq->efa_cq.ibv_cq);
 		if (rx_cq && rx_cq != tx_cq) {
-			efa_ibv_cq_poll_list_remove(&rx_cq->ibv_cq_poll_list, &rx_cq->efa_cq.util_cq.ep_list_lock, &tx_cq->efa_cq.ibv_cq);
+			efa_ibv_cq_poll_list_remove(&rx_cq->ibv_cq_poll_list, &rx_cq->ibv_cq_poll_list_lock, &tx_cq->efa_cq.ibv_cq);
 			efa_rdm_cq_wait_del_ibv_cq(rx_cq, &tx_cq->efa_cq.ibv_cq);
 		}
 	}
 
 	if (rx_cq && rx_cq != tx_cq && !ofi_atomic_get32(&rx_cq->efa_cq.util_cq.ref)) {
 		/* coverity[double_free : FALSE] - entry unlinked before free; keys differ */
-		efa_ibv_cq_poll_list_remove(&rx_cq->ibv_cq_poll_list, &rx_cq->efa_cq.util_cq.ep_list_lock, &rx_cq->efa_cq.ibv_cq);
+		efa_ibv_cq_poll_list_remove(&rx_cq->ibv_cq_poll_list, &rx_cq->ibv_cq_poll_list_lock, &rx_cq->efa_cq.ibv_cq);
 		efa_rdm_cq_wait_del_ibv_cq(rx_cq, &rx_cq->efa_cq.ibv_cq);
 		if (tx_cq) {
 			/* coverity[double_free : FALSE] - entry unlinked before free; keys differ */
-			efa_ibv_cq_poll_list_remove(&tx_cq->ibv_cq_poll_list, &tx_cq->efa_cq.util_cq.ep_list_lock, &rx_cq->efa_cq.ibv_cq);
+			efa_ibv_cq_poll_list_remove(&tx_cq->ibv_cq_poll_list, &tx_cq->ibv_cq_poll_list_lock, &rx_cq->efa_cq.ibv_cq);
 			efa_rdm_cq_wait_del_ibv_cq(tx_cq, &rx_cq->efa_cq.ibv_cq);
 		}
 	}
@@ -1422,7 +1422,7 @@ int efa_rdm_ep_register_ibv_cqs(struct efa_rdm_ep *ep)
 	rx_cq = efa_rdm_ep_get_rx_rdm_cq(ep);
 
 	if (tx_cq) {
-		ret = efa_ibv_cq_poll_list_insert(&tx_cq->ibv_cq_poll_list, &tx_cq->efa_cq.util_cq.ep_list_lock, &tx_cq->efa_cq.ibv_cq);
+		ret = efa_ibv_cq_poll_list_insert(&tx_cq->ibv_cq_poll_list, &tx_cq->ibv_cq_poll_list_lock, &tx_cq->efa_cq.ibv_cq);
 		if (ret)
 			return ret;
 		ret = efa_rdm_cq_wait_add_ibv_cq(tx_cq, &tx_cq->efa_cq.ibv_cq);
@@ -1430,7 +1430,7 @@ int efa_rdm_ep_register_ibv_cqs(struct efa_rdm_ep *ep)
 			return ret;
 
 		if (rx_cq) {
-			ret = efa_ibv_cq_poll_list_insert(&tx_cq->ibv_cq_poll_list, &tx_cq->efa_cq.util_cq.ep_list_lock, &rx_cq->efa_cq.ibv_cq);
+			ret = efa_ibv_cq_poll_list_insert(&tx_cq->ibv_cq_poll_list, &tx_cq->ibv_cq_poll_list_lock, &rx_cq->efa_cq.ibv_cq);
 			if (ret)
 				return ret;
 			ret = efa_rdm_cq_wait_add_ibv_cq(tx_cq, &rx_cq->efa_cq.ibv_cq);
@@ -1443,7 +1443,7 @@ int efa_rdm_ep_register_ibv_cqs(struct efa_rdm_ep *ep)
 	}
 
 	if (rx_cq) {
-		ret = efa_ibv_cq_poll_list_insert(&rx_cq->ibv_cq_poll_list, &rx_cq->efa_cq.util_cq.ep_list_lock, &rx_cq->efa_cq.ibv_cq);
+		ret = efa_ibv_cq_poll_list_insert(&rx_cq->ibv_cq_poll_list, &rx_cq->ibv_cq_poll_list_lock, &rx_cq->efa_cq.ibv_cq);
 		if (ret)
 			return ret;
 		ret = efa_rdm_cq_wait_add_ibv_cq(rx_cq, &rx_cq->efa_cq.ibv_cq);
@@ -1451,7 +1451,7 @@ int efa_rdm_ep_register_ibv_cqs(struct efa_rdm_ep *ep)
 			return ret;
 
 		if (tx_cq) {
-			ret = efa_ibv_cq_poll_list_insert(&rx_cq->ibv_cq_poll_list, &rx_cq->efa_cq.util_cq.ep_list_lock, &tx_cq->efa_cq.ibv_cq);
+			ret = efa_ibv_cq_poll_list_insert(&rx_cq->ibv_cq_poll_list, &rx_cq->ibv_cq_poll_list_lock, &tx_cq->efa_cq.ibv_cq);
 			if (ret)
 				return ret;
 			ret = efa_rdm_cq_wait_add_ibv_cq(rx_cq, &tx_cq->efa_cq.ibv_cq);

--- a/prov/efa/src/rdm/efa_rdm_ep_fiops.c
+++ b/prov/efa/src/rdm/efa_rdm_ep_fiops.c
@@ -1129,6 +1129,12 @@ static int efa_rdm_ep_close(struct fid *fid)
 	domain = efa_rdm_ep_domain(efa_rdm_ep);
 
 	/**
+	 * efa_rdm_cq_progress takes ep_list_lock -> srx_lock,
+	 * efa_base_ep_create_and_enable_qp and efa_base_ep_destruct_qp take qp_table_lock -> ep_list_lock,
+	 * so the locking order here has to be qp_table_lock -> ep_list_lock -> srx_lock.
+	 */
+	EFA_GENLOCK_LOCK(&domain->device->qp_table_lock, efa_qp_table_lock_sym);
+	/**
 	 * Hold cq.ep_list_lock so the cq progress cannot run concurrently, 
 	 * which prevents the deadlock of srx_lock -> progress_ep_list_lock.
 	 */
@@ -1144,7 +1150,6 @@ static int efa_rdm_ep_close(struct fid *fid)
 	ofi_genlock_lock(&efa_rdm_ep->srx_lock);
 
 	efa_rdm_ep_dequeue_progress_list(efa_rdm_ep);
-	efa_cq_unlock_ep_list(&efa_rdm_ep->base_ep);
 
 	if (efa_rdm_ep->peer_srx_ep) {
 		/*
@@ -1175,8 +1180,17 @@ static int efa_rdm_ep_close(struct fid *fid)
 		efa_rdm_ep->peer_srx_ep = NULL;
 	}
 
+	efa_base_ep_destruct_qp_unsafe(&efa_rdm_ep->base_ep);
+
+	ofi_genlock_unlock(&efa_rdm_ep->srx_lock);
+	efa_cq_unlock_ep_list(&efa_rdm_ep->base_ep);
+	EFA_GENLOCK_UNLOCK(&domain->device->qp_table_lock, efa_qp_table_lock_sym);
+
 	/* We need to free the util_ep first to avoid race conditions
-	 * with other threads progressing the cq. */
+	 * with other threads progressing the cq.
+	 *
+	 * ofi_endpoint_close() takes both cq ep_list_locks itself, so this must
+	 * run after the hold above is released. */
 	efa_base_ep_close_util_ep(&efa_rdm_ep->base_ep);
 
 	efa_rdm_ep_remove_cntr_ibv_cq_poll_list(&efa_rdm_ep->base_ep);
@@ -1203,8 +1217,6 @@ static int efa_rdm_ep_close(struct fid *fid)
 		free(efa_rdm_ep->send_pkt_entry_vec);
 	if (efa_rdm_ep->send_pkt_entry_vec_data_sizes)
 		free(efa_rdm_ep->send_pkt_entry_vec_data_sizes);
-
-	ofi_genlock_unlock(&efa_rdm_ep->srx_lock);
 
 	/*
 	 * Destroying the self AH also requires the util_domain.lock,


### PR DESCRIPTION
A tx and an rx cq cross reference each other's ibv_cq in their poll lists, so efa_rdm_cq_progress() held its own util_cq.ep_list_lock for the whole loop and then took the peer cq's ep_list_lock to poll the peer's ibv_cq. That order is whichever cq the application read, which deadlocks two ways: against efa_cq_lock_ep_list(), which always locks rx before tx, and against another thread reading the other cq of the pair, which takes the two locks in the opposite order. Both locks are real mutexes for rdm, whose control progress is FI_PROGRESS_MANUAL, so no threading model escapes it.

Guard ibv_cq_poll_list with a dedicated lock instead of borrowing ep_list_lock. Progress then walks the list under that lock and takes the ep_list_lock of each ibv_cq's owning cq one entry at a time, so no thread ever holds two ep_list_locks and the order they are acquired in stops mattering. Polling still runs under the owning cq's ep_list_lock, which is what serializes it against qp creation and destruction.