### PR TITLE
prov/efa: Enable lock ordering check with thread safety analysis

### DIFF
--- a/.github/workflows/thread-safety-analysis.yml
+++ b/.github/workflows/thread-safety-analysis.yml
@@ -19,7 +19,7 @@ on:
 permissions: {}
 
 env:
-  RDMA_CORE_VERSION: v35.0
+  RDMA_CORE_VERSION: v65.0
   RDMA_CORE_PATH: '$PWD/rdma-core/build'
 
 jobs:
@@ -56,7 +56,7 @@ jobs:
                       CC=clang
           # -Werror=thread-safety makes only locking-contract violations fatal;
           # unrelated warnings do not fail the job.
-          make -j 2 AM_CFLAGS="-Wthread-safety -Werror=thread-safety"
+          make -j 2 AM_CFLAGS="-Werror=thread-safety"
 
       - name: Upload build logs
         if: failure()

--- a/configure.ac
+++ b/configure.ac
@@ -160,6 +160,8 @@ AC_DEFINE_UNQUOTED([ENABLE_DEBUG],[$dbg],
 # Clang Thread Safety Analysis. Off by default; enable with
 # --enable-thread-safety-analysis. Only then, and only if the compiler
 # supports it, add -Wthread-safety and define OFI_THREAD_SAFETY_ANALYSIS.
+# -Wthread-safety-beta additionally enables the lock ordering checks driven by
+# the acquired_after annotations.
 AC_ARG_ENABLE([thread_safety_analysis],
 	[AS_HELP_STRING([--enable-thread-safety-analysis],
 		[Enable Clang thread safety analysis @<:@default=no@:>@])],
@@ -169,10 +171,10 @@ AC_ARG_ENABLE([thread_safety_analysis],
 AS_IF([test x"$enable_thread_safety_analysis" != x"no"], [
 	AC_MSG_CHECKING([whether $CC supports -Wthread-safety])
 	CFLAGS_save="$CFLAGS"
-	CFLAGS="-Werror -Wthread-safety $CFLAGS_save"
+	CFLAGS="-Werror -Wthread-safety -Wthread-safety-beta $CFLAGS_save"
 	AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
 			  [AC_MSG_RESULT([yes])
-			   CFLAGS="-Wthread-safety -DOFI_THREAD_SAFETY_ANALYSIS $CFLAGS_save"],
+			   CFLAGS="-Wthread-safety -Wthread-safety-beta -DOFI_THREAD_SAFETY_ANALYSIS $CFLAGS_save"],
 			  [AC_MSG_RESULT([no])
 			   CFLAGS="$CFLAGS_save"])
 	unset CFLAGS_save

--- a/prov/efa/src/efa_thread_annotations.c
+++ b/prov/efa/src/efa_thread_annotations.c
@@ -5,7 +5,6 @@
 
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_qp_table_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_implicit_av_lock_sym);
-OFI_TSA_LOCK_SYMBOL_DEFINE(efa_util_ep_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_ctrl_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_util_av_lock_sym);
 OFI_TSA_LOCK_SYMBOL_DEFINE(efa_util_domain_lock_sym);

--- a/prov/efa/src/efa_thread_annotations.h
+++ b/prov/efa/src/efa_thread_annotations.h
@@ -34,6 +34,7 @@
 #define OFI_TSA_RELEASE(...)		OFI_TSA_ANNOTATION(release_capability(__VA_ARGS__))
 #define OFI_TSA_ASSERT_CAPABILITY(x)	OFI_TSA_ANNOTATION(assert_capability(x))
 #define OFI_TSA_NO_ANALYSIS		OFI_TSA_ANNOTATION(no_thread_safety_analysis)
+#define OFI_TSA_ACQUIRED_AFTER(...)	OFI_TSA_ANNOTATION(acquired_after(__VA_ARGS__))
 
 /*
  * Lock symbols.
@@ -49,6 +50,8 @@ struct OFI_TSA_CAPABILITY("mutex") ofi_tsa_lock_symbol { char dummy; };
 
 #define OFI_TSA_LOCK_SYMBOL_DECLARE(name) \
 	extern struct ofi_tsa_lock_symbol name
+#define OFI_TSA_LOCK_SYMBOL_DECLARE_ACQUIRED_AFTER(name, ...) \
+	extern struct ofi_tsa_lock_symbol name OFI_TSA_ACQUIRED_AFTER(__VA_ARGS__)
 #define OFI_TSA_LOCK_SYMBOL_DEFINE(name) \
 	struct ofi_tsa_lock_symbol name
 
@@ -83,6 +86,8 @@ efa_genlock_held(struct ofi_genlock *lock, struct ofi_tsa_lock_symbol *sym)
 #else /* !OFI_THREAD_SAFETY_ANALYSIS */
 
 #define OFI_TSA_LOCK_SYMBOL_DECLARE(name)	struct ofi_tsa_lock_symbol_unused_##name
+#define OFI_TSA_LOCK_SYMBOL_DECLARE_ACQUIRED_AFTER(name, ...) \
+	OFI_TSA_LOCK_SYMBOL_DECLARE(name)
 #define OFI_TSA_LOCK_SYMBOL_DEFINE(name)	struct ofi_tsa_lock_symbol_unused_##name
 
 #define EFA_GENLOCK_LOCK(lock, sym)	ofi_genlock_lock(lock)
@@ -91,12 +96,15 @@ efa_genlock_held(struct ofi_genlock *lock, struct ofi_tsa_lock_symbol *sym)
 
 #endif /* OFI_THREAD_SAFETY_ANALYSIS */
 
-/* EFA lock symbols (one per lock role). */
-OFI_TSA_LOCK_SYMBOL_DECLARE(efa_qp_table_lock_sym);
-OFI_TSA_LOCK_SYMBOL_DECLARE(efa_implicit_av_lock_sym);
-OFI_TSA_LOCK_SYMBOL_DECLARE(efa_util_ep_lock_sym);
-OFI_TSA_LOCK_SYMBOL_DECLARE(efa_ctrl_lock_sym);
-OFI_TSA_LOCK_SYMBOL_DECLARE(efa_util_av_lock_sym);
+/* EFA lock symbols (one per lock role), declared outermost lock first. */
 OFI_TSA_LOCK_SYMBOL_DECLARE(efa_util_domain_lock_sym);
+OFI_TSA_LOCK_SYMBOL_DECLARE_ACQUIRED_AFTER(efa_util_av_lock_sym,
+					   efa_util_domain_lock_sym);
+OFI_TSA_LOCK_SYMBOL_DECLARE_ACQUIRED_AFTER(efa_implicit_av_lock_sym,
+					   efa_util_av_lock_sym);
+OFI_TSA_LOCK_SYMBOL_DECLARE_ACQUIRED_AFTER(efa_ctrl_lock_sym,
+					   efa_implicit_av_lock_sym);
+
+OFI_TSA_LOCK_SYMBOL_DECLARE(efa_qp_table_lock_sym);
 
 #endif /* EFA_THREAD_ANNOTATIONS_H */


### PR DESCRIPTION
Document the locking order with ACQUIRED_AFTER.