### PR TITLE
[v2.7.x]prov/efa: Allow efa-direct without FI_CONTEXT2 for GDA usecase

### DIFF
--- a/prov/efa/docs/efa_fabric_comparison.md
+++ b/prov/efa/docs/efa_fabric_comparison.md
@@ -213,13 +213,13 @@ consistent with the FI_MSG iov limit.
 | `FI_ASYNC_IOV`            |   |          |
 | `FI_BUFFERED_RECV`        |   |          |
 | `FI_CONTEXT`              |   |          |
-| `FI_CONTEXT2`             |   |R         |
+| `FI_CONTEXT2`             |   |O         |
 | `FI_LOCAL_MR (compat)`    |   |          |
 | `FI_MSG_PREFIX`           |  |          |
 | `FI_RX_CQ_DATA`           |   |O         |
 
 Feature comparison:
-- **FI_CONTEXT2**: efa-direct requires this mode, efa fabric doesn't
+- **FI_CONTEXT2**: efa-direct accepts this optional mode; without it fi_inject, FI_SELECTIVE_COMPLETION, and FI_EFA_TRACK_MR are unavailable. efa fabric doesn't use it
 - **FI_MSG_PREFIX**: efa fabric DGRAM endpoint requires FI_MSG_PREFIX due to the 40-byte prefix requirement per IBV_QPT_UD spec
 - **FI_RX_CQ_DATA**: efa-direct accepts this optional mode, meaning operations carrying CQ data consume an RX buffer on responder side
 

--- a/prov/efa/src/efa_base_ep.c
+++ b/prov/efa/src/efa_base_ep.c
@@ -714,6 +714,9 @@ int efa_base_ep_construct(struct efa_base_ep *base_ep,
 		return -FI_ENOMEM;
 	}
 
+	base_ep->context_mode = (base_ep->info->mode & FI_CONTEXT2) ?
+		USE_CONTEXT2 : NO_CONTEXT;
+
 	/* This is SRD qp's default behavior */
 	base_ep->rnr_retry = EFA_RNR_INFINITE_RETRY;
 

--- a/prov/efa/src/efa_base_ep.h
+++ b/prov/efa/src/efa_base_ep.h
@@ -74,12 +74,27 @@ struct efa_recv_wr {
 	struct ibv_sge sge[2];
 };
 
