### PR TITLE
prov/util: fix integer overflow in ofi_mr_map_verify bounds check

### DIFF
--- a/prov/efa/Makefile.include
+++ b/prov/efa/Makefile.include
@@ -313,6 +313,7 @@ nodist_prov_efa_test_gtest_efa_gtest_SOURCES = \
 	prov/efa/test/gtest/efa_gtest_rdm_peer.cc \
 	prov/efa/test/gtest/efa_gtest_msg.cc \
 	prov/efa/test/gtest/efa_gtest_rma.cc \
+	prov/efa/test/gtest/efa_gtest_rdm_rma.cc \
 	prov/efa/test/gtest/efa_gtest_hmem.cc \
 	prov/efa/test/gtest/efa_gtest_tclass_utils.c \
 	prov/efa/test/gtest/efa_gtest_tclass.cc \

--- a/prov/efa/src/rdm/efa_rdm_rma.c
+++ b/prov/efa/src/rdm/efa_rdm_rma.c
@@ -22,25 +22,29 @@ int efa_rdm_rma_verified_copy_iov(struct efa_rdm_ep *ep, struct efa_rma_iov *rma
 	struct efa_mr *efa_mr;
 	int i, ret;
 
+	ofi_genlock_lock(&efa_rdm_ep_domain(ep)->util_domain.lock);
 	for (i = 0; i < count; i++) {
-		ofi_genlock_lock(&efa_rdm_ep_domain(ep)->util_domain.lock);
 		ret = ofi_mr_map_verify(&efa_rdm_ep_domain(ep)->util_domain.mr_map,
 					(uintptr_t *)(&rma[i].addr),
 					rma[i].len, rma[i].key, flags,
 					&context);
-		efa_mr = context;
-		desc[i] = fi_mr_desc(&efa_mr->mr_fid);
-		ofi_genlock_unlock(&efa_rdm_ep_domain(ep)->util_domain.lock);
+
 		if (ret) {
+			ofi_genlock_unlock(&efa_rdm_ep_domain(ep)->util_domain.lock);
 			EFA_WARN(FI_LOG_EP_CTRL,
 				"MR verification failed (%s), addr: %lx key: %ld\n",
 				fi_strerror(-ret), rma[i].addr, rma[i].key);
 			return ret;
 		}
 
+		efa_mr = context;
+		desc[i] = fi_mr_desc(&efa_mr->mr_fid);
+
 		iov[i].iov_base = (void *)rma[i].addr;
 		iov[i].iov_len = rma[i].len;
 	}
+
+	ofi_genlock_unlock(&efa_rdm_ep_domain(ep)->util_domain.lock);
 	return 0;
 }
 

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.c
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.c
@@ -8,6 +8,7 @@
 #include "efa_device.h"
 #include "rdm/efa_rdm_ep.h"
 #include "rdm/efa_rdm_mr.h"
+#include "rdm/efa_rdm_rma.h"
 #include "ofi_mr.h"
 #include "efa_gtest_common_helpers.h"
 
@@ -237,4 +238,15 @@ uint64_t efa_test_ofi_hmem_data_dev_reg_handle(void)
 uint64_t efa_test_rdm_mr_shm_flags(uint64_t mr_flags, enum fi_hmem_iface iface)
 {
 	return efa_rdm_mr_shm_flags(mr_flags, iface);
+}
+
+int efa_test_rdm_rma_verified_copy_iov(struct fid_ep *ep_fid, uint64_t addr,
+				       size_t len, uint64_t key, uint32_t flags,
+				       struct iovec *iov, void **desc)
+{
+	struct efa_rdm_ep *ep = container_of(ep_fid, struct efa_rdm_ep,
+					     base_ep.util_ep.ep_fid);
+	struct efa_rma_iov rma = {.addr = addr, .len = len, .key = key};
+
+	return efa_rdm_rma_verified_copy_iov(ep, &rma, 1, flags, iov, desc);
 }

--- a/prov/efa/test/gtest/efa_gtest_common_helpers.h
+++ b/prov/efa/test/gtest/efa_gtest_common_helpers.h
@@ -156,6 +156,14 @@ uint64_t efa_test_ofi_hmem_data_dev_reg_handle(void);
  */
 uint64_t efa_test_rdm_mr_shm_flags(uint64_t mr_flags, enum fi_hmem_iface iface);
 
+/**
+ * @brief Wrapper around the product efa_rdm_rma_verified_copy_iov() for a
+ * single peer-supplied rma_iov (struct efa_rma_iov is not includable from C++).
+ */
+int efa_test_rdm_rma_verified_copy_iov(struct fid_ep *ep_fid, uint64_t addr,
+				       size_t len, uint64_t key, uint32_t flags,
+				       struct iovec *iov, void **desc);
+
 #ifdef __cplusplus
 }
 #endif

