### PR TITLE
core: parse FI_PARAM_SIZE_T variables with strtoull

### DIFF
--- a/src/var.c
+++ b/src/var.c
@@ -400,7 +400,7 @@ int DEFAULT_SYMVER_PRE(fi_param_get)(struct fi_provider *provider,
 			"read bool var %s=%d\n", param_name, *(int *) value);
 		break;
 	case FI_PARAM_SIZE_T:
-		* ((size_t *) value) = strtol(str_value, NULL, 0);
+		* ((size_t *) value) = strtoull(str_value, NULL, 0);
 		FI_INFO(provider, FI_LOG_CORE,
 			"read long var %s=%zu\n", param_name, *(size_t *) value);
 		break;


### PR DESCRIPTION
fi_param_get() parses FI_PARAM_SIZE_T values with strtol(), which returns a signed long and, for a value larger than LONG_MAX, clamps the result to LONG_MAX (setting errno to ERANGE). On LLP64 platforms such as Windows, long is 32 bits, so a size_t parameter set above 2^31-1 -- e.g. a multi-gigabyte mr_cache_max_size -- is clamped to ~2 GiB before it reaches the size_t destination.

Use strtoull(), which returns an unsigned long long matching the unsigned size_t destination and preserves the configured value.