+/*
+ * FI_CONTEXT2 mode of an endpoint (and of the CQ it is bound to). efa-direct
+ * can only use the caller-supplied context buffer when USE_CONTEXT2. Otherwise
+ * the provider must not dereference the context buffer, so features that depend
+ * on it (inject, selective completion, MR tracking) are disabled. UNASSIGNED is
+ * used only by a CQ before its first endpoint is enabled; an endpoint is always
+ * NO_CONTEXT or USE_CONTEXT2.
+ */
+enum context_mode {
+	UNASSIGNED,
+	NO_CONTEXT,
+	USE_CONTEXT2,
+};
+
 struct efa_base_ep {
 	struct util_ep util_ep;
 	struct efa_domain *domain;
 	struct efa_qp *qp;
 	struct efa_av *av;
 	struct fi_info *info;
+	enum context_mode context_mode;
 	size_t rnr_retry;
 	struct efa_ep_addr src_addr;
 

--- a/prov/efa/src/efa_cq.c
+++ b/prov/efa/src/efa_cq.c
@@ -40,6 +40,8 @@ static inline void efa_cq_direct_ope_release(struct efa_cq *efa_cq,
 	struct efa_base_ep *base_ep;
 
 	if (efa_env.track_mr && ibv_cq->ibv_cq_ex->wr_id) {
+		/* track_mr requires FI_CONTEXT2 (enforced at efa_ep_enable). */
+		assert(ibv_cq->context_mode == USE_CONTEXT2);
 		efa_domain = container_of(efa_cq->util_cq.domain, struct efa_domain, util_domain);
 		base_ep = efa_ibv_cq_get_base_ep_from_cur_cqe(ibv_cq, efa_domain);
 		efa_direct_ope_release(base_ep,
@@ -51,9 +53,16 @@ static void efa_cq_read_context_entry(struct efa_ibv_cq *ibv_cq, void *buf, int 
 {
 	struct fi_cq_entry *entry = buf;
 
-	if (efa_env.track_mr && ibv_cq->ibv_cq_ex->wr_id)
+	if (efa_env.track_mr && ibv_cq->ibv_cq_ex->wr_id) {
+		/* track_mr requires FI_CONTEXT2 (enforced at efa_ep_enable). */
+		assert(ibv_cq->context_mode == USE_CONTEXT2);
 		entry->op_context = ((struct efa_direct_ope *)(uintptr_t)ibv_cq->ibv_cq_ex->wr_id)->context;
-	else
+	} else
+		/*
+		 * Echo wr_id as op_context without dereferencing: it is the
+		 * caller's context (the raw context in no-FI_CONTEXT2 mode, or
+		 * the efa_context when track_mr is off).
+		 */
 		entry->op_context = (void *)(uintptr_t)ibv_cq->ibv_cq_ex->wr_id;
 }
 
@@ -64,7 +73,11 @@ void efa_cq_read_entry_common(struct efa_ibv_cq *cq, struct fi_cq_msg_entry *ent
 	struct efa_direct_ope *direct_ope;
 
 	if (!efa_cq_wc_is_unsolicited(cq) && ibv_cqx->wr_id) {
-		if (efa_env.track_mr) {
+		if (cq->context_mode != USE_CONTEXT2) {
+			/* No FI_CONTEXT2 means no context buffer */
+			entry->op_context = (void *)(uintptr_t)ibv_cqx->wr_id;
+			entry->flags = efa_cq_opcode_to_fi_flags(opcode);
+		} else if (efa_env.track_mr) {
 			direct_ope = (struct efa_direct_ope *)(uintptr_t)ibv_cqx->wr_id;
 			entry->op_context = direct_ope->context;
 			entry->flags = (opcode == IBV_WC_RECV_RDMA_WITH_IMM) ? efa_cq_opcode_to_fi_flags(opcode) : direct_ope->context->completion_flags;
@@ -139,7 +152,10 @@ static inline void efa_cq_fill_err_entry(struct efa_ibv_cq *ibv_cq, struct fi_cq
 	case IBV_WC_SEND: /* fall through */
 	case IBV_WC_RDMA_WRITE: /* fall through */
 	case IBV_WC_RDMA_READ:
-		if (!ibv_cq->ibv_cq_ex->wr_id) {
+		if (ibv_cq->context_mode != USE_CONTEXT2 || !ibv_cq->ibv_cq_ex->wr_id) {
+			/* No FI_CONTEXT2 means no context buffer so the
+			 * peer address is unavailable for these opcodes
+			 */
 			addr = FI_ADDR_NOTAVAIL;
 		} else if (efa_env.track_mr) {
 			addr = ((struct efa_direct_ope *)(uintptr_t)ibv_cq->ibv_cq_ex->wr_id)->context->addr;
@@ -222,15 +238,22 @@ static void efa_cq_handle_tx_completion(struct efa_base_ep *base_ep,
 	int ret = 0;
 	struct ibv_cq_ex *ibv_cq_ex = ibv_cq->ibv_cq_ex;
 
-	/* NULL wr_id means no FI_COMPLETION flag */
-	if (!ibv_cq_ex->wr_id)
+	/*
+	 * In FI_CONTEXT2 mode a NULL wr_id means the op did not request a
+	 * completion. Without FI_CONTEXT2, inject and selective completion are
+	 * disabled, so always generate a completion.
+	 */
+	if (ibv_cq->context_mode == USE_CONTEXT2 && !ibv_cq_ex->wr_id)
 		return;
 
 	efa_tracepoint(handle_tx_completion, ibv_cq_ex->wr_id);
 
-	if (efa_env.track_mr)
+	if (efa_env.track_mr) {
+		/* track_mr requires FI_CONTEXT2 (enforced at efa_ep_enable). */
+		assert(ibv_cq->context_mode == USE_CONTEXT2);
 		efa_direct_ope_release(base_ep,
 			(struct efa_direct_ope *)(uintptr_t)ibv_cq_ex->wr_id);
+	}
 
 	/* TX completions should not send peer address to util_cq */
 	if (base_ep->util_ep.caps & FI_SOURCE)
@@ -267,15 +290,22 @@ static void efa_cq_handle_rx_completion(struct efa_base_ep *base_ep,
 	fi_addr_t src_addr;
 	int ret = 0;
 
-	/* NULL wr_id means no FI_COMPLETION flag */
-	if (!ibv_cq_ex->wr_id)
+	/*
+	 * In FI_CONTEXT2 mode a NULL wr_id means the op did not request a
+	 * completion. Without FI_CONTEXT2, inject and selective completion are
+	 * disabled, so always generate a completion.
+	 */
+	if (ibv_cq->context_mode == USE_CONTEXT2 && !ibv_cq_ex->wr_id)
 		return;
 
 	efa_tracepoint(handle_rx_completion, ibv_cq_ex->wr_id);
 
-	if (efa_env.track_mr)
+	if (efa_env.track_mr) {
+		/* track_mr requires FI_CONTEXT2 (enforced at efa_ep_enable). */
+		assert(ibv_cq->context_mode == USE_CONTEXT2);
 		efa_direct_ope_release(base_ep,
 			(struct efa_direct_ope *)(uintptr_t)ibv_cq_ex->wr_id);
+	}
 
 	if (base_ep->util_ep.caps & FI_SOURCE) {
 		src_addr = efa_av_reverse_lookup(base_ep->av,
@@ -803,9 +833,15 @@ ssize_t efa_cq_readfrom(struct fid_cq *cq_fid, void *buf, size_t count,
 		/**
 		 * Only populate the cqes when:
 		 * 1. It is IBV_WC_RECV_RDMA_WITH_IMM which is the target side of the rdma write with imm
-		 * 2. It is a solicited wc and having wr_id (efa_context) which means it needs a completion.
+		 * 2. It is a solicited wc with a wr_id.
+		 * 3. Without FI_CONTEXT2, inject and selective completion are
+		 *    disabled, so every solicited wc must produce a completion
+		 *    even when wr_id is 0 (the application may pass a NULL
+		 *    context).
 		 */
-		if ((!efa_cq_wc_is_unsolicited(ibv_cq) && ibv_cq->ibv_cq_ex->wr_id ) || opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
+		if ((!efa_cq_wc_is_unsolicited(ibv_cq) &&
+		     (ibv_cq->ibv_cq_ex->wr_id || ibv_cq->context_mode != USE_CONTEXT2)) ||
+		    opcode == IBV_WC_RECV_RDMA_WITH_IMM) {
 			efa_tracepoint(handle_completion, ibv_cq->ibv_cq_ex->wr_id, opcode);
 			efa_cq->read_entry(ibv_cq, (void *)((uintptr_t) buf + num_cqe * efa_cq->entry_size), opcode);
 			if (src_addr)
@@ -1047,6 +1083,11 @@ int efa_cq_open_ibv_cq(struct fi_cq_attr *attr,
 	};
 
 	ibv_cq->unsolicited_write_recv_enabled = false;
+	/*
+	 * UNASSIGNED until efa_base_ep_create_qp() sets the mode from the first
+	 * endpoint enabled on this CQ.
+	 */
+	ibv_cq->context_mode = UNASSIGNED;
 #if HAVE_CAPS_UNSOLICITED_WRITE_RECV
 	if (efa_use_unsolicited_write_recv())
 		efadv_cq_init_attr.wc_flags |= EFADV_WC_EX_WITH_IS_UNSOLICITED;
@@ -1134,6 +1175,7 @@ int efa_cq_open_ibv_cq(struct fi_cq_attr *attr,
 
 	ibv_cq->data_path_direct_enabled = false;
 	ibv_cq->unsolicited_write_recv_enabled = false;
+	ibv_cq->context_mode = UNASSIGNED;
 	return efa_cq_open_ibv_cq_with_ibv_create_cq_ex(
 		&init_attr_ex, ibv_ctx, &ibv_cq->ibv_cq_ex, &ibv_cq->ibv_cq_ex_type);
 }

--- a/prov/efa/src/efa_cq.h
+++ b/prov/efa/src/efa_cq.h
@@ -23,6 +23,7 @@ struct efa_ibv_cq {
 #endif
 	struct ibv_comp_channel	*channel;
 	bool unsolicited_write_recv_enabled;
+	enum context_mode context_mode;
 };
 
 struct efa_ibv_cq_poll_list_entry {

--- a/prov/efa/src/efa_ep.c
+++ b/prov/efa/src/efa_ep.c
@@ -225,6 +225,34 @@ static int efa_ep_close(fid_t fid)
 	return 0;
 }
 
+/**
+ * @brief Commit the endpoint's FI_CONTEXT2 mode onto a CQ it is binding to
+ *
+ * All endpoints sharing a CQ must agree on FI_CONTEXT2 mode: the completion
+ * path interprets wr_id differently for each mode, so a single CQ cannot serve
+ * both. The first endpoint bound commits the CQ's mode; a later endpoint of a
+ * different mode is rejected. The mode is never reset (a late completion could
+ * otherwise dereference a context the new mode doesn't own).
+ *
+ * @param ep		efa base endpoint
+ * @param ibv_cq	CQ being bound
+ * @return 0 on success, -FI_EOPNOTSUPP if the endpoint's mode conflicts with a
+ *         mode already committed on the CQ
+ */
+static int efa_ep_commit_cq_context_mode(struct efa_base_ep *ep,
+					 struct efa_ibv_cq *ibv_cq)
+{
+	if (ibv_cq->context_mode != UNASSIGNED &&
+	    ibv_cq->context_mode != ep->context_mode) {
+		EFA_WARN(FI_LOG_EP_CTRL,
+			 "CQ is already in use by an endpoint with a different "
+			 "FI_CONTEXT2 mode\n");
+		return -FI_EINVAL;
+	}
+	ibv_cq->context_mode = ep->context_mode;
+	return 0;
+}
+
 static int efa_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 {
 	struct efa_base_ep *ep;
@@ -250,6 +278,24 @@ static int efa_ep_bind(struct fid *fid, struct fid *bfid, uint64_t flags)
 		efa_domain = container_of(cq->util_cq.domain, struct efa_domain, util_domain);
 		if (ep->domain != efa_domain)
 			return -FI_EINVAL;
+
+		/*
+		 * Selective completion requires the provider to suppress
+		 * completions per-operation, which efa-direct implements via the
+		 * caller-supplied context buffer. Without FI_CONTEXT2 there is no
+		 * such buffer, so selective completion cannot be honored.
+		 */
+		if ((flags & FI_SELECTIVE_COMPLETION) &&
+		    ep->context_mode != USE_CONTEXT2) {
+			EFA_WARN(FI_LOG_EP_CTRL,
+				 "FI_SELECTIVE_COMPLETION requires FI_CONTEXT2 "
+				 "for efa-direct endpoints\n");
+			return -FI_EOPNOTSUPP;
+		}
+
+		ret = efa_ep_commit_cq_context_mode(ep, &cq->ibv_cq);
+		if (ret)
+			return ret;
 
 		ret = ofi_ep_bind_cq(&ep->util_ep, &cq->util_cq, flags);
 		if (ret)
@@ -338,6 +384,16 @@ static int efa_ep_enable(struct fid_ep *ep_fid)
 	int err;
 
 	base_ep = container_of(ep_fid, struct efa_base_ep, util_ep.ep_fid);
+
+	/* No context2 means no context buffer, which the mr tracking
+	 * builds on top of
+	 */
+	if (efa_env.track_mr && base_ep->context_mode != USE_CONTEXT2) {
+		EFA_WARN(FI_LOG_EP_CTRL,
+			 "FI_EFA_TRACK_MR is not supported for efa-direct "
+			 "endpoints without FI_CONTEXT2\n");
+		return -FI_EOPNOTSUPP;
+	}
 
 	err = efa_base_ep_create_and_enable_qp(base_ep);
 	if (err)

--- a/prov/efa/src/efa_msg.c
+++ b/prov/efa/src/efa_msg.c
@@ -94,19 +94,24 @@ static inline ssize_t efa_post_recv(struct efa_base_ep *base_ep, const struct fi
 	wr = &base_ep->efa_recv_wr_vec[wr_index].wr;
 	wr->num_sge = msg->iov_count;
 	wr->sg_list = base_ep->efa_recv_wr_vec[wr_index].sge;
-	efa_ctx = efa_fill_context(msg->context, msg->addr, flags,
-				   FI_RECV | FI_MSG);
-	if (efa_env.track_mr && efa_ctx) {
-		direct_ope = efa_direct_rxe_alloc(base_ep, efa_ctx, msg);
-		if (!direct_ope) {
-			EFA_WARN(FI_LOG_EP_DATA,
-				 "Failed to allocate direct RX operation entry for MR tracking\n");
-			err = -FI_EAGAIN;
-			goto out_err;
-		}
-		wr->wr_id = (uintptr_t) direct_ope;
+	if (base_ep->context_mode != USE_CONTEXT2) {
+		/* No FI_CONTEXT2: no buffer, just copy value */
+		wr->wr_id = (uintptr_t) msg->context;
 	} else {
-		wr->wr_id = (uintptr_t) efa_ctx;
+		efa_ctx = efa_fill_context(msg->context, msg->addr, flags,
+					   FI_RECV | FI_MSG);
+		if (efa_env.track_mr && efa_ctx) {
+			direct_ope = efa_direct_rxe_alloc(base_ep, efa_ctx, msg);
+			if (!direct_ope) {
+				EFA_WARN(FI_LOG_EP_DATA,
+					 "Failed to allocate direct RX operation entry for MR tracking\n");
+				err = -FI_EAGAIN;
+				goto out_err;
+			}
+			wr->wr_id = (uintptr_t) direct_ope;
+		} else {
+			wr->wr_id = (uintptr_t) efa_ctx;
+		}
 	}
 
 	for (i = 0; i < msg->iov_count; i++) {
@@ -244,19 +249,24 @@ static inline ssize_t efa_post_send(struct efa_base_ep *base_ep, const struct fi
 	ofi_genlock_lock(&base_ep->util_ep.lock);
 
 	/* Prepare work request ID */
-	efa_ctx = efa_fill_context(msg->context, msg->addr, flags,
-				   FI_SEND | FI_MSG);
-	if (efa_env.track_mr && efa_ctx) {
-		direct_ope = efa_direct_txe_alloc(base_ep, efa_ctx, msg, NULL);
-		if (!direct_ope) {
-			EFA_WARN(FI_LOG_EP_DATA,
-				 "Failed to allocate direct TX operation entry for MR tracking\n");
-			ret = -FI_EAGAIN;
-			goto out_err;
-		}
-		wr_id = (uintptr_t) direct_ope;
+	if (base_ep->context_mode != USE_CONTEXT2) {
+		/* No FI_CONTEXT2: no buffer, just copy value */
+		wr_id = (uintptr_t) msg->context;
 	} else {
-		wr_id = (uintptr_t) efa_ctx;
+		efa_ctx = efa_fill_context(msg->context, msg->addr, flags,
+					   FI_SEND | FI_MSG);
+		if (efa_env.track_mr && efa_ctx) {
+			direct_ope = efa_direct_txe_alloc(base_ep, efa_ctx, msg, NULL);
+			if (!direct_ope) {
+				EFA_WARN(FI_LOG_EP_DATA,
+					 "Failed to allocate direct TX operation entry for MR tracking\n");
+				ret = -FI_EAGAIN;
+				goto out_err;
+			}
+			wr_id = (uintptr_t) direct_ope;
+		} else {
+			wr_id = (uintptr_t) efa_ctx;
+		}
 	}
 
 	/* Handle 0-byte send with inline path and 0 SGEs */
@@ -403,6 +413,10 @@ static ssize_t efa_ep_msg_inject(struct fid_ep *ep_fid, const void *buf, size_t 
 	struct fi_msg msg;
 	struct iovec iov;
 
+	/* inject is unavailable without FI_CONTEXT2 */
+	if (base_ep->context_mode != USE_CONTEXT2)
+		return -FI_ENOSYS;
+
 	EFA_SETUP_IOV(iov, buf, len);
 	EFA_SETUP_MSG(msg, &iov, NULL, 1, dest_addr, NULL, 0);
 
@@ -416,6 +430,10 @@ static ssize_t efa_ep_msg_injectdata(struct fid_ep *ep_fid, const void *buf,
 	struct efa_base_ep *base_ep = container_of(ep_fid, struct efa_base_ep, util_ep.ep_fid);
 	struct fi_msg msg;
 	struct iovec iov;
+
+	/* inject is unavailable without FI_CONTEXT2 */
+	if (base_ep->context_mode != USE_CONTEXT2)
+		return -FI_ENOSYS;
 
 	EFA_SETUP_IOV(iov, buf, len);
 	EFA_SETUP_MSG(msg, &iov, NULL, 1, dest_addr, NULL, data);

--- a/prov/efa/src/efa_prov_info.c
+++ b/prov/efa/src/efa_prov_info.c
@@ -238,9 +238,11 @@ void efa_prov_info_set_tx_rx_attr(struct fi_info *prov_info,
 		*prov_info->rx_attr	= efa_dgrm_rx_attr;
 	}
 
-	/* efa-direct and DGRAM paths require FI_CONTEXT2 */
-	prov_info->tx_attr->mode |= FI_CONTEXT2;
-	prov_info->rx_attr->mode |= FI_CONTEXT2;
+	/*
+	 * Neither efa-direct nor DGRAM requires FI_CONTEXT2 unconditionally; it
+	 * is advertised conditionally in efa_get_user_info() based on whether
+	 * the application requested it (or passed NULL hints).
+	 */
 
 	prov_info->tx_attr->inject_size = device->efa_attr.inline_buf_size;
 #if HAVE_INLINE_BUF_SIZE_EX
@@ -481,8 +483,6 @@ int efa_prov_info_alloc(struct fi_info **prov_info_ptr,
 	if (!prov_info)
 		return -FI_ENOMEM;
 
-	prov_info->mode |= FI_CONTEXT2; 	/* EFA direct path requires FI_CONTEXT2 mode */
-
 	if (ep_type == FI_EP_RDM) {
 		prov_info->caps	= EFA_RDM_CAPS;
 
@@ -585,7 +585,7 @@ int efa_prov_info_alloc_for_rdm(struct fi_info **prov_info_rdm_ptr,
 
 	prov_info_rdm->caps |= efa_rdm_added_tx_caps | efa_rdm_added_rx_caps | efa_domain_caps;
 
-	/* efa-direct requires FI_CONTEXT2 but RDM doesn't. So unset FI_CONTEXT2 */
+	/* RDM never uses FI_CONTEXT2; efa-direct opts in separately. Unset it. */
 	prov_info_rdm->mode &= ~FI_CONTEXT2;
 	prov_info_rdm->tx_attr->mode &= ~FI_CONTEXT2;
 	prov_info_rdm->rx_attr->mode &= ~FI_CONTEXT2;

--- a/prov/efa/src/efa_rma.c
+++ b/prov/efa/src/efa_rma.c
@@ -63,19 +63,25 @@ static inline ssize_t efa_rma_post_read(struct efa_base_ep *base_ep,
 	ofi_genlock_lock(&base_ep->util_ep.lock);
 
 	/* Prepare work request ID */
-	efa_ctx = efa_fill_context(msg->context, msg->addr, flags,
-						       FI_RMA | FI_READ);
-	if (efa_env.track_mr && efa_ctx) {
-		direct_ope = efa_direct_txe_alloc(base_ep, efa_ctx, NULL, msg);
-		if (!direct_ope) {
-			EFA_WARN(FI_LOG_EP_DATA,
-				 "Failed to allocate direct TX operation entry for MR tracking\n");
-			err = -FI_EAGAIN;
-			goto out_err;
-		}
-		wr_id = (uintptr_t) direct_ope;
+	if (base_ep->context_mode != USE_CONTEXT2) {
+		/* No FI_CONTEXT2: echo raw context pointer, never dereference. */
+		wr_id = (uintptr_t) msg->context;
 	} else {
-		wr_id = (uintptr_t) efa_ctx;
+		efa_ctx = efa_fill_context(msg->context, msg->addr, flags,
+							       FI_RMA | FI_READ);
+		if (efa_env.track_mr && efa_ctx) {
+			direct_ope = efa_direct_txe_alloc(
+				base_ep, efa_ctx, NULL, msg);
+			if (!direct_ope) {
+				EFA_WARN(FI_LOG_EP_DATA,
+					 "Failed to allocate direct TX operation entry for MR tracking\n");
+				err = -FI_EAGAIN;
+				goto out_err;
+			}
+			wr_id = (uintptr_t) direct_ope;
+		} else {
+			wr_id = (uintptr_t) efa_ctx;
+		}
 	}
 
 	/* Handle 0-byte read with bounce buffer */
@@ -224,19 +230,25 @@ static inline ssize_t efa_rma_post_write(struct efa_base_ep *base_ep,
 	ofi_genlock_lock(&base_ep->util_ep.lock);
 
 	/* Prepare work request ID */
-	efa_ctx = efa_fill_context(msg->context, msg->addr, flags,
-						       FI_RMA | FI_WRITE);
-	if (efa_env.track_mr && efa_ctx) {
-		direct_ope = efa_direct_txe_alloc(base_ep, efa_ctx, NULL, msg);
-		if (!direct_ope) {
-			EFA_WARN(FI_LOG_EP_DATA,
-				 "Failed to allocate direct TX operation entry for MR tracking\n");
-			err = -FI_EAGAIN;
-			goto out_err;
-		}
-		wr_id = (uintptr_t) direct_ope;
+	if (base_ep->context_mode != USE_CONTEXT2) {
+		/* No FI_CONTEXT2: echo raw context pointer, never dereference. */
+		wr_id = (uintptr_t) msg->context;
 	} else {
-		wr_id = (uintptr_t) efa_ctx;
+		efa_ctx = efa_fill_context(msg->context, msg->addr, flags,
+							       FI_RMA | FI_WRITE);
+		if (efa_env.track_mr && efa_ctx) {
+			direct_ope = efa_direct_txe_alloc(
+				base_ep, efa_ctx, NULL, msg);
+			if (!direct_ope) {
+				EFA_WARN(FI_LOG_EP_DATA,
+					 "Failed to allocate direct TX operation entry for MR tracking\n");
+				err = -FI_EAGAIN;
+				goto out_err;
+			}
+			wr_id = (uintptr_t) direct_ope;
+		} else {
+			wr_id = (uintptr_t) efa_ctx;
+		}
 	}
 
 	len_fits_inline = total_len <= base_ep->inject_rma_size;
@@ -422,7 +434,7 @@ ssize_t efa_rma_inject_write(struct fid_ep *ep_fid, const void *buf, size_t len,
 	err = efa_rma_check_cap(base_ep);
 	if (err)
 		return err;
-	if (len > base_ep->inject_rma_size)
+	if (base_ep->context_mode != USE_CONTEXT2 || len > base_ep->inject_rma_size)
 		return -FI_ENOSYS;
 
 	EFA_SETUP_IOV(iov, buf, len);
@@ -446,7 +458,7 @@ ssize_t efa_rma_inject_writedata(struct fid_ep *ep_fid, const void *buf,
 	err = efa_rma_check_cap(base_ep);
 	if (err)
 		return err;
-	if (len > base_ep->inject_rma_size)
+	if (base_ep->context_mode != USE_CONTEXT2 || len > base_ep->inject_rma_size)
 		return -FI_ENOSYS;
 
 	EFA_SETUP_IOV(iov, buf, len);

--- a/prov/efa/src/efa_user_info.c
+++ b/prov/efa/src/efa_user_info.c
@@ -553,6 +553,34 @@ int efa_user_info_alter_rdm(int version, struct fi_info *info, const struct fi_i
 }
 
 /**
+ * @brief advertise FI_CONTEXT2 for an efa base-ep (efa-direct or DGRAM) info
+ *
+ * Advertises FI_CONTEXT2 when the application requested it (or passed NULL
+ * hints). Without FI_CONTEXT2 the endpoint runs without touching the caller's
+ * context buffer, which also disables inject; a nonzero inject_size hint
+ * therefore cannot be satisfied and the info is rejected.
+ *
+ * @param	info[in,out]	info to be updated
+ * @param	hints[in]	user provided hints
+ * @return	0 to keep the info, -FI_ENODATA if the caller should skip it
+ */
+static int efa_user_info_set_context2(struct fi_info *info,
+				      const struct fi_info *hints)
+{
+	if (!hints || (hints->mode & FI_CONTEXT2)) {
+		info->mode |= FI_CONTEXT2;
+		info->tx_attr->mode |= FI_CONTEXT2;
+		info->rx_attr->mode |= FI_CONTEXT2;
+		return 0;
+	}
+
+	if (hints->tx_attr && hints->tx_attr->inject_size)
+		return -FI_ENODATA;
+	info->tx_attr->inject_size = 0;
+	return 0;
+}
+
+/**
  * @brief update EFA direct info to match user hints
  *
  * the input info is a duplicate of prov info, which matches
@@ -568,6 +596,11 @@ int efa_user_info_alter_rdm(int version, struct fi_info *info, const struct fi_i
 static
 int efa_user_info_alter_direct(int version, struct fi_info *info, const struct fi_info *hints)
 {
+	int ret = efa_user_info_set_context2(info, hints);
+	if (ret)
+		return ret;
+	bool use_context2 = info->mode & FI_CONTEXT2;
+
 	/*
 	 * FI_HMEM is a primary capability. When user explicitly
 	 * requested it, verify support. When no hints, advertise if supported.
@@ -644,51 +677,51 @@ int efa_user_info_alter_direct(int version, struct fi_info *info, const struct f
 		info->rx_attr->caps &= ~OFI_RX_RMA_CAPS;
 	}
 	/*
-	 * Handle inject_size hint for larger inline data support.
-	 *
-	 * prov_info advertises inline_buf_size_ex as inject_size so that
-	 * ofi_check_info allows larger inline data size. Here we adjust the
-	 * tx queue depth based on what the user requested, since larger
-	 * inline data reduces the maximum number of send queue entries.
+	 * A larger inline (inject) size reduces the number of send queue
+	 * entries, so when the application requests one, cap the tx queue depth
+	 * to what the device supports for that size. Only meaningful with
+	 * FI_CONTEXT2; inject is unavailable otherwise.
 	 */
-	struct efa_device *device = &g_efa_selected_device_list[0];
-	uint16_t inline_buf_size = device->efa_attr.inline_buf_size;
+	if (use_context2) {
+		struct efa_device *device = &g_efa_selected_device_list[0];
+		uint16_t inline_buf_size = device->efa_attr.inline_buf_size;
 
-	if (!hints || !hints->tx_attr || !hints->tx_attr->inject_size) {
-		/* No hint: default to inline_buf_size */
-		info->tx_attr->inject_size = inline_buf_size;
-	} else if (hints->tx_attr->inject_size > inline_buf_size) {
-		/* Wide WQE: query actual tx depth */
+		if (!hints || !hints->tx_attr || !hints->tx_attr->inject_size) {
+			/* No hint: default to inline_buf_size */
+			info->tx_attr->inject_size = inline_buf_size;
+		} else if (hints->tx_attr->inject_size > inline_buf_size) {
+			/* Wide WQE: query actual tx depth */
 #if HAVE_INLINE_BUF_SIZE_EX
-		struct efadv_sq_depth_attr sq_attr = {0};
-		int max_sq_depth;
+			struct efadv_sq_depth_attr sq_attr = {0};
+			int max_sq_depth;
 
-		sq_attr.max_inline_data = hints->tx_attr->inject_size;
-		sq_attr.flags = EFADV_SQ_DEPTH_ATTR_INLINE_WRITE;
-		max_sq_depth = efadv_get_max_sq_depth(device->ibv_ctx,
-						      &sq_attr,
-						      sizeof(sq_attr));
-		if (max_sq_depth < 0) {
-			EFA_INFO(FI_LOG_CORE,
-				 "efadv_get_max_sq_depth failed: %d\n",
-				 max_sq_depth);
-			return -FI_ENODATA;
-		}
-		if (hints->tx_attr->size > max_sq_depth) {
-			EFA_INFO(FI_LOG_CORE,
-				 "Requested TX SQ depth (%zu) exceeds maximum depth (%d)"
-				 " for inline size %zu\n",
-				 hints->tx_attr->size, max_sq_depth,
-				 hints->tx_attr->inject_size);
-			return -FI_ENODATA;
-		}
-		info->tx_attr->size = max_sq_depth;
+			sq_attr.max_inline_data = hints->tx_attr->inject_size;
+			sq_attr.flags = EFADV_SQ_DEPTH_ATTR_INLINE_WRITE;
+			max_sq_depth = efadv_get_max_sq_depth(device->ibv_ctx,
+							      &sq_attr,
+							      sizeof(sq_attr));
+			if (max_sq_depth < 0) {
+				EFA_INFO(FI_LOG_CORE,
+					 "efadv_get_max_sq_depth failed: %d\n",
+					 max_sq_depth);
+				return -FI_ENODATA;
+			}
+			if (hints->tx_attr->size > max_sq_depth) {
+				EFA_INFO(FI_LOG_CORE,
+					 "Requested TX SQ depth (%zu) exceeds maximum depth (%d)"
+					 " for inline size %zu\n",
+					 hints->tx_attr->size, max_sq_depth,
+					 hints->tx_attr->inject_size);
+				return -FI_ENODATA;
+			}
+			info->tx_attr->size = max_sq_depth;
 #else
-		return -FI_ENODATA;
+			return -FI_ENODATA;
 #endif
+		}
+		/* inject_size <= inline_buf_size: no adjustment needed,
+		 * ofi_alter_info will set inject_size from hints */
 	}
-	/* inject_size <= inline_buf_size: no adjustment needed,
-	 * ofi_alter_info will set inject_size from hints */
 	/*
 	 * Handle user-provided hints and adapt the info object passed back up
 	 * based on EFA-specific constraints.
@@ -839,6 +872,19 @@ int efa_get_user_info(uint32_t version, const char *node,
 
 		if (EFA_INFO_TYPE_IS_DIRECT(prov_info)) {
 			ret = efa_user_info_alter_direct(version, dupinfo, hints);
+			if (ret) {
+				fi_freeinfo(dupinfo);
+				continue;
+			}
+		}
+
+		/*
+		 * DGRAM runs on the same efa base endpoint as efa-direct, so it
+		 * advertises FI_CONTEXT2 conditionally the same way (efa-direct
+		 * handles this inside efa_user_info_alter_direct()).
+		 */
+		if (EFA_INFO_TYPE_IS_DGRAM(prov_info)) {
+			ret = efa_user_info_set_context2(dupinfo, hints);
 			if (ret) {
 				fi_freeinfo(dupinfo);
 				continue;

--- a/prov/efa/test/efa_unit_test_common.c
+++ b/prov/efa/test/efa_unit_test_common.c
@@ -67,7 +67,7 @@ struct fi_info *efa_unit_test_alloc_hints(enum fi_ep_type ep_type, char *fabric_
 	/* Use a minimal caps that efa / efa-direct should always support */
 	hints->domain_attr->mr_mode = MR_MODE_BITS;
 
-	/* EFA direct and dgram paths require FI_CONTEXT2 */
+	/* efa-direct and DGRAM default to FI_CONTEXT2 here but no longer require it */
 	if (!fabric_name || !strcasecmp(fabric_name, EFA_DIRECT_FABRIC_NAME))
 		hints->mode |= FI_CONTEXT2;
 

--- a/prov/efa/test/gtest/efa_gtest_cq.cc
+++ b/prov/efa/test/gtest/efa_gtest_cq.cc
@@ -489,3 +489,144 @@ TEST_F(EfaCQPollTest, stops_at_cqe_to_process)
 	int ret = efa_cq_poll_ibv_cq(2, ibv_cq);
 	EXPECT_EQ(ret, 0);
 }
+
+/**
+ * @brief Completion-path fixture for an efa-direct endpoint opened WITHOUT
+ * FI_CONTEXT2. In this mode the CQ must never dereference wr_id as a context
+ * buffer: op_context is echoed verbatim and completion flags are derived from
+ * the CQE opcode. Identical to EfaCQPollTest except the FI_CONTEXT2 bit is
+ * cleared from the hints.
+ */
+class EfaCQPollNoContext2Test : public Test
+{
+	protected:
+	struct efa_resource resource = {};
+	StrictMock<MockEfa> mock_efa;
+	struct efa_ibv_cq *ibv_cq = nullptr;
+	uint32_t qp_num = 0;
+
+	void SetUp() override
+	{
+		struct fi_info *hints = efa_test_alloc_default_hints(
+			FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
+		ASSERT_NE(hints, nullptr);
+		/* Drop FI_CONTEXT2 so the endpoint runs in no-context2 mode. */
+		hints->mode &= ~FI_CONTEXT2;
+
+		memset(&resource, 0, sizeof(resource));
+		efa_test_resource_construct(&resource, hints);
+		ASSERT_NE(resource.cq, nullptr);
+		/* The returned info must not require FI_CONTEXT2. */
+		ASSERT_EQ(resource.info->mode & FI_CONTEXT2, (uint64_t) 0);
+		ibv_cq = efa_test_get_ibv_cq(resource.cq);
+		ASSERT_NE(ibv_cq, nullptr);
+		qp_num = efa_test_get_qp_num(resource.ep);
+
+		MockEfa::set(&mock_efa);
+	}
+
+	void TearDown() override
+	{
+		MockEfa::set(nullptr);
+		efa_test_resource_destruct(&resource);
+	}
+};
+
+class EfaCQPollNoContext2TxTest :
+	public EfaCQPollNoContext2Test,
+	public WithParamInterface<enum ibv_wc_opcode>
+{
+	protected:
+	static uint64_t expected_flags(enum ibv_wc_opcode opcode)
+	{
+		switch (opcode) {
+		case IBV_WC_SEND:
+			return FI_SEND | FI_MSG;
+		case IBV_WC_RDMA_READ:
+			return FI_RMA | FI_READ;
+		case IBV_WC_RDMA_WRITE:
+			return FI_RMA | FI_WRITE;
+		default:
+			return 0;
+		}
+	}
+};
+
+/**
+ * @brief With a non-NULL context, the no-context2 completion path echoes the
+ * raw context pointer as op_context and derives flags from the opcode. The
+ * context buffer's completion_flags is poisoned with a value that can never be
+ * opcode-derived, so a stray dereference would be caught.
+ */
+TEST_P(EfaCQPollNoContext2TxTest, echoes_context_and_derives_flags_from_opcode)
+{
+	enum ibv_wc_opcode opcode = GetParam();
+	const uint64_t poison = 0xdead;
+	struct efa_context *ctx = efa_test_alloc_context(poison, 0x42);
+	ASSERT_NE(ctx, nullptr);
+
+	EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_start_poll).WillOnce(Return(0));
+	EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_qp_num)
+		.WillRepeatedly(Return(qp_num));
+	EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_opcode)
+		.WillRepeatedly(Return(opcode));
+	EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_wc_flags)
+		.WillRepeatedly(Return(0));
+	EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_byte_len)
+		.WillRepeatedly(Return(64));
+	EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_next_poll).WillOnce(Return(ENOENT));
+	EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_end_poll).Times(1);
+
+	efa_test_set_ibv_cq_ex(ibv_cq, 0, (uint64_t) (uintptr_t) ctx);
+
+	int ret = efa_cq_poll_ibv_cq(10, ibv_cq);
+	EXPECT_EQ(ret, ENOENT);
+
+	struct fi_cq_data_entry entry = {};
+	ASSERT_EQ(efa_test_cq_read_staged_data_entry(resource.cq, &entry), 1);
+	/* op_context is the raw context pointer, echoed verbatim. */
+	EXPECT_EQ(entry.op_context, (void *) ctx);
+	/* flags come from the opcode, NOT ctx->completion_flags. */
+	EXPECT_EQ(entry.flags, expected_flags(opcode));
+	EXPECT_NE(entry.flags, poison);
+	EXPECT_EQ(entry.len, (size_t) 64);
+
+	free(ctx);
+}
+
+/**
+ * @brief Without FI_CONTEXT2, inject and selective completion are disabled, so
+ * even a NULL context (wr_id == 0) must still produce a completion (op_context
+ * NULL, flags from the opcode). This guards the efa_cq_poll_ibv_cq path.
+ */
+TEST_P(EfaCQPollNoContext2TxTest, null_context_still_writes_completion)
+{
+	enum ibv_wc_opcode opcode = GetParam();
+
+	EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_start_poll).WillOnce(Return(0));
+	EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_qp_num)
+		.WillRepeatedly(Return(qp_num));
+	EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_opcode)
+		.WillRepeatedly(Return(opcode));
+	EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_wc_flags)
+		.WillRepeatedly(Return(0));
+	EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_wc_read_byte_len)
+		.WillRepeatedly(Return(64));
+	EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_next_poll).WillOnce(Return(ENOENT));
+	EFA_EXPECT_CALL(mock_efa, efa_ibv_cq_end_poll).Times(1);
+
+	efa_test_set_ibv_cq_ex(ibv_cq, 0, 0);
+
+	int ret = efa_cq_poll_ibv_cq(10, ibv_cq);
+	EXPECT_EQ(ret, ENOENT);
+
+	struct fi_cq_data_entry entry = {};
+	ASSERT_EQ(efa_test_cq_read_staged_data_entry(resource.cq, &entry), 1);
+	EXPECT_EQ(entry.op_context, nullptr);
+	EXPECT_EQ(entry.flags, expected_flags(opcode));
+	EXPECT_EQ(entry.len, (size_t) 64);
+}
+
+INSTANTIATE_TEST_SUITE_P(TxOpcodes, EfaCQPollNoContext2TxTest,
+			 Values(IBV_WC_SEND, IBV_WC_RDMA_READ,
+				IBV_WC_RDMA_WRITE));

--- a/prov/efa/test/gtest/efa_gtest_msg.cc
+++ b/prov/efa/test/gtest/efa_gtest_msg.cc
@@ -5,6 +5,7 @@
 #include "efa_gtest_common_helpers.h"
 #include "efa_gtest_common_mocks.h"
 #include "efa_gtest_common_resource.h"
+#include <cstring>
 #include <gtest/gtest.h>
 
 using testing::_;
@@ -24,12 +25,14 @@ class EfaMsgTest : public Test
 	void *local_desc = nullptr;
 	int prev_track_mr = 0;
 
-	void construct(size_t buf_size)
+	void construct(size_t buf_size, bool use_context2 = true)
 	{
 		int ret;
 		struct fi_info *hints = efa_test_alloc_default_hints(
 			FI_EP_RDM, EFA_DIRECT_FABRIC_NAME);
 		ASSERT_NE(hints, nullptr);
+		if (!use_context2)
+			hints->mode &= ~FI_CONTEXT2;
 
 		efa_test_resource_construct(&resource, hints);
 		ASSERT_NE(resource.ep, nullptr);
@@ -118,4 +121,66 @@ TEST_F(EfaMsgTest, recv_success_keeps_direct_ope_alive)
 	EXPECT_EQ(ret, 0);
 
 	EXPECT_EQ(efa_test_ope_list_count(resource.ep), 1u);
+}
+
+/**
+ * @brief Without FI_CONTEXT2, efa_post_send must NOT touch the caller's context
+ * buffer: it echoes the raw context pointer as wr_id and never calls
+ * efa_fill_context (which would write completion_flags/addr into the buffer).
+ */
+TEST_F(EfaMsgTest, send_no_context2_echoes_context_and_leaves_buffer_untouched)
+{
+	struct fi_context2 ctx;
+	struct fi_context2 expected;
+	memset(&ctx, 0xAB, sizeof(ctx));
+	memset(&expected, 0xAB, sizeof(expected));
+
+	prev_track_mr = efa_test_set_track_mr(0);
+
+	ASSERT_NO_FATAL_FAILURE(construct(4096, /*use_context2=*/false));
+
+	/* wr_id is exactly the caller's context pointer, echoed verbatim. */
+	auto wr_id_is_ctx = Truly([&ctx](uintptr_t wr_id) {
+		return wr_id == (uintptr_t) &ctx;
+	});
+	EFA_EXPECT_CALL(mock_efa, efa_qp_post_send, _, _, _, 1, _,
+			wr_id_is_ctx, _, _, _, _, _)
+		.WillOnce(Return(0));
+
+	int ret = fi_send(resource.ep, local_buf, 4096, local_desc, peer_addr,
+			  &ctx);
+	EXPECT_EQ(ret, 0);
+
+	/* The provider must not have written into the context buffer. */
+	EXPECT_EQ(memcmp(&ctx, &expected, sizeof(ctx)), 0);
+	/* No direct_ope is allocated in no-context2 mode. */
+	EXPECT_EQ(efa_test_ope_list_count(resource.ep), 0u);
+}
+
+/**
+ * @brief Same guarantee for efa_post_recv without FI_CONTEXT2.
+ */
+TEST_F(EfaMsgTest, recv_no_context2_echoes_context_and_leaves_buffer_untouched)
+{
+	struct fi_context2 ctx;
+	struct fi_context2 expected;
+	memset(&ctx, 0xAB, sizeof(ctx));
+	memset(&expected, 0xAB, sizeof(expected));
+
+	prev_track_mr = efa_test_set_track_mr(0);
+
+	ASSERT_NO_FATAL_FAILURE(construct(4096, /*use_context2=*/false));
+
+	auto wr_id_is_ctx = Truly([&ctx](const struct ibv_recv_wr *wr) {
+		return wr->wr_id == (uintptr_t) &ctx;
+	});
+	EFA_EXPECT_CALL(mock_efa, efa_qp_post_recv, _, wr_id_is_ctx, _)
+		.WillOnce(Return(0));
+
+	int ret = fi_recv(resource.ep, local_buf, 4096, local_desc, peer_addr,
+			  &ctx);
+	EXPECT_EQ(ret, 0);
+
+	EXPECT_EQ(memcmp(&ctx, &expected, sizeof(ctx)), 0);
+	EXPECT_EQ(efa_test_ope_list_count(resource.ep), 0u);
 }

--- a/prov/efa/test/gtest/efa_gtest_rma.cc
+++ b/prov/efa/test/gtest/efa_gtest_rma.cc
@@ -5,6 +5,7 @@
 #include "efa_gtest_common_helpers.h"
 #include "efa_gtest_common_mocks.h"
 #include "efa_gtest_common_resource.h"
+#include <cstring>
 #include <gtest/gtest.h>
 #include <rdma/fi_rma.h>
 
@@ -225,4 +226,70 @@ TEST_F(EfaRmaTest, write_track_mr_keeps_direct_ope_alive)
 	EXPECT_EQ(ret, 0);
 
 	EXPECT_EQ(efa_test_ope_list_count(resource.ep), 1u);
+}
+
+/**
+ * @brief Without FI_CONTEXT2, efa_rma_post_read must NOT touch the caller's
+ * context buffer: it echoes the raw context pointer as wr_id and never calls
+ * efa_fill_context.
+ */
+TEST_F(EfaRmaTest, read_no_context2_echoes_context_and_leaves_buffer_untouched)
+{
+	struct fi_context2 ctx;
+	struct fi_context2 expected;
+	memset(&ctx, 0xAB, sizeof(ctx));
+	memset(&expected, 0xAB, sizeof(expected));
+
+	struct fi_info *hints = make_hints();
+	ASSERT_NE(hints, nullptr);
+	hints->mode &= ~FI_CONTEXT2;
+
+	ASSERT_NO_FATAL_FAILURE(construct(hints));
+	reg_buffer(4096);
+
+	auto wr_id_is_ctx = Truly([&ctx](uintptr_t wr_id) {
+		return wr_id == (uintptr_t) &ctx;
+	});
+	EFA_EXPECT_CALL(mock_efa, efa_qp_post_read, _, _, 1, kRemoteKey,
+			kRemoteAddr, wr_id_is_ctx, _, _, _, _)
+		.WillOnce(Return(0));
+
+	int ret = fi_read(resource.ep, local_buf, 4096, local_desc, peer_addr,
+			  kRemoteAddr, kRemoteKey, &ctx);
+	EXPECT_EQ(ret, 0);
+
+	EXPECT_EQ(memcmp(&ctx, &expected, sizeof(ctx)), 0);
+	EXPECT_EQ(efa_test_ope_list_count(resource.ep), 0u);
+}
+
+/**
+ * @brief Same guarantee for efa_rma_post_write without FI_CONTEXT2.
+ */
+TEST_F(EfaRmaTest, write_no_context2_echoes_context_and_leaves_buffer_untouched)
+{
+	struct fi_context2 ctx;
+	struct fi_context2 expected;
+	memset(&ctx, 0xAB, sizeof(ctx));
+	memset(&expected, 0xAB, sizeof(expected));
+
+	struct fi_info *hints = make_hints();
+	ASSERT_NE(hints, nullptr);
+	hints->mode &= ~FI_CONTEXT2;
+
+	ASSERT_NO_FATAL_FAILURE(construct(hints));
+	reg_buffer(4096);
+
+	auto wr_id_is_ctx = Truly([&ctx](uintptr_t wr_id) {
+		return wr_id == (uintptr_t) &ctx;
+	});
+	EFA_EXPECT_CALL(mock_efa, efa_qp_post_write, _, _, 1, _, _, kRemoteKey,
+			kRemoteAddr, wr_id_is_ctx, _, _, _, _, _)
+		.WillOnce(Return(0));
+
+	int ret = fi_write(resource.ep, local_buf, 4096, local_desc, peer_addr,
+			   kRemoteAddr, kRemoteKey, &ctx);
+	EXPECT_EQ(ret, 0);
+
+	EXPECT_EQ(memcmp(&ctx, &expected, sizeof(ctx)), 0);
+	EXPECT_EQ(efa_test_ope_list_count(resource.ep), 0u);
 }


### PR DESCRIPTION
Currently, efa-direct does not support the GDA usecase where the wqe posting is handled on the GPU and completions are handled on the CPU. This is because efa-direct requires FI_CONTEXT2, meaning that the user provided context buffer is used to store and pass values between the two API call. Furthermore, efa-direct cannot just cue off of context == NULL as this is used to specify the inject path, with no completions, which is not suitable for the GDA case.

This patch removes that requirement by allowing efa-direct without any FI_CONTEXT* set. In this mode, eps can be creted with either FI_CONTEXT2 or without FI_CONTEXT2 and a CQ that is bound will take on this mode. The CQ will reject binding to an ep in an incompatible mode. In this mode, completions will be generated unconditionally, and any features which use or build on the user provided context buffer like mr tracking are not compatible.


(cherry picked from commit 0fcf126fbc687bd45f08750cd702609d010383c4)