### PR TITLE
fabtests: parse the shared long options when need

### DIFF
--- a/fabtests/common/shared.c
+++ b/fabtests/common/shared.c
@@ -4638,6 +4638,32 @@ struct option long_opts[] = {
 	{NULL, 0, NULL, 0},
 };
 
+static int ft_count_long_opts(const struct option *opts)
+{
+	int n;
+
+	for (n = 0; opts[n].name; n++)
+		;
+	return n;
+}
+
+struct option *ft_merge_long_opts(const struct option *extra,
+				  const struct option *base)
+{
+	int extra_cnt = ft_count_long_opts(extra);
+	int base_cnt = ft_count_long_opts(base);
+	struct option *merged;
+
+	merged = calloc(extra_cnt + base_cnt + 1, sizeof(*merged));
+	if (!merged)
+		return NULL;
+
+	memcpy(merged, extra, extra_cnt * sizeof(*merged));
+	memcpy(merged + extra_cnt, base, base_cnt * sizeof(*merged));
+
+	return merged;
+}
+
 int ft_parse_progress_model_string(char* progress_str)
 {
 	int ret = -1;

--- a/fabtests/functional/rdm.c
+++ b/fabtests/functional/rdm.c
@@ -65,6 +65,7 @@ static int run(void)
 int main(int argc, char **argv)
 {
 	int op, ret, cleanup_ret;
+	int lopt_idx = 0;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_SIZE;
@@ -73,9 +74,12 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "Uh" ADDR_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt_long(argc, argv, "Uh" ADDR_OPTS INFO_OPTS, long_opts,
+				 &lopt_idx)) != -1) {
 		switch (op) {
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parse_addr_opts(op, optarg, &opts);
 			ft_parseinfo(op, optarg, hints, &opts);
 			break;
@@ -85,6 +89,7 @@ int main(int argc, char **argv)
 		case '?':
 		case 'h':
 			ft_usage(argv[0], "A simple RDM client-sever example.");
+			ft_longopts_usage();
 			return EXIT_FAILURE;
 		}
 	}

--- a/fabtests/functional/unexpected_msg.c
+++ b/fabtests/functional/unexpected_msg.c
@@ -336,9 +336,12 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "vCUM:h" CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt_long(argc, argv, "vCUM:h" CS_OPTS INFO_OPTS,
+				 long_opts, &lopt_idx)) != -1) {
 		switch (op) {
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parsecsopts(op, optarg, &opts);
 			ft_parse_addr_opts(op, optarg, &opts);
 			ft_parseinfo(op, optarg, hints, &opts);
@@ -362,6 +365,7 @@ int main(int argc, char **argv)
 			FT_PRINT_OPTS_USAGE("-C", "transfer remote CQ data");
 			FT_PRINT_OPTS_USAGE("-M <count>", "number of concurrent msgs");
 			FT_PRINT_OPTS_USAGE("-U", "Do transmission with FI_DELIVERY_COMPLETE");
+			ft_longopts_usage();
 			return EXIT_FAILURE;
 		}
 	}

--- a/fabtests/include/shared.h
+++ b/fabtests/include/shared.h
@@ -720,6 +720,9 @@ extern struct option long_opts[];
 int ft_parse_long_opts(int op, char *optarg);
 void ft_longopts_usage();
 