--- a/prov/efa/test/gtest/efa_gtest_rdm_rma.cc
+++ b/prov/efa/test/gtest/efa_gtest_rdm_rma.cc
@@ -1,0 +1,103 @@
+/* SPDX-License-Identifier: BSD-2-Clause OR GPL-2.0-only */
+/* SPDX-FileCopyrightText: Copyright Amazon.com, Inc. or its affiliates. All
+ * rights reserved. */
+
+#include "efa_gtest_common_helpers.h"
+#include "efa_gtest_common_resource.h"
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <gtest/gtest.h>
+
+using testing::TestWithParam;
+using testing::ValuesIn;
+
+/*
+ * The addr and len of an incoming RTW/RTR/RTA packet are supplied by the remote
+ * peer, so efa_rdm_rma_verified_copy_iov() must reject every target region that
+ * is not fully contained in the registered MR - including the ones that make
+ * the bounds arithmetic wrap around.
+ */
+struct RmaVerifyCase {
+	const char *name;
+	/* offset of the peer-supplied addr relative to the start of the MR */
+	ptrdiff_t offset;
+	/* peer-supplied length */
+	size_t len;
+	int expected_ret;
+};
+
+static constexpr size_t kMrLen = 4096;
+
+static const RmaVerifyCase kRmaVerifyCases[] = {
+	{"whole_region", 0, kMrLen, 0},
+	{"interior_region", 64, 64, 0},
+	{"last_byte", kMrLen - 1, 1, 0},
+	/* (addr + len) wraps to (addr - 1), which is below the MR end. */
+	{"len_size_max", 0, SIZE_MAX, -FI_EACCES},
+	/* (MR end - addr) wraps, so the space left in the MR looks huge. */
+	{"addr_past_mr_end", kMrLen + 64, 64, -FI_EACCES},
+	{"len_past_mr_end", 0, kMrLen + 1, -FI_EACCES},
+	{"addr_before_mr_start", -64, 64, -FI_EACCES},
+};
+
+class EfaRdmRmaVerifyTest : public TestWithParam<RmaVerifyCase>
+{
+	protected:
+	struct efa_resource resource = {};
+	uint8_t *buf = nullptr;
+	struct fid_mr *mr = nullptr;
+
+	void SetUp() override
+	{
+		efa_test_resource_construct(
+			&resource, efa_test_alloc_default_hints(
+					   FI_EP_RDM, EFA_FABRIC_NAME));
+		ASSERT_NE(resource.ep, nullptr);
+
+		buf = new uint8_t[kMrLen]();
+		ASSERT_EQ(fi_mr_reg(resource.domain, buf, kMrLen,
+				    FI_REMOTE_READ | FI_REMOTE_WRITE, 0, 0, 0,
+				    &mr, nullptr),
+			  0);
+	}
+
+	void TearDown() override
+	{
+		if (mr)
+			fi_close(&mr->fid);
+		delete[] buf;
+		efa_test_resource_destruct(&resource);
+	}
+};
+
+TEST_P(EfaRdmRmaVerifyTest, enforces_mr_bounds)
+{
+	const RmaVerifyCase &c = GetParam();
+	uint64_t addr = (uint64_t) (uintptr_t) buf + c.offset;
+	struct iovec iov = {};
+	void *desc = nullptr;
+	int ret;
+
+	ret = efa_test_rdm_rma_verified_copy_iov(resource.ep, addr, c.len,
+						 fi_mr_key(mr), FI_REMOTE_WRITE,
+						 &iov, &desc);
+	EXPECT_EQ(ret, c.expected_ret);
+
+	if (c.expected_ret) {
+		/* A rejected region must not reach the caller's iov/desc. */
+		EXPECT_EQ(iov.iov_base, nullptr);
+		EXPECT_EQ(iov.iov_len, 0u);
+		EXPECT_EQ(desc, nullptr);
+	} else {
+		EXPECT_EQ(iov.iov_base, (void *) (uintptr_t) addr);
+		EXPECT_EQ(iov.iov_len, c.len);
+		EXPECT_EQ(desc, fi_mr_desc(mr));
+	}
+}
+
+INSTANTIATE_TEST_SUITE_P(
+	, EfaRdmRmaVerifyTest, ValuesIn(kRmaVerifyCases),
+	[](const testing::TestParamInfo<RmaVerifyCase> &info) {
+		return std::string(info.param.name);
+	});

--- a/prov/util/src/util_mr_map.c
+++ b/prov/util/src/util_mr_map.c
@@ -140,13 +140,22 @@ int ofi_mr_map_verify(struct ofi_mr_map *map, uintptr_t *io_addr,
 
 	addr = (void *) (*io_addr + (uintptr_t) attr->offset);
 
+	/*
+	 * addr and len come from a remote peer's rma_iov, so the bounds check
+	 * must hold for every 64-bit value of either.
+	 *
+	 * Compare the offset of the target region into the MR against the
+	 * space the MR has left.  Neither subtraction can underflow because
+	 * the preceding checks establish addr >= iov_base and len <= iov_len.
+	 */
 	if ((addr < attr->mr_iov[0].iov_base) ||
-	    (((char *) addr + len) > ((char *) attr->mr_iov[0].iov_base +
-			    	      attr->mr_iov[0].iov_len))) {
+	    (len > attr->mr_iov[0].iov_len) ||
+	    ((uintptr_t) addr - (uintptr_t) attr->mr_iov[0].iov_base >
+	     attr->mr_iov[0].iov_len - len)) {
                 FI_WARN(map->prov, FI_LOG_MR,
-                        "target region (%p - %p) "
+                        "target region (%p, len %zu) "
                         "out of registered range (%p - %p)\n",
-                        addr, (char *) addr + len,
+                        addr, len,
                         (char *) attr->mr_iov[0].iov_base,
                         (char *) attr->mr_iov[0].iov_base +
                         attr->mr_iov[0].iov_len);


### PR DESCRIPTION
ofi_mr_map_verify() bounded the target region by comparing (addr + len)
against the end of the registered region. Both addr and len come from
the rma_iov of an incoming RMA or atomic request, i.e. from the remote
peer, so (addr + len) can wrap around. In the case of len == SIZE_MAX
the sum is (addr - 1), which is below the end of the region, and the
check passes. The peer can then read or write past the end of the MR
into adjacent application memory.

Compare the offset of the target region into the MR against the space
the MR has left instead, and reject a len larger than the MR length
outright. Then neither subtraction can underflow.

The PR also includes two fixes for prov/efa