### PR TITLE
windows: name the loopback interface "lo"

### DIFF
--- a/src/windows/osd.c
+++ b/src/windows/osd.c
@@ -478,7 +478,12 @@ int getifaddrs(struct ifaddrs **ifap)
 			}
 			fa->speed = aa->TransmitLinkSpeed;
 			/* Generate fake Unix-like device names */
-			sprintf_s(fa->ad_name, sizeof(fa->ad_name), "eth%d", i++);
+			if (fa->ifa_flags & IFF_LOOPBACK) {
+				sprintf_s(fa->ad_name, sizeof(fa->ad_name), "lo");
+			}
+			else {
+				sprintf_s(fa->ad_name, sizeof(fa->ad_name), "eth%d", i++);
+			}
 		}
 	}
 	ret = 0;


### PR DESCRIPTION
The Windows getifaddrs() shim synthesizes Unix-like device names for enumerated adapters, but named every adapter -- including the software loopback -- "ethN". The loopback is already tagged with IFF_LOOPBACK, so name it "lo" to match the convention used on Unix platforms and let callers identify the loopback interface consistently regardless of OS.