+struct option *ft_merge_long_opts(const struct option *extra,
+				  const struct option *base);
+
 #define ft_assert(expr)					\
 	do {						\
 		if (!debug_assert) {			\

--- a/fabtests/prov/efa/src/efa_gda.c
+++ b/fabtests/prov/efa/src/efa_gda.c
@@ -53,8 +53,14 @@ static bool use_hw_cntr;
 static volatile uint64_t *hw_send_cntr_ptr;
 static volatile uint64_t *hw_recv_cntr_ptr;
 
+/* Numbered past the shared LONG_OPT_* values and every short option */
 enum {
-	LONG_OPT_USE_HW_CNTR,
+	LONG_OPT_USE_HW_CNTR = 256,
+};
+
+static struct option gda_long_opts[] = {
+	{"use-hw-cntr", no_argument, NULL, LONG_OPT_USE_HW_CNTR},
+	{0, 0, 0, 0}
 };
 
 static int create_hw_cntr(struct fid_cntr **cntr,
@@ -442,28 +448,31 @@ int main(int argc, char **argv)
 {
 	int op, ret, i, cleanup_ret;
 	struct fi_rma_iov remote_iov = {0};
+	struct option *test_opts;
 
 	opts = INIT_OPTS;
 	opts.options |= FT_OPT_OOB_SYNC;
 
 	timeout = 5;
 
+	test_opts = ft_merge_long_opts(gda_long_opts, long_opts);
+	if (!test_opts)
+		return EXIT_FAILURE;
+
 	hints = fi_allocinfo();
 	if (!hints)
 		return EXIT_FAILURE;
 
 	while ((op = getopt_long(argc, argv,
-			    "vh" ADDR_OPTS INFO_OPTS CS_OPTS API_OPTS,
-			    (struct option[]){
-				{"use-hw-cntr", no_argument, NULL,
-				 LONG_OPT_USE_HW_CNTR},
-				{0, 0, 0, 0}
-			    }, NULL)) != -1) {
+				 "vh" ADDR_OPTS INFO_OPTS CS_OPTS API_OPTS,
+				 test_opts, &lopt_idx)) != -1) {
 		switch (op) {
 		case LONG_OPT_USE_HW_CNTR:
 			use_hw_cntr = true;
 			break;
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parse_addr_opts(op, optarg, &opts);
 			ft_parseinfo(op, optarg, hints, &opts);
 			ft_parsecsopts(op, optarg, &opts);
@@ -482,6 +491,7 @@ int main(int argc, char **argv)
 			FT_PRINT_OPTS_USAGE("-v", "Enable data verification");
 			FT_PRINT_OPTS_USAGE("--use-hw-cntr",
 				"Use hardware counter instead of send CQ");
+			ft_longopts_usage();
 			return EXIT_FAILURE;
 		}
 	}

--- a/fabtests/prov/efa/src/efa_mr_test.c
+++ b/fabtests/prov/efa/src/efa_mr_test.c
@@ -240,11 +240,13 @@ static void usage(char *name)
 {
 	ft_usage(name,
 		"Test HMEM dmabuf MR with aligned and unaligned VAs\n");
+	ft_longopts_usage();
 }
 
 int main(int argc, char **argv)
 {
 	int op, ret, cleanup_ret;
+	int lopt_idx = 0;
 
 	opts = INIT_OPTS;
 	opts.transfer_size = DEFAULT_BUF_SIZE;
@@ -253,9 +255,12 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, "h" HMEM_OPTS CS_OPTS INFO_OPTS)) != -1) {
+	while ((op = getopt_long(argc, argv, "h" HMEM_OPTS CS_OPTS INFO_OPTS,
+				 long_opts, &lopt_idx)) != -1) {
 		switch (op) {
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parseinfo(op, optarg, hints, &opts);
 			ft_parsecsopts(op, optarg, &opts);
 			break;

--- a/fabtests/prov/efa/src/efa_shared.c
+++ b/fabtests/prov/efa/src/efa_shared.c
@@ -27,22 +27,10 @@ struct option *efa_long_opts;
 
 void build_efa_long_opts(void)
 {
-	static bool initialized = false;
-	int shared_cnt, i;
-	int extra_cnt = sizeof(efa_extra_opts) / sizeof(efa_extra_opts[0]) - 1;
-
-	if (initialized)
+	if (efa_long_opts)
 		return;
 
-	for (shared_cnt = 0; long_opts[shared_cnt].name; shared_cnt++)
-		;
-	efa_long_opts = calloc(shared_cnt + extra_cnt + 1, sizeof(struct option));
-	for (i = 0; i < extra_cnt; i++)
-		efa_long_opts[i] = efa_extra_opts[i];
-	for (i = 0; i < shared_cnt; i++)
-		efa_long_opts[extra_cnt + i] = long_opts[i];
-
-	initialized = true;
+	efa_long_opts = ft_merge_long_opts(efa_extra_opts, long_opts);
 }
 
 void efa_longopts_usage(void)

--- a/fabtests/prov/efa/src/mr_abort.c
+++ b/fabtests/prov/efa/src/mr_abort.c
@@ -2606,22 +2606,12 @@ static struct option *mr_abort_long_opts;
 
 static int build_mr_abort_long_opts(void)
 {
-	int efa_cnt, extra_cnt, i;
-
 	build_efa_long_opts();
 
-	for (efa_cnt = 0; efa_long_opts[efa_cnt].name; efa_cnt++)
-		;
-	extra_cnt = sizeof(mr_abort_extra_opts) / sizeof(mr_abort_extra_opts[0]) - 1;
-
-	mr_abort_long_opts = calloc(efa_cnt + extra_cnt + 1, sizeof(struct option));
+	mr_abort_long_opts = ft_merge_long_opts(mr_abort_extra_opts,
+						efa_long_opts);
 	if (!mr_abort_long_opts)
 		return -FI_ENOMEM;
-
-	for (i = 0; i < extra_cnt; i++)
-		mr_abort_long_opts[i] = mr_abort_extra_opts[i];
-	for (i = 0; i < efa_cnt; i++)
-		mr_abort_long_opts[extra_cnt + i] = efa_long_opts[i];
 
 	return 0;
 }

--- a/fabtests/unit/mr_test.c
+++ b/fabtests/unit/mr_test.c
@@ -291,11 +291,13 @@ static void usage(char *name)
 {
 	ft_unit_usage(name, "Unit test for Memory Region (MR)");
 	ft_hmem_usage();
+	ft_longopts_usage();
 }
 
 int main(int argc, char **argv)
 {
 	int op, ret, cleanup_ret;
+	int lopt_idx = 0;
 	int failed = 0;
 
 	buf = NULL;
@@ -304,9 +306,12 @@ int main(int argc, char **argv)
 	if (!hints)
 		return EXIT_FAILURE;
 
-	while ((op = getopt(argc, argv, FAB_OPTS HMEM_OPTS "h")) != -1) {
+	while ((op = getopt_long(argc, argv, FAB_OPTS HMEM_OPTS "h", long_opts,
+				 &lopt_idx)) != -1) {
 		switch (op) {
 		default:
+			if (!ft_parse_long_opts(op, optarg))
+				continue;
 			ft_parseinfo(op, optarg, hints, &opts);
 			break;
 		case '?':


### PR DESCRIPTION
290dfc3 ("fabtests: add --use-cuda-pcie-mapping for CUDA dmabuf export") appends --use-cuda-pcie-mapping to every dmabuf (-R) test, but only tests using the shared long_opts table parsed it, so fi_unexpected_msg and fi_efa_gda aborted with "invalid option". Add the shared long option parsing only to the tests that need to run with it: fi_rdm and fi_unexpected_msg switch to getopt_long() with long_opts, and fi_efa_gda, fi_mr_abort and fi_efa_rma_bw merge their own tables with long_opts via the new ft_merge_long_opts() helper.